### PR TITLE
Turkish translation and some text corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - enabled translation support
   - let me know in the forum if you want to help with translations or add your own language, already added
-	- added German AI transaltion
-	- added Polish AI transaltion
+	- added German AI translation
+	- added Polish AI translation
 - added MS VC Redistributable to the installer (required for ImDisk UI)
 
 
@@ -28,14 +28,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added installer
-- add add token integrity level elevation to enclave processes allowing for better UIPI (User Interface Privilege Isolation)
+- added token integrity level elevation to enclave processes allowing for better UIPI (User Interface Privilege Isolation)
 - added driver unload protection
-- added secure desktop prompting capability to require trusted user OK to shutdown Core components
+- added secure desktop prompting capability to require trusted user confirmation to shutdown Core components
 - added copy path to accesstree
 - added approve/restore tweaks buttons to tweak view
-- addes resource access restriction tweaks
-- addes execution controll tweaks
-- addes firewall rule tweaks
+- added resource access restriction tweaks
+- added execution control tweaks
+- added firewall rule tweaks
  
 ### Changed
 - improved tweaks view
@@ -51,26 +51,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added DNS filter server
-- added support for firewall rule templates, these allow to define windows firewall rule tempaltes with wildcard enabled paths
+- added support for firewall rule templates; these allow defining windows firewall rule templates with wildcard enabled paths
 - log and trace data memory usage column per program item
 - added total service memory usage indicator
 - added trace presets per process
 - added option to allow debugging of processes in an enclave (disabled security!!!)
 - added operation filter to ingress view
-- added expand/colapse all button to program tree
+- added expand/collapse all button to program tree
 
 ### Changed
-- Reworked path rule handling the new mechanism
-  - the emchanism can now ise more complex rules, for now its set to simple dos pattern later this will be changed and an import machnism added
-- firewall pop up now ignores incomming connection atempts
+- Reworked path rule handling to the new mechanism
+  - the mechanism can now use more complex rules; for now, it's set to simple DOS pattern. Later, this will be changed, and an import mechanism added
+- firewall pop up now ignores incoming connection attempts
 - refactored project structure
-- improved and cleaned up framwork
+- improved and cleaned up framework
 - improved and cleaned up variant implementation
 - log and trace data are now stored in per program memory pools
 
 ### Fixed
 - deadlock when cleaning up program list
-- fixed crash when stoping service while UI is still active
+- fixed crash when stopping service while UI is still active
 
 
 
@@ -85,16 +85,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - reworked and improved signature verification
-- moved ingress regord to separate file
+- moved ingress record to separate file
 - renamed AccessLog.dat to AccessRecord.dat and TrafficLog.dat to TrafficRecord.dat
-  - note: as this is still in beta the old files wont be loaded or cleaned up autoamtically
+  - note: as this is still in beta, the old files won't be loaded or cleaned up automatically
   - you can delete them manually from C:\ProgramData\Xanasoft\MajorPrivacy
-- by default no records (Traffic, Execution, Ingress, Access) are stored to disk anymore
+- by default, no records (Traffic, Execution, Ingress, Access) are stored to disk anymore
 - changed the services ini file name to PrivacyAgent.ini
 - the pop up notification no longer shows redundant entries
 
 ### Fixed
-- fixed ZwLockRegistryKey usage incompatybility with HVCI
+- fixed ZwLockRegistryKey usage incompatibility with HVCI
 - fixed process protection related ui crashes around dll loading
 - fixed crash when setting firewall filtering mode
 
@@ -112,13 +112,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added options to configure trace/access log limits
 - added tweak info panel
 - added centralized signature DB folder (C:\ProgramData\Xanasoft\MajorPrivacy\sig_db\) [#21](https://github.com/xanasoft/MajorPrivacy/issues/21)
-  - this allows to create user signatures without modifying fodlers of 3rd party applications
-  - Mote: a *.mpsig file in the application folder will still take precedence
+  - this allows creating user signatures without modifying folders of 3rd party applications
+  - Note: a *.mpsig file in the application folder will still take precedence
 - added ability to sign a certificate instead of a file
 - added auto name generation to rule creation dialog
-- addded process audit rule, keeps an eye on the process as if it would be protected but without any protection
+- added process audit rule; keeps an eye on the process as if it would be protected but without any protection
 - files can now be signed from the library view
-- explorer file propertie dialog can now be opened from the library/module view
+- explorer file properties dialog can now be opened from the library/module view
 - added icons to main panel tabs
 - added program picker to rule creation dialogs
 - added UserKey Signature based config protection [#28](https://github.com/xanasoft/MajorPrivacy/issues/28)
@@ -128,18 +128,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added a process view based side panel to the enclave view
 - added icons to the enclave view
 - added context menu to the enclave view
-- added color coding to trace, rule, and otehr views
+- added color coding to trace, rule, and other views
 - made access mask columns human readable
 - added signature db viewer
 
 ### Changed
-- reworked internal path handling, this changes the file versions hance *.dat files from previosue builds will be discarded
-- renamed *.sig files to *.mpsig and enachanced the format to make it future proof, old files wont be loaded anymore
+- reworked internal path handling, this changes the file versions hence *.dat files from previous builds will be discarded
+- renamed *.sig files to *.mpsig and enhanced the format to make it future proof, old files wont be loaded anymore
 - Streamlined the APIs
 
 ### Fixed
 - fixed issue saving rules by the driver
-- fixed issues with soem tweaks
+- fixed issues with some tweaks
 
 
 
@@ -152,26 +152,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added option to ignore invalid resource accessa tempts (bad path syntax, etc)
 - last network activity values are now saved to the programs.dat
 - program item column counting all accessed files for any program item
-- added autoamted Access log and trace log cleanup, default retention time is 14 days
+- added automated Access log and trace log cleanup, default retention time is 14 days
 - added detection of missing program files thay are indicated in gray in the program tree
 - added clean up option to remove missing program items
 - added custom user defined program groups
-- added option to clear teh ignore list
+- added option to clear the ignore list
 - added option to run privacy agent as service
 - added mount manager viewer
 - added browse button to program editor window
 - added icon picker to program editor window
-- added secure volume specifiv access panel
+- added secure volume specific access panel
 
 ### Changed
-- replaced the Access tree with a new dynamic implementaion more siutable for the user case
+- replaced the Access tree with a new dynamic implementaion more suitable for the user case
 - the program tree now can display different column selections for each page
 - reworked nt to dos path resolution
 - improved maintenance menu
 - improved program item deletion
 
 ### Fixed
-- improved driver loading added workarounf for outdated driver already being installed
+- improved driver loading added workaround for outdated driver already being installed
 - fixed consistency issue in CTreeItemModel
 - fixed crash in CTraceModel
 - fixed issue when a service changes its BinaryPath
@@ -185,21 +185,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - access log is now saved to disk
 - added option to trace registry accesses
-- added dat fiel viewer
+- added dat file viewer
 - added auto scroll to trace logs
-- added fitlers to program view
+- added filters to program view
 - added new window layouts
 
 ### Changed
-- improved tree behavioure (double click to expand/colapse all sub branches)
-- improved access tree behavioure a lot
+- improved tree behavior (double click to expand/colapse all sub branches)
+- improved access tree behavior significantly
 - improved traffic view
 - changed Programs.dat format
   - WARNING: the old file will be discarded and not impprted
 
 ### Fixed
 - fixed minor issue in driver post op cleanup
-- fixed driver incompatybility with windows 10
+- fixed driver incompatibility with windows 10
 - fixed issues with slow startup causing error messages
 - fixed issues with reparse point resolution
 
@@ -209,7 +209,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added option to clean up all agent logs
-- addes view filters and toolbars to variouse lists
+- addes view filters and toolbars to various lists
 
 ### Changed
 - reworked volume rule handling, rules can now be stored in $mpsys$ file in the volume root itself
@@ -217,10 +217,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - reworked password handoff to imbox to make it more secure
 - improved mount error handling
 - improved GUI
-- improved access logging, allowed operations are now logged from the post op with status
-  - this allows to ignore access atempts to non existing objects (see settings)
+- improved access logging; allowed operations are now logged from the post op with status
+  - this allows ignoring access attempts to non existing objects (see settings)
 - improved finder bar
-- when starting the agent now enums all loaded libraries
+- when starting, the agent now enumerates all loaded libraries
  
 ### Fixed
 - fixed issues with volume unmounting
@@ -236,20 +236,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added driver based process protection
 - added driver based process controll rules
 - added driver based file and folder protection
-  - access to sellected files and folders can be blocked or restricted
-  - restriction can be to only allow folder browsing but not file reading or making faths read only
+  - access to selected files and folders can be blocked or restricted
+  - restriction can allow only folder browsing but not file reading, or make paths read-only
 - added encrypted file container support
-  - fille access rules can be set up to auto apply to loaded containers restricting access to trusted processes only
+  - file access rules can be set to auto-apply to loaded containers, restricting access to trusted processes only
 - added open files list
 - added file access trace log
-- added file access monitor, using trace data it builds a access tree for easier visualizatoin
+- added file access monitor; using trace data it builds an access tree for easier visualizatoin
 - added running process tree
 - added loaded modules (dlls) list for each process
 - added execution monitor listing what starts what
-- added ingress minotir listing which processes accessed other processes and with which access mask
+- added ingress monitor listing which processes accessed other processes and with which access mask
 - added execution trace log
-- added dns cache viever
-- added user key generation and file signing mechnism
+- added dns cache viewer
+- added user key generation and file signing mechanism
 
 
 

--- a/Library/API/PrivacyDefs.h
+++ b/Library/API/PrivacyDefs.h
@@ -162,7 +162,7 @@ enum class EExecLogRole // API_S_... TODO
 	eUndefined = 0,
 	eActor,
 	eTarget,
-	eBooth,
+	eBoth,
 };
 
 enum class EExecLogType // API_S_... TODO

--- a/MajorPrivacy/Core/Processes/ExecLogEntry.cpp
+++ b/MajorPrivacy/Core/Processes/ExecLogEntry.cpp
@@ -16,7 +16,7 @@ QString CExecLogEntry::GetRoleStr(EExecLogRole Role)
 {
 	switch (Role)
 	{
-	case EExecLogRole::eBooth:				return QObject::tr("Booth");
+	case EExecLogRole::eBoth:				return QObject::tr("Both");
 	case EExecLogRole::eActor:				return QObject::tr("Actor");
 	case EExecLogRole::eTarget:				return QObject::tr("Target");
 	default: return QObject::tr("Unknown");

--- a/MajorPrivacy/Core/Programs/ProgramFile.cpp
+++ b/MajorPrivacy/Core/Programs/ProgramFile.cpp
@@ -450,7 +450,7 @@ QString CProgramFile::GetSignatureInfoStr(UCISignInfo SignInfo)
 	case SE_SIGNING_LEVEL_MICROSOFT:		Str += tr(" (CI: Microsoft)"); break;
 	case SE_SIGNING_LEVEL_CUSTOM_4:			Str += tr(" (CI: Level 4)"); break;
 	case SE_SIGNING_LEVEL_CUSTOM_5:			Str += tr(" (CI: Level 5)"); break;
-	case SE_SIGNING_LEVEL_DYNAMIC_CODEGEN:	Str += tr(" (CI: Code Gene.)"); break;
+	case SE_SIGNING_LEVEL_DYNAMIC_CODEGEN:	Str += tr(" (CI: Code Gen.)"); break;
 	case SE_SIGNING_LEVEL_WINDOWS:			Str += tr(" (CI: Windows)"); break;
 	case SE_SIGNING_LEVEL_CUSTOM_7:			Str += tr(" (CI: Level 7)"); break;
 	case SE_SIGNING_LEVEL_WINDOWS_TCB:		Str += tr(" (CI: Windows TCB)"); break;

--- a/MajorPrivacy/Forms/EnclaveWnd.ui
+++ b/MajorPrivacy/Forms/EnclaveWnd.ui
@@ -185,7 +185,7 @@
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="chkAllowDebugging">
         <property name="text">
-         <string>Allow Debuging (INSECURE !!!)</string>
+         <string>Allow Debugging (INSECURE !!!)</string>
         </property>
        </widget>
       </item>

--- a/MajorPrivacy/Forms/FirewallRuleWnd.ui
+++ b/MajorPrivacy/Forms/FirewallRuleWnd.ui
@@ -244,7 +244,7 @@
       <item row="1" column="1" colspan="3">
        <widget class="QRadioButton" name="radProfileCustom">
         <property name="text">
-         <string>Sellected:</string>
+         <string>Selected:</string>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">radProfiles</string>

--- a/MajorPrivacy/Forms/OptionsTransferWnd.ui
+++ b/MajorPrivacy/Forms/OptionsTransferWnd.ui
@@ -92,7 +92,7 @@
      <item row="0" column="0" colspan="4">
       <widget class="QLabel" name="lblInfo">
        <property name="text">
-        <string>Please sellect which options you want to import/export.</string>
+        <string>Please select which options you want to import/export.</string>
        </property>
       </widget>
      </item>

--- a/MajorPrivacy/Forms/PopUpWindow.ui
+++ b/MajorPrivacy/Forms/PopUpWindow.ui
@@ -165,7 +165,7 @@
          <item row="0" column="0">
           <widget class="QPushButton" name="btnFwPrev">
            <property name="text">
-            <string>Previouse</string>
+            <string>Previous</string>
            </property>
           </widget>
          </item>
@@ -355,7 +355,7 @@
               </column>
               <column>
                <property name="text">
-                <string>Tiem Stamp</string>
+                <string>Time Stamp</string>
                </property>
               </column>
               <column>
@@ -493,7 +493,7 @@
          <item row="0" column="0">
           <widget class="QPushButton" name="btnResPrev">
            <property name="text">
-            <string>Previouse</string>
+            <string>Previous</string>
            </property>
           </widget>
          </item>
@@ -584,7 +584,7 @@
               </column>
               <column>
                <property name="text">
-                <string>Tiem Stamp</string>
+                <string>Time Stamp</string>
                </property>
               </column>
               <column>
@@ -699,7 +699,7 @@
          <item row="0" column="0">
           <widget class="QPushButton" name="btnExecPrev">
            <property name="text">
-            <string>Previouse</string>
+            <string>Previous</string>
            </property>
           </widget>
          </item>

--- a/MajorPrivacy/Forms/SettingsWindow.ui
+++ b/MajorPrivacy/Forms/SettingsWindow.ui
@@ -437,7 +437,7 @@
            <item row="6" column="1" colspan="2">
             <widget class="QCheckBox" name="chkLogNotFound">
              <property name="text">
-              <string>Trace also access atempts to non existing resources</string>
+              <string>Trace also access attempts to non existing resources</string>
              </property>
             </widget>
            </item>
@@ -521,9 +521,9 @@
             </widget>
            </item>
            <item row="1" column="1" colspan="2">
-            <widget class="QRadioButton" name="radFwAlowList">
+            <widget class="QRadioButton" name="radFwAllowList">
              <property name="text">
-              <string>Alow List Mode (recommended)</string>
+              <string>Allow List Mode (recommended)</string>
              </property>
             </widget>
            </item>
@@ -846,7 +846,7 @@
            <item row="2" column="0">
             <widget class="QLabel" name="label_12">
              <property name="text">
-              <string>Trace Log Retention Tme:</string>
+              <string>Trace Log Retention Time:</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/MajorPrivacy/MajorPrivacy.cpp
+++ b/MajorPrivacy/MajorPrivacy.cpp
@@ -556,7 +556,7 @@ void CMajorPrivacy::StoreState()
 
 void CMajorPrivacy::BuildMenu()
 {
-	m_pMain = menuBar()->addMenu("Privacy");
+	m_pMain = menuBar()->addMenu(tr("Privacy"));
 	//m_pMain->addSeparator();
 	m_pMaintenance = m_pMain->addMenu(QIcon(":/Icons/Maintenance.png"), tr("&Maintenance"));
 		m_pImportOptions = m_pMaintenance->addAction(QIcon(":/Icons/Import.png"), tr("Import Options"), this, SLOT(OnMaintenance()));
@@ -577,7 +577,7 @@ void CMajorPrivacy::BuildMenu()
 	m_pExit = m_pMain->addAction(QIcon(":/Icons/Exit.png"), tr("Exit"), this, SLOT(OnExit()));
 
 
-	m_pView = menuBar()->addMenu("View");
+	m_pView = menuBar()->addMenu(tr("View"));
 	m_pProgTree = m_pView->addAction(QIcon(":/Icons/Tree.png"), tr("Toggle Program Tree"), this, SLOT(OnToggleTree()));
 	m_pProgTree->setCheckable(true);
 	m_pProgTree->setChecked(theConf->GetBool("Options/ShowProgramTree", true));
@@ -606,13 +606,13 @@ void CMajorPrivacy::BuildMenu()
 	m_pWndTopMost->setChecked(theConf->GetBool("Options/AlwaysOnTop", false));
 
 
-	m_pVolumes = menuBar()->addMenu("Volumes");
+	m_pVolumes = menuBar()->addMenu(tr("Volumes"));
 	m_pMountVolume = m_pVolumes->addAction(QIcon(":/Icons/AddVolume.png"), tr("Add and Mount Volume Image"), this, SIGNAL(OnMountVolume()));
 	m_pUnmountAllVolumes = m_pVolumes->addAction(QIcon(":/Icons/UnmountVolume.png"), tr("Unmount All Volumes"), this, SIGNAL(OnUnmountAllVolumes()));
 	m_pVolumes->addSeparator();
 	m_pCreateVolume = m_pVolumes->addAction(QIcon(":/Icons/MountVolume.png"), tr("Create Volume"), this, SIGNAL(OnCreateVolume()));
 
-	m_pSecurity = menuBar()->addMenu("Security");
+	m_pSecurity = menuBar()->addMenu(tr("Security"));
 	m_pSignFile = m_pSecurity->addAction(QIcon(":/Icons/Cert.png"), tr("Sign File"), this, SLOT(OnSignFile()));
 	m_pSignDb  = m_pSecurity->addAction(QIcon(":/Icons/CertDB.png"), tr("Signature Database"), this, [this]() {
 		CSignatureDbWnd* pWnd = new CSignatureDbWnd();
@@ -630,7 +630,7 @@ void CMajorPrivacy::BuildMenu()
 	
 
 
-	m_pTools = menuBar()->addMenu("Tools");
+	m_pTools = menuBar()->addMenu(tr("Tools"));
 	m_pCleanUpProgs = m_pTools->addAction(QIcon(":/Icons/Clean.png"), tr("CleanUp Program List"), this, SLOT(CleanUpPrograms()));
 	m_pReGroupProgs = m_pTools->addAction(QIcon(":/Icons/ReGroup.png"), tr("Re-Group all Programs"), this, SLOT(ReGroupPrograms()));
 
@@ -660,7 +660,7 @@ void CMajorPrivacy::BuildMenu()
 	m_pTools->addSeparator();
 	m_pClearLogs = m_pTools->addAction(QIcon(":/Icons/Trash.png"), tr("Clear All Trace Logs"), this, SLOT(ClearTraceLogs()));
 
-	m_pOptions = menuBar()->addMenu("Options");
+	m_pOptions = menuBar()->addMenu(tr("Options"));
 	m_pSettings = m_pOptions->addAction(QIcon(":/Icons/Settings.png"), tr("Settings"), this, SLOT(OpenSettings()));
 	m_pOptions->addSeparator();
 	m_pUnlockConfig = m_pOptions->addAction(QIcon(":/Icons/LockOpen.png"), tr("Unlock Config"), this, SLOT(OnUnlockConfig()));
@@ -1663,7 +1663,7 @@ QString CMajorPrivacy::FormatError(const STATUS& Error)
 		case STATUS_ERR_CANT_REMOVE_FROM_PATTERN:	return tr("Can't remove from pattern.");
 		case STATUS_ERR_PROG_PARENT_NOT_VALID:		return tr("Parent program not valid.");
 		case STATUS_ERR_CANT_REMOVE_AUTO_ITEM:		return tr("Removing program items which are auto generated and represent found components can not be removed.");
-		case STATUS_ERR_NO_USER_KEY:				return tr("Before you can sign a Binary you need to create your User Key, use the 'Security->Setup User Key' menu comand to do that.");
+		case STATUS_ERR_NO_USER_KEY:				return tr("Before you can sign a Binary you need to create your User Key, use the 'Security->Setup User Key' menu command to do that.");
 		case STATUS_ERR_WRONG_PASSWORD:				return tr("Wrong Password!");
 		}
 	}
@@ -1942,7 +1942,7 @@ void CMajorPrivacy::CleanUpPrograms()
 
 void CMajorPrivacy::ReGroupPrograms()
 {
-	if (QMessageBox::question(this, "MajorPrivacy", tr("Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules."), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes) {
+	if (QMessageBox::question(this, "MajorPrivacy", tr("Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules."), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes) {
 		QList<STATUS> Results = QList<STATUS>() << theCore->ReGroupPrograms();
 		theGUI->CheckResults(Results, this);
 	}

--- a/MajorPrivacy/MajorPrivacy.h
+++ b/MajorPrivacy/MajorPrivacy.h
@@ -33,13 +33,13 @@ public:
 
 	struct SCurrentItems
 	{
-		QSet<CProgramItemPtr> Items; // all items including not sellected children
+		QSet<CProgramItemPtr> Items; // all items including not selected children
 
 		//QMap<quint64, CProcessPtr> Processes;
-		QSet<CProgramFilePtr> ProgramsEx; // explicitly sellected program
-		QSet<CProgramFilePtr> ProgramsIm; // implicitly sellected program
-		QSet<CWindowsServicePtr> ServicesEx; // explicitly sellected services
-		QSet<CWindowsServicePtr> ServicesIm; // implicitly sellected services
+		QSet<CProgramFilePtr> ProgramsEx; // explicitly selected program
+		QSet<CProgramFilePtr> ProgramsIm; // implicitly selected program
+		QSet<CWindowsServicePtr> ServicesEx; // explicitly selected services
+		QSet<CWindowsServicePtr> ServicesIm; // implicitly selected services
 
 		bool bAllPrograms = false;
 	};

--- a/MajorPrivacy/MajorPrivacy_de.ts
+++ b/MajorPrivacy/MajorPrivacy_de.ts
@@ -1,5289 +1,5248 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="de">
-	<context>
-		<name>AccessRuleWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formular</translation>
-		</message>
-		<message>
-			<source>Access Rule Identity</source>
-			<translation>Identität der Zugriffsregel</translation>
-		</message>
-		<message>
-			<source>Description...</source>
-			<translation>Beschreibung ...</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Path Pattern</source>
-			<translation>Pfadmuster</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Path &amp;&amp; Action</source>
-			<translation>Pfad &amp;&amp; Aktion</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Pfad</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAbstractTweak</name>
-		<message>
-			<source>Tweak Group</source>
-			<translation>Tweak-Gruppe</translation>
-		</message>
-		<message>
-			<source>Tweak Bundle</source>
-			<translation>Tweak-Paket</translation>
-		</message>
-		<message>
-			<source>Set Registry Option</source>
-			<translation>Registrierungsoption setzen</translation>
-		</message>
-		<message>
-			<source>Configure Group Policy</source>
-			<translation>Gruppenrichtlinie konfigurieren</translation>
-		</message>
-		<message>
-			<source>Disable System Service</source>
-			<translation>Systemdienst deaktivieren</translation>
-		</message>
-		<message>
-			<source>Disable Scheduled Task</source>
-			<translation>Geplante Aufgabe deaktivieren</translation>
-		</message>
-		<message>
-			<source>Resource Access Rule</source>
-			<translation>Ressourcenzugriffsregel</translation>
-		</message>
-		<message>
-			<source>Execution Control Rule</source>
-			<translation>Ausführungsregel</translation>
-		</message>
-		<message>
-			<source>Firewall Rule</source>
-			<translation>Firewall-Regel</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-		<message>
-			<source>Not set</source>
-			<translation>Nicht gesetzt</translation>
-		</message>
-		<message>
-			<source>Applied</source>
-			<translation>Übernommen</translation>
-		</message>
-		<message>
-			<source>Set</source>
-			<translation>Gesetzt</translation>
-		</message>
-		<message>
-			<source>Missing</source>
-			<translation>Fehlt</translation>
-		</message>
-		<message>
-			<source>Ineffective</source>
-			<translation>Wirkungslos</translation>
-		</message>
-		<message>
-			<source>Custom</source>
-			<translation>Benutzerdefiniert</translation>
-		</message>
-		<message>
-			<source>Group</source>
-			<translation>Gruppe</translation>
-		</message>
-		<message>
-			<source>Not available</source>
-			<translation>Nicht verfügbar</translation>
-		</message>
-		<message>
-			<source>Recommended</source>
-			<translation>Empfohlen</translation>
-		</message>
-		<message>
-			<source>Not recommended</source>
-			<translation>Nicht empfohlen</translation>
-		</message>
-		<message>
-			<source>Breaking</source>
-			<translation>Problematisch</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessListModel</name>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Last Access</source>
-			<translation>Letzter Zugriff</translation>
-		</message>
-		<message>
-			<source>Access</source>
-			<translation>Zugriff</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessListView</name>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Last Access</source>
-			<translation>Letzter Zugriff</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessPage</name>
-		<message>
-			<source>Access Rules</source>
-			<translation>Zugriffsregeln</translation>
-		</message>
-		<message>
-			<source>Open Resources</source>
-			<translation>Offene Ressourcen</translation>
-		</message>
-		<message>
-			<source>Access Monitor</source>
-			<translation>Zugriffsmonitor</translation>
-		</message>
-		<message>
-			<source>Trace Log</source>
-			<translation>Protokoll verfolgen</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessRule</name>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Allow Read-Only</source>
-			<translation>Nur-Lesen erlauben</translation>
-		</message>
-		<message>
-			<source>Allow Listing</source>
-			<translation>Auflisten erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Schützen</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Log</source>
-			<translation>Nicht protokollieren</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessRuleModel</name>
-		<message>
-			<source>%1 - %2</source>
-			<translation>%1 - %2</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Ja</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nein</translation>
-		</message>
-		<message>
-			<source> (Hidden)</source>
-			<translation> (Versteckt)</translation>
-		</message>
-		<message>
-			<source> (Temporary)</source>
-			<translation> (Temporär)</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Aktiviert</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Pfad</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Regel aktivieren</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Regel deaktivieren</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Regel löschen</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Regel bearbeiten</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Regel duplizieren</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Regel erstellen</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Alle Aktionen</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Allow Read-Only</source>
-			<translation>Nur-Lesen erlauben</translation>
-		</message>
-		<message>
-			<source>Allow Listing</source>
-			<translation>Auflisten erlauben</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Schützen</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Log</source>
-			<translation>Nicht protokollieren</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Deaktivierte Regeln ausblenden</translation>
-		</message>
-		<message>
-			<source>Show Hidden Rules</source>
-			<translation>Versteckte Regeln anzeigen</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Regeln aktualisieren</translation>
-		</message>
-		<message>
-			<source>Remove Temporary Rules</source>
-			<translation>Temporäre Regeln entfernen</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Möchten Sie die ausgewählten Regelobjekte löschen?</translation>
-		</message>
-		<message>
-			<source>Do you want to delete all Temporary Rules?</source>
-			<translation>Möchten Sie alle temporären Regeln löschen?</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessRuleWnd</name>
-		<message>
-			<source>Create Program Rule</source>
-			<translation>Programmeregel erstellen</translation>
-		</message>
-		<message>
-			<source>Edit Program Rule</source>
-			<translation>Programmeregel bearbeiten</translation>
-		</message>
-		<message>
-			<source>New Access Rule</source>
-			<translation>Neue Zugriffsregel</translation>
-		</message>
-		<message>
-			<source>Global (Any/No Enclave)</source>
-			<translation>Global (beliebige/keine Enklave)</translation>
-		</message>
-		<message>
-			<source>Browse for Folder</source>
-			<translation>Ordner durchsuchen</translation>
-		</message>
-		<message>
-			<source>Browse for File</source>
-			<translation>Datei durchsuchen</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Read Only</source>
-			<translation>Nur Lesen</translation>
-		</message>
-		<message>
-			<source>Directory Listing</source>
-			<translation>Verzeichnisauflistung</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Schützen</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Log</source>
-			<translation>Nicht protokollieren</translation>
-		</message>
-		<message>
-			<source>Select Directory</source>
-			<translation>Verzeichnis auswählen</translation>
-		</message>
-		<message>
-			<source>Select File</source>
-			<translation>Datei auswählen</translation>
-		</message>
-		<message>
-			<source>The path must be contained within the volume.</source>
-			<translation>Der Pfad muss sich innerhalb des Volumes befinden.</translation>
-		</message>
-		<message>
-			<source>The sellected program type is not supported for this rule type</source>
-			<translation>Der ausgewählte Programmtyp wird für diesen Regeltyp nicht unterstützt</translation>
-		</message>
-		<message>
-			<source>%1 %2 %3</source>
-			<translation>%1 %2 %3</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessTraceModel</name>
-		<message>
-			<source>Unknown Program</source>
-			<translation>Unbekanntes Programm</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>PROGRAM MISSING</source>
-			<translation>PROGRAMM FEHLT</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Pfad</translation>
-		</message>
-		<message>
-			<source>Operation</source>
-			<translation>Operation</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Program (Actor)</source>
-			<translation>Programm (Akteur)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessTraceView</name>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Auto Scroll</source>
-			<translation>Automatisches Scrollen</translation>
-		</message>
-		<message>
-			<source>Hold updates</source>
-			<translation>Aktualisierungen anhalten</translation>
-		</message>
-		<message>
-			<source>Clear Trace Log</source>
-			<translation>Verfolgungsprotokoll löschen</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CAccessView</name>
-		<message>
-			<source>Any Access</source>
-			<translation>Beliebiger Zugriff</translation>
-		</message>
-		<message>
-			<source>Read/Write</source>
-			<translation>Lesen/Schreiben</translation>
-		</message>
-		<message>
-			<source>Write Only</source>
-			<translation>Nur Schreiben</translation>
-		</message>
-		<message>
-			<source>Reload Access Tree</source>
-			<translation>Zugriffsbaum neu laden</translation>
-		</message>
-		<message>
-			<source>CleanUp Access Tree</source>
-			<translation>Zugriffsbaum bereinigen</translation>
-		</message>
-		<message>
-			<source>Copy Path</source>
-			<translation>Pfad kopieren</translation>
-		</message>
-		<message>
-			<source>My Computer</source>
-			<translation>Arbeitsplatz</translation>
-		</message>
-		<message>
-			<source>\\.\</source>
-			<translation>\\.\</translation>
-		</message>
-		<message>
-			<source>Registry</source>
-			<translation>Registrierung</translation>
-		</message>
-		<message>
-			<source>Network</source>
-			<translation>Netzwerk</translation>
-		</message>
-		<message>
-			<source>Loading %1</source>
-			<translation>%1 wird geladen</translation>
-		</message>
-		<message>
-			<source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
-			<translation>Möchten Sie den Zugriffsbaum bereinigen? Dabei werden alle Dateien und Ordner entfernt, die nicht mehr im System vorhanden sind. Außerdem werden alle Verweise auf Dateien und Ordner entfernt, die zwar existieren, sich jedoch auf derzeit nicht eingebundenen Volumes befinden. Der Vorgang greift auf alle protokollierten Speicherorte zu und kann einige Zeit dauern. Danach wird die Ansicht aktualisiert.</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CDnsCacheEntry</name>
-		<message>
-			<source>UNKNOWN (%1)</source>
-			<translation>UNBEKANNT (%1)</translation>
-		</message>
-		<message>
-			<source>Cached</source>
-			<translation>Zwischengespeichert</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsCacheModel</name>
-		<message>
-			<source>Host name</source>
-			<translation>Hostname</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>TTL (sec)</source>
-			<translation>TTL (Sek)</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Last seen</source>
-			<translation>Zuletzt gesehen</translation>
-		</message>
-		<message>
-			<source>Counter</source>
-			<translation>Zähler</translation>
-		</message>
-		<message>
-			<source>Resolved data</source>
-			<translation>Aufgelöste Daten</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CDnsCacheView</name>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Cached</source>
-			<translation>Zwischengespeichert</translation>
-		</message>
-		<message>
-			<source>Any Type</source>
-			<translation>Beliebiger Typ</translation>
-		</message>
-		<message>
-			<source>A or AAAA</source>
-			<translation>A oder AAAA</translation>
-		</message>
-		<message>
-			<source>A</source>
-			<translation>A</translation>
-		</message>
-		<message>
-			<source>AAAA</source>
-			<translation>AAAA</translation>
-		</message>
-		<message>
-			<source>CNAME</source>
-			<translation>CNAME</translation>
-		</message>
-		<message>
-			<source>MX</source>
-			<translation>MX</translation>
-		</message>
-		<message>
-			<source>PTR</source>
-			<translation>PTR</translation>
-		</message>
-		<message>
-			<source>SRV</source>
-			<translation>SRV</translation>
-		</message>
-		<message>
-			<source>TXT</source>
-			<translation>TXT</translation>
-		</message>
-		<message>
-			<source>WKS</source>
-			<translation>WKS</translation>
-		</message>
-		<message>
-			<source>Clear System DNS Cache</source>
-			<translation>System-DNS-Cache leeren</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CDnsPage</name>
-		<message>
-			<source>Dns Rules</source>
-			<translation>DNS-Regeln</translation>
-		</message>
-		<message>
-			<source>DnsCache</source>
-			<translation>DNS-Cache</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CDnsRule</name>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>None</source>
-			<translation>Keine</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CDnsRuleModel</name>
-		<message>
-			<source>Yes</source>
-			<translation>Ja</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nein</translation>
-		</message>
-		<message>
-			<source> (Temporary)</source>
-			<translation> (Temporär)</translation>
-		</message>
-		<message>
-			<source>Host Name</source>
-			<translation>Hostname</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Aktiviert</translation>
-		</message>
-		<message>
-			<source>Hit Count</source>
-			<translation>Trefferanzahl</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CDnsRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Regel aktivieren</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Regel deaktivieren</translation>
-		</message>
-		<message>
-			<source>Set Blocking</source>
-			<translation>Blockieren festlegen</translation>
-		</message>
-		<message>
-			<source>Set Allowing</source>
-			<translation>Erlauben festlegen</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Regel löschen</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Regel bearbeiten</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Regel duplizieren</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Regel erstellen</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Alle Aktionen</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Deaktivierte Regeln ausblenden</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Regeln aktualisieren</translation>
-		</message>
-		<message>
-			<source>Edit Dns Rule</source>
-			<translation>DNS-Regel bearbeiten</translation>
-		</message>
-		<message>
-			<source>Enter Host Name</source>
-			<translation>Hostname eingeben</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Möchten Sie die ausgewählten Regelobjekte löschen?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclave</name>
-		<message>
-			<source>Developer Signed</source>
-			<translation>Vom Entwickler signiert</translation>
-		</message>
-		<message>
-			<source>User Signed</source>
-			<translation>Vom Benutzer signiert</translation>
-		</message>
-		<message>
-			<source>Microsoft</source>
-			<translation>Microsoft</translation>
-		</message>
-		<message>
-			<source>Microsoft/AV</source>
-			<translation>Microsoft/Antivirenprogramm</translation>
-		</message>
-		<message>
-			<source>Microsoft Trusted</source>
-			<translation>Von Microsoft vertrauenswürdig</translation>
-		</message>
-		<message>
-			<source>Unknown Root</source>
-			<translation>Unbekannter Ursprung</translation>
-		</message>
-		<message>
-			<source>None</source>
-			<translation>Keine</translation>
-		</message>
-		<message>
-			<source>Undetermined</source>
-			<translation>Unbestimmt</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Eject</source>
-			<translation>Auswerfen</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CEnclaveManager</name>
-		<message>
-			<source>Major Privacy&apos;s Private Enclave</source>
-			<translation>Private Enklave von Major Privacy</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclaveModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>ID</source>
-			<translation>ID</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Vertrauensebene</translation>
-		</message>
-		<message>
-			<source>Trusted Spawn/UnTrusted</source>
-			<translation>Vertrauenswürdiger Start/Nicht vertrauenswürdig</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CEnclaveView</name>
-		<message>
-			<source>Run in Enclave</source>
-			<translation>In Enklave ausführen</translation>
-		</message>
-		<message>
-			<source>Terminate All Processes</source>
-			<translation>Alle Prozesse beenden</translation>
-		</message>
-		<message>
-			<source>Delete Enclave</source>
-			<translation>Enklave löschen</translation>
-		</message>
-		<message>
-			<source>Edit Enclave</source>
-			<translation>Enklave bearbeiten</translation>
-		</message>
-		<message>
-			<source>Duplicate Enclave</source>
-			<translation>Enklave duplizieren</translation>
-		</message>
-		<message>
-			<source>Create Enclave</source>
-			<translation>Enklave erstellen</translation>
-		</message>
-		<message>
-			<source>Open Parent Folder</source>
-			<translation>Übergeordneten Ordner öffnen</translation>
-		</message>
-		<message>
-			<source>File Properties</source>
-			<translation>Dateieigenschaften</translation>
-		</message>
-		<message>
-			<source>Terminate Process</source>
-			<translation>Prozess beenden</translation>
-		</message>
-		<message>
-			<source>%1 can&apos;t be edited!</source>
-			<translation>%1 kann nicht bearbeitet werden!</translation>
-		</message>
-		<message>
-			<source>The process was ejected form the enclave, and is running unprotected, probably due to insuficient signature level!</source>
-			<translation>Der Prozess wurde aus der Enklave entfernt und läuft ungeschützt – vermutlich wegen unzureichender Signaturstufe!</translation>
-		</message>
-		<message>
-			<source>Failed to start process!</source>
-			<translation>Prozess konnte nicht gestartet werden!</translation>
-		</message>
-		<message>
-			<source>Do you want to terminate all processes in the sellected enclaves?</source>
-			<translation>Möchten Sie alle Prozesse in den ausgewählten Enklaven beenden?</translation>
-		</message>
-		<message>
-			<source>Terminate without asking</source>
-			<translation>Ohne Nachfrage beenden</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Enclave?</source>
-			<translation>Möchten Sie die ausgewählte Enklave löschen?</translation>
-		</message>
-		<message>
-			<source>Do you want to terminate %1?</source>
-			<translation>Möchten Sie %1 beenden?</translation>
-		</message>
-		<message>
-			<source>the selected processes</source>
-			<translation>die ausgewählten Prozesse</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CEnclaveWnd</name>
-		<message>
-			<source>Change Icon</source>
-			<translation>Symbol ändern</translation>
-		</message>
-		<message>
-			<source>Browse for Image</source>
-			<translation>Nach Bild suchen</translation>
-		</message>
-		<message>
-			<source>Create Secure Enclave</source>
-			<translation>Sichere Enklave erstellen</translation>
-		</message>
-		<message>
-			<source>Edit Secure Enclave</source>
-			<translation>Sichere Enklave bearbeiten</translation>
-		</message>
-		<message>
-			<source>New Secure Enclave</source>
-			<translation>Neue sichere Enklave</translation>
-		</message>
-		<message>
-			<source>User Signature ONLY (not recommended)</source>
-			<translation>Nur Benutzersignatur (nicht empfohlen)</translation>
-		</message>
-		<message>
-			<source>User + Microsoft/AV Signature</source>
-			<translation>Benutzer + Microsoft/AV-Signatur</translation>
-		</message>
-		<message>
-			<source>User + Trusted by Microsoft (Code Root)</source>
-			<translation>Benutzer + von Microsoft vertrauenswürdig (Code Root)</translation>
-		</message>
-		<message>
-			<source>Any Signature (Unknown Root)</source>
-			<translation>Beliebige Signatur (unbekannter Ursprung)</translation>
-		</message>
-		<message>
-			<source>No Signature</source>
-			<translation>Keine Signatur</translation>
-		</message>
-		<message>
-			<source>Allow Execution</source>
-			<translation>Ausführung erlauben</translation>
-		</message>
-		<message>
-			<source>Eject from Secure Enclave</source>
-			<translation>Aus sicherer Enklave entfernen</translation>
-		</message>
-		<message>
-			<source>Prevent Execution</source>
-			<translation>Ausführung verhindern</translation>
-		</message>
-		<message>
-			<source>Don&apos;t change</source>
-			<translation>Keine Änderung</translation>
-		</message>
-		<message>
-			<source>Medium +</source>
-			<translation>Mittel +</translation>
-		</message>
-		<message>
-			<source>High</source>
-			<translation>Hoch</translation>
-		</message>
-		<message>
-			<source>System</source>
-			<translation>System</translation>
-		</message>
-		<message>
-			<source>Select Image File</source>
-			<translation>Bilddatei auswählen</translation>
-		</message>
-		<message>
-			<source>Image Files (*.png)</source>
-			<translation>Bilddateien (*.png)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CExecutionModel</name>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Role</source>
-			<translation>Rolle</translation>
-		</message>
-		<message>
-			<source>Last Status</source>
-			<translation>Letzter Status</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CExecutionView</name>
-		<message>
-			<source>Any Role</source>
-			<translation>Beliebige Rolle</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Akteur</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Ziel</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Show entries per UPID</source>
-			<translation>Einträge nach UPID anzeigen</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-	</context>
-	<context>
-		<name>CFirewallRuleWnd</name>
-		<message>
-			<source>Create Firewall Rule</source>
-			<translation>Firewall-Regel erstellen</translation>
-		</message>
-		<message>
-			<source>Edit Firewall Rule</source>
-			<translation>Firewall-Regel bearbeiten</translation>
-		</message>
-		<message>
-			<source>&amp;MP-Rule, New Firewall Rule</source>
-			<translation>&amp;MP-Regel, neue Firewall-Regel</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Bidirectional</source>
-			<translation>Bidirektional</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Eingehend</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Ausgehend</translation>
-		</message>
-		<message>
-			<source>Any Protocol</source>
-			<translation>Beliebiges Protokoll</translation>
-		</message>
-		<message>
-			<source>[Add IP]</source>
-			<translation>[IP hinzufügen]</translation>
-		</message>
-		<message>
-			<source>The sellected program type is not supported for this rule type</source>
-			<translation>Der ausgewählte Programmtyp wird für diesen Regeltyp nicht unterstützt</translation>
-		</message>
-		<message>
-			<source>All Types</source>
-			<translation>Alle Typen</translation>
-		</message>
-		<message>
-			<source>Invalid Sub Net</source>
-			<translation>Ungültiges Subnetz</translation>
-		</message>
-		<message>
-			<source>Invalid IP Address</source>
-			<translation>Ungültige IP-Adresse</translation>
-		</message>
-		<message>
-			<source>Invalid IP Range</source>
-			<translation>Ungültiger IP-Bereich</translation>
-		</message>
-		<message>
-			<source>%4, %1 %2 %3</source>
-			<translation>%4, %1 %2 %3</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CFwRule</name>
-		<message>
-			<source>All</source>
-			<translation>Alle</translation>
-		</message>
-		<message>
-			<source>Domain</source>
-			<translation>Domäne</translation>
-		</message>
-		<message>
-			<source>Private</source>
-			<translation>Privat</translation>
-		</message>
-		<message>
-			<source>Public</source>
-			<translation>Öffentlich</translation>
-		</message>
-		<message>
-			<source>Any</source>
-			<translation>Beliebig</translation>
-		</message>
-		<message>
-			<source>LAN</source>
-			<translation>LAN</translation>
-		</message>
-		<message>
-			<source>WiFi</source>
-			<translation>WLAN</translation>
-		</message>
-		<message>
-			<source>VPN</source>
-			<translation>VPN</translation>
-		</message>
-		<message>
-			<source>FromLog</source>
-			<translation>Aus Protokoll</translation>
-		</message>
-		<message>
-			<source>UnRuled</source>
-			<translation>Regellos</translation>
-		</message>
-		<message>
-			<source>Rule Allowed</source>
-			<translation>Regel erlaubt</translation>
-		</message>
-		<message>
-			<source>Rule Blocked</source>
-			<translation>Regel blockiert</translation>
-		</message>
-		<message>
-			<source>Rule Error</source>
-			<translation>Regelfehler</translation>
-		</message>
-		<message>
-			<source>Rule Generated</source>
-			<translation>Regel generiert</translation>
-		</message>
-		<message>
-			<source>Undefined</source>
-			<translation>Undefiniert</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Eingehend</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Ausgehend</translation>
-		</message>
-		<message>
-			<source>Bidirectional</source>
-			<translation>Bidirektional</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CFwRuleModel</name>
-		<message>
-			<source>%1 - %2</source>
-			<translation>%1 - %2</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Ja</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nein</translation>
-		</message>
-		<message>
-			<source> (Temporary)</source>
-			<translation> (Temporär)</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Grouping</source>
-			<translation>Gruppierung</translation>
-		</message>
-		<message>
-			<source>Index</source>
-			<translation>Index</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Aktiviert</translation>
-		</message>
-		<message>
-			<source>Hit Count</source>
-			<translation>Trefferanzahl</translation>
-		</message>
-		<message>
-			<source>Profiles</source>
-			<translation>Profile</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Direction</source>
-			<translation>Richtung</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokoll</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Remote-Adresse</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Lokale Adresse</translation>
-		</message>
-		<message>
-			<source>Remote Ports</source>
-			<translation>Remote-Ports</translation>
-		</message>
-		<message>
-			<source>Local Ports</source>
-			<translation>Lokale Ports</translation>
-		</message>
-		<message>
-			<source>ICMP Options</source>
-			<translation>ICMP-Optionen</translation>
-		</message>
-		<message>
-			<source>Interfaces</source>
-			<translation>Schnittstellen</translation>
-		</message>
-		<message>
-			<source>Edge Traversal</source>
-			<translation>Edge Traversal</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CFwRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Regel aktivieren</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Regel deaktivieren</translation>
-		</message>
-		<message>
-			<source>Set Blocking</source>
-			<translation>Blockieren festlegen</translation>
-		</message>
-		<message>
-			<source>Set Allowing</source>
-			<translation>Erlauben festlegen</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Regel löschen</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Regel bearbeiten</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Regel duplizieren</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Regel erstellen</translation>
-		</message>
-		<message>
-			<source>All Directions</source>
-			<translation>Alle Richtungen</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Eingehend</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Ausgehend</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Alle Aktionen</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Deaktivierte Regeln ausblenden</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Regeln aktualisieren</translation>
-		</message>
-		<message>
-			<source>Remove Temporary Rules</source>
-			<translation>Temporäre Regeln entfernen</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Möchten Sie die ausgewählten Regelobjekte löschen?</translation>
-		</message>
-		<message>
-			<source>Do you want to delete all Temporary Rules?</source>
-			<translation>Möchten Sie alle temporären Regeln löschen?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CGenericRule</name>
-		<message>
-			<source> (duplicate)</source>
-			<translation> (Duplikat)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CHandleModel</name>
-		<message>
-			<source>PROCESS MISSING</source>
-			<translation>PROZESS FEHLT</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CHomePage</name>
-		<message>
-			<source>Time Stamp|Type|Event|Message</source>
-			<translation>Zeitstempel|Typ|Ereignis|Nachricht</translation>
-		</message>
-		<message>
-			<source>Success</source>
-			<translation>Erfolg</translation>
-		</message>
-		<message>
-			<source>Error</source>
-			<translation>Fehler</translation>
-		</message>
-		<message>
-			<source>Warning</source>
-			<translation>Warnung</translation>
-		</message>
-		<message>
-			<source>Information</source>
-			<translation>Information</translation>
-		</message>
-		<message>
-			<source>Audit Success</source>
-			<translation>Überprüfung erfolgreich</translation>
-		</message>
-		<message>
-			<source>Audit Failure</source>
-			<translation>Überprüfung fehlgeschlagen</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CInfoView</name>
-		<message>
-			<source>Info</source>
-			<translation>Info</translation>
-		</message>
-		<message>
-			<source>Name: %1 (%2)</source>
-			<translation>Name: %1 (%2)</translation>
-		</message>
-		<message>
-			<source>Path: %1</source>
-			<translation>Pfad: %1</translation>
-		</message>
-		<message>
-			<source>Groups (%1)</source>
-			<translation>Gruppen (%1)</translation>
-		</message>
-		<message>
-			<source>Root (%1)</source>
-			<translation>Stamm (%1)</translation>
-		</message>
-		<message>
-			<source>%1 (%2)</source>
-			<translation>%1 (%2)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CIngressModel</name>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Role</source>
-			<translation>Rolle</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Operation</source>
-			<translation>Operation</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CIngressView</name>
-		<message>
-			<source>Any Role</source>
-			<translation>Beliebige Rolle</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Akteur</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Ziel</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>All Operations</source>
-			<translation>Alle Operationen</translation>
-		</message>
-		<message>
-			<source>Control Execution</source>
-			<translation>Ausführung kontrollieren</translation>
-		</message>
-		<message>
-			<source>Change Permissions</source>
-			<translation>Berechtigungen ändern</translation>
-		</message>
-		<message>
-			<source>Write Memory</source>
-			<translation>Speicher schreiben</translation>
-		</message>
-		<message>
-			<source>Read Memory</source>
-			<translation>Speicher lesen</translation>
-		</message>
-		<message>
-			<source>Special Permissions</source>
-			<translation>Spezielle Berechtigungen</translation>
-		</message>
-		<message>
-			<source>Write Properties</source>
-			<translation>Eigenschaften schreiben</translation>
-		</message>
-		<message>
-			<source>Read Properties</source>
-			<translation>Eigenschaften lesen</translation>
-		</message>
-		<message>
-			<source>Show Private Entries</source>
-			<translation>Private Einträge anzeigen</translation>
-		</message>
-		<message>
-			<source>Show entries per UPID</source>
-			<translation>Einträge pro UPID anzeigen</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CLibraryInfoView</name>
-		<message>
-			<source>Name|Signer|Valid|SHA1 Fingerprint|Certificate Fingerprint</source>
-			<translation>Name|Signierer|Gültig|SHA1-Fingerabdruck|Zertifikat-Fingerabdruck</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Ja</translation>
-		</message>
-		<message>
-			<source>INVALID</source>
-			<translation>UNGÜLTIG</translation>
-		</message>
-		<message>
-			<source>Yes (Catalog)</source>
-			<translation>Ja (Katalog)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CLibraryModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Vertrauensebene</translation>
-		</message>
-		<message>
-			<source>Last Status</source>
-			<translation>Letzter Status</translation>
-		</message>
-		<message>
-			<source>Last Load</source>
-			<translation>Letztes Laden</translation>
-		</message>
-		<message>
-			<source>Count</source>
-			<translation>Anzahl</translation>
-		</message>
-		<message>
-			<source>Signing Certificate</source>
-			<translation>Signierzertifikat</translation>
-		</message>
-		<message>
-			<source>Module</source>
-			<translation>Modul</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CLibraryView</name>
-		<message>
-			<source>Sign File</source>
-			<translation>Datei signieren</translation>
-		</message>
-		<message>
-			<source>Remove File Signature</source>
-			<translation>Dateisignatur entfernen</translation>
-		</message>
-		<message>
-			<source>Sign Certificate</source>
-			<translation>Zertifikat signieren</translation>
-		</message>
-		<message>
-			<source>Remove Cert Signature</source>
-			<translation>Zertifikatsignatur entfernen</translation>
-		</message>
-		<message>
-			<source>Open Parent Folder</source>
-			<translation>Übergeordneten Ordner öffnen</translation>
-		</message>
-		<message>
-			<source>File Properties</source>
-			<translation>Dateieigenschaften</translation>
-		</message>
-		<message>
-			<source>By Program</source>
-			<translation>Nach Programm</translation>
-		</message>
-		<message>
-			<source>By Library</source>
-			<translation>Nach Bibliothek</translation>
-		</message>
-		<message>
-			<source>All Signatures</source>
-			<translation>Alle Signaturen</translation>
-		</message>
-		<message>
-			<source>User Sign. ONLY</source>
-			<translation>Nur Benutzersignatur</translation>
-		</message>
-		<message>
-			<source>Microsoft/AV</source>
-			<translation>Microsoft/AV</translation>
-		</message>
-		<message>
-			<source>Trusted by MSFT</source>
-			<translation>Von Microsoft vertrauenswürdig</translation>
-		</message>
-		<message>
-			<source>Untrusted/None</source>
-			<translation>Nicht vertrauenswürdig/Keine</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Untrusted</source>
-			<translation>Nicht vertrauenswürdig</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>CleanUp Libraries</source>
-			<translation>Bibliotheken bereinigen</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-	</context>
-	<context>
-		<name>CMajorPrivacy</name>
-		<message>
-			<source>Starting ...</source>
-			<translation>Starte ...</translation>
-		</message>
-		<message>
-			<source>The driver configuration is corrupted, and could not be loaded, plrease restore from a backup.</source>
-			<translation>Die Treiberkonfiguration ist beschädigt und konnte nicht geladen werden. Bitte stelle sie aus einem Backup wieder her.</translation>
-		</message>
-		<message>
-			<source>The driver configuration is Untrusted (INVALID Signature, or Sequence). Do you want to load ir anyways?</source>
-			<translation>Die Treiberkonfiguration ist nicht vertrauenswürdig (ungültige Signatur oder Sequenz). Möchtest du sie trotzdem laden?</translation>
-		</message>
-		<message>
-			<source>The Privacy Agent is not currently installed as a service. Would you like to install it now (Yes), run it without installation (No), or abort the connection attempt (Cancel)?</source>
-			<translation>Der Privacy Agent ist derzeit nicht als Dienst installiert. Möchtest du ihn jetzt installieren (Ja), ohne Installation ausführen (Nein) oder den Verbindungsversuch abbrechen (Abbrechen)?</translation>
-		</message>
-		<message>
-			<source>Remember this choice.</source>
-			<translation>Diesen Auswahl merken.</translation>
-		</message>
-		<message>
-			<source>Major Privacy will now attempt to start the Privacy Agent, please confirm the UAC prompt.</source>
-			<translation>Major Privacy wird nun versuchen, den Privacy Agent zu starten. Bitte bestätige die UAC-Abfrage.</translation>
-		</message>
-		<message>
-			<source>Privacy Agent Ready %1/%2</source>
-			<translation>Privacy Agent bereit %1/%2</translation>
-		</message>
-		<message>
-			<source>Privacy Agent Failed: %1</source>
-			<translation>Privacy Agent fehlgeschlagen: %1</translation>
-		</message>
-		<message>
-			<source>Do you want to close Major Privacy?</source>
-			<translation>Möchtest du Major Privacy schließen?</translation>
-		</message>
-		<message>
-			<source>Lost connection to Service, do you want to reconnect?</source>
-			<translation>Verbindung zum Dienst verloren. Möchtest du erneut verbinden?</translation>
-		</message>
-		<message>
-			<source>Mem Usage: %1 + %2 (Logs)</source>
-			<translation>Speichernutzung: %1 + %2 (Logs)</translation>
-		</message>
-		<message>
-			<source>Disconnected from privacy agent</source>
-			<translation>Vom Privacy Agent getrennt</translation>
-		</message>
-		<message>
-			<source>&amp;Maintenance</source>
-			<translation>&amp;Wartung</translation>
-		</message>
-		<message>
-			<source>Import Options</source>
-			<translation>Optionen importieren</translation>
-		</message>
-		<message>
-			<source>Export Options</source>
-			<translation>Optionen exportieren</translation>
-		</message>
-		<message>
-			<source>&amp;Advanced</source>
-			<translation>&amp;Erweitert</translation>
-		</message>
-		<message>
-			<source>Connect</source>
-			<translation>Verbinden</translation>
-		</message>
-		<message>
-			<source>Disconnect</source>
-			<translation>Trennen</translation>
-		</message>
-		<message>
-			<source>Install Services</source>
-			<translation>Dienste installieren</translation>
-		</message>
-		<message>
-			<source>Remove Services</source>
-			<translation>Dienste entfernen</translation>
-		</message>
-		<message>
-			<source>Open User Data Folder</source>
-			<translation>Benutzerdatenordner öffnen</translation>
-		</message>
-		<message>
-			<source>Open System Data Folder</source>
-			<translation>Systemdatenordner öffnen</translation>
-		</message>
-		<message>
-			<source>Open *.dat Editor</source>
-			<translation>*.dat-Editor öffnen</translation>
-		</message>
-		<message>
-			<source>Exit</source>
-			<translation>Beenden</translation>
-		</message>
-		<message>
-			<source>Toggle Program Tree</source>
-			<translation>Programmbaum ein-/ausblenden</translation>
-		</message>
-		<message>
-			<source>Stack Panels</source>
-			<translation>Paneele stapeln</translation>
-		</message>
-		<message>
-			<source>Merge Panels</source>
-			<translation>Paneele zusammenführen</translation>
-		</message>
-		<message>
-			<source>Separate Column Sets</source>
-			<translation>Spaltensätze trennen</translation>
-		</message>
-		<message>
-			<source>Show Tab Labels</source>
-			<translation>Reiterbeschriftungen anzeigen</translation>
-		</message>
-		<message>
-			<source>Always on Top</source>
-			<translation>Immer im Vordergrund</translation>
-		</message>
-		<message>
-			<source>Add and Mount Volume Image</source>
-			<translation>Volume-Image hinzufügen und einbinden</translation>
-		</message>
-		<message>
-			<source>Unmount All Volumes</source>
-			<translation>Alle Volumes aushängen</translation>
-		</message>
-		<message>
-			<source>Create Volume</source>
-			<translation>Volume erstellen</translation>
-		</message>
-		<message>
-			<source>Sign File</source>
-			<translation>Datei signieren</translation>
-		</message>
-		<message>
-			<source>Signature Database</source>
-			<translation>Signaturdatenbank</translation>
-		</message>
-		<message>
-			<source>Unload Protection</source>
-			<translation>Schutz entladen</translation>
-		</message>
-		<message>
-			<source>Enable Rule Protection</source>
-			<translation>Regelschutz aktivieren</translation>
-		</message>
-		<message>
-			<source>Disable Rules Protection</source>
-			<translation>Regelschutz deaktivieren</translation>
-		</message>
-		<message>
-			<source>Setup User Key</source>
-			<translation>Benutzerschlüssel einrichten</translation>
-		</message>
-		<message>
-			<source>Remove User Key</source>
-			<translation>Benutzerschlüssel entfernen</translation>
-		</message>
-		<message>
-			<source>CleanUp Program List</source>
-			<translation>Programmliste bereinigen</translation>
-		</message>
-		<message>
-			<source>Re-Group all Programs</source>
-			<translation>Alle Programme neu gruppieren</translation>
-		</message>
-		<message>
-			<source>&amp;Advanced Tools</source>
-			<translation>&amp;Erweiterte Werkzeuge</translation>
-		</message>
-		<message>
-			<source>Mount Manager</source>
-			<translation>Mount-Manager</translation>
-		</message>
-		<message>
-			<source>Virtual Disks</source>
-			<translation>Virtuelle Laufwerke</translation>
-		</message>
-		<message>
-			<source>Clear All Trace Logs</source>
-			<translation>Alle Protokolle löschen</translation>
-		</message>
-		<message>
-			<source>Settings</source>
-			<translation>Einstellungen</translation>
-		</message>
-		<message>
-			<source>Unlock Config</source>
-			<translation>Konfiguration entsperren</translation>
-		</message>
-		<message>
-			<source>Commit Changes</source>
-			<translation>Änderungen übernehmen</translation>
-		</message>
-		<message>
-			<source>Discard Changes</source>
-			<translation>Änderungen verwerfen</translation>
-		</message>
-		<message>
-			<source>Clear Ignore List</source>
-			<translation>Ignorierliste leeren</translation>
-		</message>
-		<message>
-			<source>Reset All Prompts</source>
-			<translation>Alle Hinweise zurücksetzen</translation>
-		</message>
-		<message>
-			<source>&amp;Help</source>
-			<translation>&amp;Hilfe</translation>
-		</message>
-		<message>
-			<source>Visit Support Forum</source>
-			<translation>Support-Forum besuchen</translation>
-		</message>
-		<message>
-			<source>About the Qt Framework</source>
-			<translation>Über das Qt-Framework</translation>
-		</message>
-		<message>
-			<source>About MajorPrivacy</source>
-			<translation>Über MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>System Overview</source>
-			<translation>Systemübersicht</translation>
-		</message>
-		<message>
-			<source>Process Security</source>
-			<translation>Prozesssicherheit</translation>
-		</message>
-		<message>
-			<source>Secure Enclaves</source>
-			<translation>Sichere Enklaven</translation>
-		</message>
-		<message>
-			<source>Resource Protection</source>
-			<translation>Ressourcenschutz</translation>
-		</message>
-		<message>
-			<source>Secure Volumes</source>
-			<translation>Gesicherte Volumes</translation>
-		</message>
-		<message>
-			<source>Network Firewall</source>
-			<translation>Netzwerk-Firewall</translation>
-		</message>
-		<message>
-			<source>DNS Filtering</source>
-			<translation>DNS-Filterung</translation>
-		</message>
-		<message>
-			<source>Privacy Tweaks</source>
-			<translation>Datenschutzanpassungen</translation>
-		</message>
-		<message>
-			<source>Set Time Filter</source>
-			<translation>Zeitfilter setzen</translation>
-		</message>
-		<message>
-			<source>Any time</source>
-			<translation>Beliebige Zeit</translation>
-		</message>
-		<message>
-			<source>Last 5 Seconds</source>
-			<translation>Letzte 5 Sekunden</translation>
-		</message>
-		<message>
-			<source>Last 10 Seconds</source>
-			<translation>Letzte 10 Sekunden</translation>
-		</message>
-		<message>
-			<source>Last 30 Seconds</source>
-			<translation>Letzte 30 Sekunden</translation>
-		</message>
-		<message>
-			<source>Last Minute</source>
-			<translation>Letzte Minute</translation>
-		</message>
-		<message>
-			<source>Last 3 Minutes</source>
-			<translation>Letzte 3 Minuten</translation>
-		</message>
-		<message>
-			<source>Last 5 Minutes</source>
-			<translation>Letzte 5 Minuten</translation>
-		</message>
-		<message>
-			<source>Last 15 Minutes</source>
-			<translation>Letzte 15 Minuten</translation>
-		</message>
-		<message>
-			<source>Last 30 Minutes</source>
-			<translation>Letzte 30 Minuten</translation>
-		</message>
-		<message>
-			<source>Last Hour</source>
-			<translation>Letzte Stunde</translation>
-		</message>
-		<message>
-			<source>Last 3 Hours</source>
-			<translation>Letzte 3 Stunden</translation>
-		</message>
-		<message>
-			<source>Last 12 Hours</source>
-			<translation>Letzte 12 Stunden</translation>
-		</message>
-		<message>
-			<source>Last 24 Hours</source>
-			<translation>Letzte 24 Stunden</translation>
-		</message>
-		<message>
-			<source>Last 48 Hours</source>
-			<translation>Letzte 48 Stunden</translation>
-		</message>
-		<message>
-			<source>Last Week</source>
-			<translation>Letzte Woche</translation>
-		</message>
-		<message>
-			<source>Last 2 Weeks</source>
-			<translation>Letzte 2 Wochen</translation>
-		</message>
-		<message>
-			<source>Last Month</source>
-			<translation>Letzter Monat</translation>
-		</message>
-		<message>
-			<source>Show/Hide</source>
-			<translation>Einblenden/Ausblenden</translation>
-		</message>
-		<message>
-			<source>Process Protection Popups</source>
-			<translation>Popupmeldungen für Prozessschutz</translation>
-		</message>
-		<message>
-			<source>Resource Access Popups</source>
-			<translation>Popupmeldungen für Ressourcenzugriffe</translation>
-		</message>
-		<message>
-			<source>Network Firewall Popups</source>
-			<translation>Popupmeldungen für Netzwerk-Firewall</translation>
-		</message>
-		<message>
-			<source>Firewall Profile</source>
-			<translation>Firewall-Profil</translation>
-		</message>
-		<message>
-			<source>Use Allow List</source>
-			<translation>Erlaubnisliste verwenden</translation>
-		</message>
-		<message>
-			<source>Use Block List</source>
-			<translation>Sperrliste verwenden</translation>
-		</message>
-		<message>
-			<source>Disabled Firewall</source>
-			<translation>Firewall deaktiviert</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to sign a file</source>
-			<translation>Geben Sie das Passwort für die sichere Konfiguration ein, um eine Datei zu signieren</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to sign a certificate</source>
-			<translation>Geben Sie das Passwort für die sichere Konfiguration ein, um ein Zertifikat zu signieren</translation>
-		</message>
-		<message>
-			<source>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>AccessRuleWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <source>Access Rule Identity</source>
+        <translation>Identität der Zugriffsregel</translation>
+    </message>
+    <message>
+        <source>Description...</source>
+        <translation>Beschreibung ...</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Path Pattern</source>
+        <translation>Pfadmuster</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Path &amp;&amp; Action</source>
+        <translation>Pfad &amp;&amp; Aktion</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Pfad</translation>
+    </message>
+</context>
+<context>
+    <name>CAbstractTweak</name>
+    <message>
+        <source>Tweak Group</source>
+        <translation>Tweak-Gruppe</translation>
+    </message>
+    <message>
+        <source>Tweak Bundle</source>
+        <translation>Tweak-Paket</translation>
+    </message>
+    <message>
+        <source>Set Registry Option</source>
+        <translation>Registrierungsoption setzen</translation>
+    </message>
+    <message>
+        <source>Configure Group Policy</source>
+        <translation>Gruppenrichtlinie konfigurieren</translation>
+    </message>
+    <message>
+        <source>Disable System Service</source>
+        <translation>Systemdienst deaktivieren</translation>
+    </message>
+    <message>
+        <source>Disable Scheduled Task</source>
+        <translation>Geplante Aufgabe deaktivieren</translation>
+    </message>
+    <message>
+        <source>Resource Access Rule</source>
+        <translation>Ressourcenzugriffsregel</translation>
+    </message>
+    <message>
+        <source>Execution Control Rule</source>
+        <translation>Ausführungsregel</translation>
+    </message>
+    <message>
+        <source>Firewall Rule</source>
+        <translation>Firewall-Regel</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>Not set</source>
+        <translation>Nicht gesetzt</translation>
+    </message>
+    <message>
+        <source>Applied</source>
+        <translation>Übernommen</translation>
+    </message>
+    <message>
+        <source>Set</source>
+        <translation>Gesetzt</translation>
+    </message>
+    <message>
+        <source>Missing</source>
+        <translation>Fehlt</translation>
+    </message>
+    <message>
+        <source>Ineffective</source>
+        <translation>Wirkungslos</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>Benutzerdefiniert</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Gruppe</translation>
+    </message>
+    <message>
+        <source>Not available</source>
+        <translation>Nicht verfügbar</translation>
+    </message>
+    <message>
+        <source>Recommended</source>
+        <translation>Empfohlen</translation>
+    </message>
+    <message>
+        <source>Not recommended</source>
+        <translation>Nicht empfohlen</translation>
+    </message>
+    <message>
+        <source>Breaking</source>
+        <translation>Problematisch</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessListModel</name>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Last Access</source>
+        <translation>Letzter Zugriff</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>Zugriff</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessListView</name>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Last Access</source>
+        <translation>Letzter Zugriff</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessPage</name>
+    <message>
+        <source>Access Rules</source>
+        <translation>Zugriffsregeln</translation>
+    </message>
+    <message>
+        <source>Open Resources</source>
+        <translation>Offene Ressourcen</translation>
+    </message>
+    <message>
+        <source>Access Monitor</source>
+        <translation>Zugriffsmonitor</translation>
+    </message>
+    <message>
+        <source>Trace Log</source>
+        <translation>Protokoll verfolgen</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRule</name>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Allow Read-Only</source>
+        <translation>Nur-Lesen erlauben</translation>
+    </message>
+    <message>
+        <source>Allow Listing</source>
+        <translation>Auflisten erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Schützen</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Log</source>
+        <translation>Nicht protokollieren</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRuleModel</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation>%1 - %2</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nein</translation>
+    </message>
+    <message>
+        <source> (Hidden)</source>
+        <translation> (Versteckt)</translation>
+    </message>
+    <message>
+        <source> (Temporary)</source>
+        <translation> (Temporär)</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Aktiviert</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Pfad</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Regel aktivieren</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Regel deaktivieren</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Regel löschen</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Regel bearbeiten</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Regel duplizieren</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Regel erstellen</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Alle Aktionen</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Allow Read-Only</source>
+        <translation>Nur-Lesen erlauben</translation>
+    </message>
+    <message>
+        <source>Allow Listing</source>
+        <translation>Auflisten erlauben</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Schützen</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Log</source>
+        <translation>Nicht protokollieren</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Deaktivierte Regeln ausblenden</translation>
+    </message>
+    <message>
+        <source>Show Hidden Rules</source>
+        <translation>Versteckte Regeln anzeigen</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Regeln aktualisieren</translation>
+    </message>
+    <message>
+        <source>Remove Temporary Rules</source>
+        <translation>Temporäre Regeln entfernen</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Möchten Sie die ausgewählten Regelobjekte löschen?</translation>
+    </message>
+    <message>
+        <source>Do you want to delete all Temporary Rules?</source>
+        <translation>Möchten Sie alle temporären Regeln löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRuleWnd</name>
+    <message>
+        <source>Create Program Rule</source>
+        <translation>Programmeregel erstellen</translation>
+    </message>
+    <message>
+        <source>Edit Program Rule</source>
+        <translation>Programmeregel bearbeiten</translation>
+    </message>
+    <message>
+        <source>New Access Rule</source>
+        <translation>Neue Zugriffsregel</translation>
+    </message>
+    <message>
+        <source>Global (Any/No Enclave)</source>
+        <translation>Global (beliebige/keine Enklave)</translation>
+    </message>
+    <message>
+        <source>Browse for Folder</source>
+        <translation>Ordner durchsuchen</translation>
+    </message>
+    <message>
+        <source>Browse for File</source>
+        <translation>Datei durchsuchen</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Read Only</source>
+        <translation>Nur Lesen</translation>
+    </message>
+    <message>
+        <source>Directory Listing</source>
+        <translation>Verzeichnisauflistung</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Schützen</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Log</source>
+        <translation>Nicht protokollieren</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>Verzeichnis auswählen</translation>
+    </message>
+    <message>
+        <source>Select File</source>
+        <translation>Datei auswählen</translation>
+    </message>
+    <message>
+        <source>The path must be contained within the volume.</source>
+        <translation>Der Pfad muss sich innerhalb des Volumes befinden.</translation>
+    </message>
+    <message>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Der ausgewählte Programmtyp wird für diesen Regeltyp nicht unterstützt</translation>
+    </message>
+    <message>
+        <source>%1 %2 %3</source>
+        <translation>%1 %2 %3</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessTraceModel</name>
+    <message>
+        <source>Unknown Program</source>
+        <translation>Unbekanntes Programm</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>PROGRAM MISSING</source>
+        <translation>PROGRAMM FEHLT</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Pfad</translation>
+    </message>
+    <message>
+        <source>Operation</source>
+        <translation>Operation</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Program (Actor)</source>
+        <translation>Programm (Akteur)</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessTraceView</name>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Auto Scroll</source>
+        <translation>Automatisches Scrollen</translation>
+    </message>
+    <message>
+        <source>Hold updates</source>
+        <translation>Aktualisierungen anhalten</translation>
+    </message>
+    <message>
+        <source>Clear Trace Log</source>
+        <translation>Verfolgungsprotokoll löschen</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessView</name>
+    <message>
+        <source>Any Access</source>
+        <translation>Beliebiger Zugriff</translation>
+    </message>
+    <message>
+        <source>Read/Write</source>
+        <translation>Lesen/Schreiben</translation>
+    </message>
+    <message>
+        <source>Write Only</source>
+        <translation>Nur Schreiben</translation>
+    </message>
+    <message>
+        <source>Reload Access Tree</source>
+        <translation>Zugriffsbaum neu laden</translation>
+    </message>
+    <message>
+        <source>CleanUp Access Tree</source>
+        <translation>Zugriffsbaum bereinigen</translation>
+    </message>
+    <message>
+        <source>Copy Path</source>
+        <translation>Pfad kopieren</translation>
+    </message>
+    <message>
+        <source>My Computer</source>
+        <translation>Arbeitsplatz</translation>
+    </message>
+    <message>
+        <source>\\.\</source>
+        <translation>\\.\</translation>
+    </message>
+    <message>
+        <source>Registry</source>
+        <translation>Registrierung</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>Netzwerk</translation>
+    </message>
+    <message>
+        <source>Loading %1</source>
+        <translation>%1 wird geladen</translation>
+    </message>
+    <message>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <translation>Möchten Sie den Zugriffsbaum bereinigen? Dabei werden alle Dateien und Ordner entfernt, die nicht mehr im System vorhanden sind. Außerdem werden alle Verweise auf Dateien und Ordner entfernt, die zwar existieren, sich jedoch auf derzeit nicht eingebundenen Volumes befinden. Der Vorgang greift auf alle protokollierten Speicherorte zu und kann einige Zeit dauern. Danach wird die Ansicht aktualisiert.</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsCacheEntry</name>
+    <message>
+        <source>UNKNOWN (%1)</source>
+        <translation>UNBEKANNT (%1)</translation>
+    </message>
+    <message>
+        <source>Cached</source>
+        <translation>Zwischengespeichert</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsCacheModel</name>
+    <message>
+        <source>Host name</source>
+        <translation>Hostname</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>TTL (sec)</source>
+        <translation>TTL (Sek)</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Last seen</source>
+        <translation>Zuletzt gesehen</translation>
+    </message>
+    <message>
+        <source>Counter</source>
+        <translation>Zähler</translation>
+    </message>
+    <message>
+        <source>Resolved data</source>
+        <translation>Aufgelöste Daten</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsCacheView</name>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Cached</source>
+        <translation>Zwischengespeichert</translation>
+    </message>
+    <message>
+        <source>Any Type</source>
+        <translation>Beliebiger Typ</translation>
+    </message>
+    <message>
+        <source>A or AAAA</source>
+        <translation>A oder AAAA</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <source>AAAA</source>
+        <translation>AAAA</translation>
+    </message>
+    <message>
+        <source>CNAME</source>
+        <translation>CNAME</translation>
+    </message>
+    <message>
+        <source>MX</source>
+        <translation>MX</translation>
+    </message>
+    <message>
+        <source>PTR</source>
+        <translation>PTR</translation>
+    </message>
+    <message>
+        <source>SRV</source>
+        <translation>SRV</translation>
+    </message>
+    <message>
+        <source>TXT</source>
+        <translation>TXT</translation>
+    </message>
+    <message>
+        <source>WKS</source>
+        <translation>WKS</translation>
+    </message>
+    <message>
+        <source>Clear System DNS Cache</source>
+        <translation>System-DNS-Cache leeren</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsPage</name>
+    <message>
+        <source>Dns Rules</source>
+        <translation>DNS-Regeln</translation>
+    </message>
+    <message>
+        <source>DnsCache</source>
+        <translation>DNS-Cache</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsRule</name>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Keine</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsRuleModel</name>
+    <message>
+        <source>Yes</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nein</translation>
+    </message>
+    <message>
+        <source> (Temporary)</source>
+        <translation> (Temporär)</translation>
+    </message>
+    <message>
+        <source>Host Name</source>
+        <translation>Hostname</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Aktiviert</translation>
+    </message>
+    <message>
+        <source>Hit Count</source>
+        <translation>Trefferanzahl</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Regel aktivieren</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Regel deaktivieren</translation>
+    </message>
+    <message>
+        <source>Set Blocking</source>
+        <translation>Blockieren festlegen</translation>
+    </message>
+    <message>
+        <source>Set Allowing</source>
+        <translation>Erlauben festlegen</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Regel löschen</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Regel bearbeiten</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Regel duplizieren</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Regel erstellen</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Alle Aktionen</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Deaktivierte Regeln ausblenden</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Regeln aktualisieren</translation>
+    </message>
+    <message>
+        <source>Edit Dns Rule</source>
+        <translation>DNS-Regel bearbeiten</translation>
+    </message>
+    <message>
+        <source>Enter Host Name</source>
+        <translation>Hostname eingeben</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Möchten Sie die ausgewählten Regelobjekte löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclave</name>
+    <message>
+        <source>Developer Signed</source>
+        <translation>Vom Entwickler signiert</translation>
+    </message>
+    <message>
+        <source>User Signed</source>
+        <translation>Vom Benutzer signiert</translation>
+    </message>
+    <message>
+        <source>Microsoft</source>
+        <translation>Microsoft</translation>
+    </message>
+    <message>
+        <source>Microsoft/AV</source>
+        <translation>Microsoft/Antivirenprogramm</translation>
+    </message>
+    <message>
+        <source>Microsoft Trusted</source>
+        <translation>Von Microsoft vertrauenswürdig</translation>
+    </message>
+    <message>
+        <source>Unknown Root</source>
+        <translation>Unbekannter Ursprung</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Keine</translation>
+    </message>
+    <message>
+        <source>Undetermined</source>
+        <translation>Unbestimmt</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Eject</source>
+        <translation>Auswerfen</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveManager</name>
+    <message>
+        <source>Major Privacy&apos;s Private Enclave</source>
+        <translation>Private Enklave von Major Privacy</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Vertrauensebene</translation>
+    </message>
+    <message>
+        <source>Trusted Spawn/UnTrusted</source>
+        <translation>Vertrauenswürdiger Start/Nicht vertrauenswürdig</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveView</name>
+    <message>
+        <source>Run in Enclave</source>
+        <translation>In Enklave ausführen</translation>
+    </message>
+    <message>
+        <source>Terminate All Processes</source>
+        <translation>Alle Prozesse beenden</translation>
+    </message>
+    <message>
+        <source>Delete Enclave</source>
+        <translation>Enklave löschen</translation>
+    </message>
+    <message>
+        <source>Edit Enclave</source>
+        <translation>Enklave bearbeiten</translation>
+    </message>
+    <message>
+        <source>Duplicate Enclave</source>
+        <translation>Enklave duplizieren</translation>
+    </message>
+    <message>
+        <source>Create Enclave</source>
+        <translation>Enklave erstellen</translation>
+    </message>
+    <message>
+        <source>Open Parent Folder</source>
+        <translation>Übergeordneten Ordner öffnen</translation>
+    </message>
+    <message>
+        <source>File Properties</source>
+        <translation>Dateieigenschaften</translation>
+    </message>
+    <message>
+        <source>Terminate Process</source>
+        <translation>Prozess beenden</translation>
+    </message>
+    <message>
+        <source>%1 can&apos;t be edited!</source>
+        <translation>%1 kann nicht bearbeitet werden!</translation>
+    </message>
+    <message>
+        <source>The process was ejected form the enclave, and is running unprotected, probably due to insuficient signature level!</source>
+        <translation>Der Prozess wurde aus der Enklave entfernt und läuft ungeschützt – vermutlich wegen unzureichender Signaturstufe!</translation>
+    </message>
+    <message>
+        <source>Failed to start process!</source>
+        <translation>Prozess konnte nicht gestartet werden!</translation>
+    </message>
+    <message>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
+        <translation>Möchten Sie alle Prozesse in den ausgewählten Enklaven beenden?</translation>
+    </message>
+    <message>
+        <source>Terminate without asking</source>
+        <translation>Ohne Nachfrage beenden</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Enclave?</source>
+        <translation>Möchten Sie die ausgewählte Enklave löschen?</translation>
+    </message>
+    <message>
+        <source>Do you want to terminate %1?</source>
+        <translation>Möchten Sie %1 beenden?</translation>
+    </message>
+    <message>
+        <source>the selected processes</source>
+        <translation>die ausgewählten Prozesse</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveWnd</name>
+    <message>
+        <source>Change Icon</source>
+        <translation>Symbol ändern</translation>
+    </message>
+    <message>
+        <source>Browse for Image</source>
+        <translation>Nach Bild suchen</translation>
+    </message>
+    <message>
+        <source>Create Secure Enclave</source>
+        <translation>Sichere Enklave erstellen</translation>
+    </message>
+    <message>
+        <source>Edit Secure Enclave</source>
+        <translation>Sichere Enklave bearbeiten</translation>
+    </message>
+    <message>
+        <source>New Secure Enclave</source>
+        <translation>Neue sichere Enklave</translation>
+    </message>
+    <message>
+        <source>User Signature ONLY (not recommended)</source>
+        <translation>Nur Benutzersignatur (nicht empfohlen)</translation>
+    </message>
+    <message>
+        <source>User + Microsoft/AV Signature</source>
+        <translation>Benutzer + Microsoft/AV-Signatur</translation>
+    </message>
+    <message>
+        <source>User + Trusted by Microsoft (Code Root)</source>
+        <translation>Benutzer + von Microsoft vertrauenswürdig (Code Root)</translation>
+    </message>
+    <message>
+        <source>Any Signature (Unknown Root)</source>
+        <translation>Beliebige Signatur (unbekannter Ursprung)</translation>
+    </message>
+    <message>
+        <source>No Signature</source>
+        <translation>Keine Signatur</translation>
+    </message>
+    <message>
+        <source>Allow Execution</source>
+        <translation>Ausführung erlauben</translation>
+    </message>
+    <message>
+        <source>Eject from Secure Enclave</source>
+        <translation>Aus sicherer Enklave entfernen</translation>
+    </message>
+    <message>
+        <source>Prevent Execution</source>
+        <translation>Ausführung verhindern</translation>
+    </message>
+    <message>
+        <source>Don&apos;t change</source>
+        <translation>Keine Änderung</translation>
+    </message>
+    <message>
+        <source>Medium +</source>
+        <translation>Mittel +</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Hoch</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Select Image File</source>
+        <translation>Bilddatei auswählen</translation>
+    </message>
+    <message>
+        <source>Image Files (*.png)</source>
+        <translation>Bilddateien (*.png)</translation>
+    </message>
+</context>
+<context>
+    <name>CExecutionModel</name>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rolle</translation>
+    </message>
+    <message>
+        <source>Last Status</source>
+        <translation>Letzter Status</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CExecutionView</name>
+    <message>
+        <source>Any Role</source>
+        <translation>Beliebige Rolle</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Akteur</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Ziel</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Show entries per UPID</source>
+        <translation>Einträge nach UPID anzeigen</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+</context>
+<context>
+    <name>CFirewallRuleWnd</name>
+    <message>
+        <source>Create Firewall Rule</source>
+        <translation>Firewall-Regel erstellen</translation>
+    </message>
+    <message>
+        <source>Edit Firewall Rule</source>
+        <translation>Firewall-Regel bearbeiten</translation>
+    </message>
+    <message>
+        <source>&amp;MP-Rule, New Firewall Rule</source>
+        <translation>&amp;MP-Regel, neue Firewall-Regel</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Bidirectional</source>
+        <translation>Bidirektional</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Eingehend</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Ausgehend</translation>
+    </message>
+    <message>
+        <source>Any Protocol</source>
+        <translation>Beliebiges Protokoll</translation>
+    </message>
+    <message>
+        <source>[Add IP]</source>
+        <translation>[IP hinzufügen]</translation>
+    </message>
+    <message>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Der ausgewählte Programmtyp wird für diesen Regeltyp nicht unterstützt</translation>
+    </message>
+    <message>
+        <source>All Types</source>
+        <translation>Alle Typen</translation>
+    </message>
+    <message>
+        <source>Invalid Sub Net</source>
+        <translation>Ungültiges Subnetz</translation>
+    </message>
+    <message>
+        <source>Invalid IP Address</source>
+        <translation>Ungültige IP-Adresse</translation>
+    </message>
+    <message>
+        <source>Invalid IP Range</source>
+        <translation>Ungültiger IP-Bereich</translation>
+    </message>
+    <message>
+        <source>%4, %1 %2 %3</source>
+        <translation>%4, %1 %2 %3</translation>
+    </message>
+</context>
+<context>
+    <name>CFwRule</name>
+    <message>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <source>Domain</source>
+        <translation>Domäne</translation>
+    </message>
+    <message>
+        <source>Private</source>
+        <translation>Privat</translation>
+    </message>
+    <message>
+        <source>Public</source>
+        <translation>Öffentlich</translation>
+    </message>
+    <message>
+        <source>Any</source>
+        <translation>Beliebig</translation>
+    </message>
+    <message>
+        <source>LAN</source>
+        <translation>LAN</translation>
+    </message>
+    <message>
+        <source>WiFi</source>
+        <translation>WLAN</translation>
+    </message>
+    <message>
+        <source>VPN</source>
+        <translation>VPN</translation>
+    </message>
+    <message>
+        <source>FromLog</source>
+        <translation>Aus Protokoll</translation>
+    </message>
+    <message>
+        <source>UnRuled</source>
+        <translation>Regellos</translation>
+    </message>
+    <message>
+        <source>Rule Allowed</source>
+        <translation>Regel erlaubt</translation>
+    </message>
+    <message>
+        <source>Rule Blocked</source>
+        <translation>Regel blockiert</translation>
+    </message>
+    <message>
+        <source>Rule Error</source>
+        <translation>Regelfehler</translation>
+    </message>
+    <message>
+        <source>Rule Generated</source>
+        <translation>Regel generiert</translation>
+    </message>
+    <message>
+        <source>Undefined</source>
+        <translation>Undefiniert</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Eingehend</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Ausgehend</translation>
+    </message>
+    <message>
+        <source>Bidirectional</source>
+        <translation>Bidirektional</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+</context>
+<context>
+    <name>CFwRuleModel</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation>%1 - %2</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nein</translation>
+    </message>
+    <message>
+        <source> (Temporary)</source>
+        <translation> (Temporär)</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Grouping</source>
+        <translation>Gruppierung</translation>
+    </message>
+    <message>
+        <source>Index</source>
+        <translation>Index</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Aktiviert</translation>
+    </message>
+    <message>
+        <source>Hit Count</source>
+        <translation>Trefferanzahl</translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation>Profile</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Richtung</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Remote-Adresse</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Lokale Adresse</translation>
+    </message>
+    <message>
+        <source>Remote Ports</source>
+        <translation>Remote-Ports</translation>
+    </message>
+    <message>
+        <source>Local Ports</source>
+        <translation>Lokale Ports</translation>
+    </message>
+    <message>
+        <source>ICMP Options</source>
+        <translation>ICMP-Optionen</translation>
+    </message>
+    <message>
+        <source>Interfaces</source>
+        <translation>Schnittstellen</translation>
+    </message>
+    <message>
+        <source>Edge Traversal</source>
+        <translation>Edge Traversal</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CFwRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Regel aktivieren</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Regel deaktivieren</translation>
+    </message>
+    <message>
+        <source>Set Blocking</source>
+        <translation>Blockieren festlegen</translation>
+    </message>
+    <message>
+        <source>Set Allowing</source>
+        <translation>Erlauben festlegen</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Regel löschen</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Regel bearbeiten</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Regel duplizieren</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Regel erstellen</translation>
+    </message>
+    <message>
+        <source>All Directions</source>
+        <translation>Alle Richtungen</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Eingehend</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Ausgehend</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Alle Aktionen</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Deaktivierte Regeln ausblenden</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Regeln aktualisieren</translation>
+    </message>
+    <message>
+        <source>Remove Temporary Rules</source>
+        <translation>Temporäre Regeln entfernen</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Möchten Sie die ausgewählten Regelobjekte löschen?</translation>
+    </message>
+    <message>
+        <source>Do you want to delete all Temporary Rules?</source>
+        <translation>Möchten Sie alle temporären Regeln löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CGenericRule</name>
+    <message>
+        <source> (duplicate)</source>
+        <translation> (Duplikat)</translation>
+    </message>
+</context>
+<context>
+    <name>CHandleModel</name>
+    <message>
+        <source>PROCESS MISSING</source>
+        <translation>PROZESS FEHLT</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CHomePage</name>
+    <message>
+        <source>Time Stamp|Type|Event|Message</source>
+        <translation>Zeitstempel|Typ|Ereignis|Nachricht</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation>Erfolg</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Warnung</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>Information</translation>
+    </message>
+    <message>
+        <source>Audit Success</source>
+        <translation>Überprüfung erfolgreich</translation>
+    </message>
+    <message>
+        <source>Audit Failure</source>
+        <translation>Überprüfung fehlgeschlagen</translation>
+    </message>
+</context>
+<context>
+    <name>CInfoView</name>
+    <message>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <source>Name: %1 (%2)</source>
+        <translation>Name: %1 (%2)</translation>
+    </message>
+    <message>
+        <source>Path: %1</source>
+        <translation>Pfad: %1</translation>
+    </message>
+    <message>
+        <source>Groups (%1)</source>
+        <translation>Gruppen (%1)</translation>
+    </message>
+    <message>
+        <source>Root (%1)</source>
+        <translation>Stamm (%1)</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+</context>
+<context>
+    <name>CIngressModel</name>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rolle</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Operation</source>
+        <translation>Operation</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CIngressView</name>
+    <message>
+        <source>Any Role</source>
+        <translation>Beliebige Rolle</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Akteur</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Ziel</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>All Operations</source>
+        <translation>Alle Operationen</translation>
+    </message>
+    <message>
+        <source>Control Execution</source>
+        <translation>Ausführung kontrollieren</translation>
+    </message>
+    <message>
+        <source>Change Permissions</source>
+        <translation>Berechtigungen ändern</translation>
+    </message>
+    <message>
+        <source>Write Memory</source>
+        <translation>Speicher schreiben</translation>
+    </message>
+    <message>
+        <source>Read Memory</source>
+        <translation>Speicher lesen</translation>
+    </message>
+    <message>
+        <source>Special Permissions</source>
+        <translation>Spezielle Berechtigungen</translation>
+    </message>
+    <message>
+        <source>Write Properties</source>
+        <translation>Eigenschaften schreiben</translation>
+    </message>
+    <message>
+        <source>Read Properties</source>
+        <translation>Eigenschaften lesen</translation>
+    </message>
+    <message>
+        <source>Show Private Entries</source>
+        <translation>Private Einträge anzeigen</translation>
+    </message>
+    <message>
+        <source>Show entries per UPID</source>
+        <translation>Einträge pro UPID anzeigen</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+</context>
+<context>
+    <name>CLibraryInfoView</name>
+    <message>
+        <source>Name|Signer|Valid|SHA1 Fingerprint|Certificate Fingerprint</source>
+        <translation>Name|Signierer|Gültig|SHA1-Fingerabdruck|Zertifikat-Fingerabdruck</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <source>INVALID</source>
+        <translation>UNGÜLTIG</translation>
+    </message>
+    <message>
+        <source>Yes (Catalog)</source>
+        <translation>Ja (Katalog)</translation>
+    </message>
+</context>
+<context>
+    <name>CLibraryModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Vertrauensebene</translation>
+    </message>
+    <message>
+        <source>Last Status</source>
+        <translation>Letzter Status</translation>
+    </message>
+    <message>
+        <source>Last Load</source>
+        <translation>Letztes Laden</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation>Anzahl</translation>
+    </message>
+    <message>
+        <source>Signing Certificate</source>
+        <translation>Signierzertifikat</translation>
+    </message>
+    <message>
+        <source>Module</source>
+        <translation>Modul</translation>
+    </message>
+</context>
+<context>
+    <name>CLibraryView</name>
+    <message>
+        <source>Sign File</source>
+        <translation>Datei signieren</translation>
+    </message>
+    <message>
+        <source>Remove File Signature</source>
+        <translation>Dateisignatur entfernen</translation>
+    </message>
+    <message>
+        <source>Sign Certificate</source>
+        <translation>Zertifikat signieren</translation>
+    </message>
+    <message>
+        <source>Remove Cert Signature</source>
+        <translation>Zertifikatsignatur entfernen</translation>
+    </message>
+    <message>
+        <source>Open Parent Folder</source>
+        <translation>Übergeordneten Ordner öffnen</translation>
+    </message>
+    <message>
+        <source>File Properties</source>
+        <translation>Dateieigenschaften</translation>
+    </message>
+    <message>
+        <source>By Program</source>
+        <translation>Nach Programm</translation>
+    </message>
+    <message>
+        <source>By Library</source>
+        <translation>Nach Bibliothek</translation>
+    </message>
+    <message>
+        <source>All Signatures</source>
+        <translation>Alle Signaturen</translation>
+    </message>
+    <message>
+        <source>User Sign. ONLY</source>
+        <translation>Nur Benutzersignatur</translation>
+    </message>
+    <message>
+        <source>Microsoft/AV</source>
+        <translation>Microsoft/AV</translation>
+    </message>
+    <message>
+        <source>Trusted by MSFT</source>
+        <translation>Von Microsoft vertrauenswürdig</translation>
+    </message>
+    <message>
+        <source>Untrusted/None</source>
+        <translation>Nicht vertrauenswürdig/Keine</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Untrusted</source>
+        <translation>Nicht vertrauenswürdig</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>CleanUp Libraries</source>
+        <translation>Bibliotheken bereinigen</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+</context>
+<context>
+    <name>CMajorPrivacy</name>
+    <message>
+        <source>Starting ...</source>
+        <translation>Starte ...</translation>
+    </message>
+    <message>
+        <source>The driver configuration is corrupted, and could not be loaded, plrease restore from a backup.</source>
+        <translation>Die Treiberkonfiguration ist beschädigt und konnte nicht geladen werden. Bitte stelle sie aus einem Backup wieder her.</translation>
+    </message>
+    <message>
+        <source>The driver configuration is Untrusted (INVALID Signature, or Sequence). Do you want to load ir anyways?</source>
+        <translation>Die Treiberkonfiguration ist nicht vertrauenswürdig (ungültige Signatur oder Sequenz). Möchtest du sie trotzdem laden?</translation>
+    </message>
+    <message>
+        <source>The Privacy Agent is not currently installed as a service. Would you like to install it now (Yes), run it without installation (No), or abort the connection attempt (Cancel)?</source>
+        <translation>Der Privacy Agent ist derzeit nicht als Dienst installiert. Möchtest du ihn jetzt installieren (Ja), ohne Installation ausführen (Nein) oder den Verbindungsversuch abbrechen (Abbrechen)?</translation>
+    </message>
+    <message>
+        <source>Remember this choice.</source>
+        <translation>Diesen Auswahl merken.</translation>
+    </message>
+    <message>
+        <source>Major Privacy will now attempt to start the Privacy Agent, please confirm the UAC prompt.</source>
+        <translation>Major Privacy wird nun versuchen, den Privacy Agent zu starten. Bitte bestätige die UAC-Abfrage.</translation>
+    </message>
+    <message>
+        <source>Privacy Agent Ready %1/%2</source>
+        <translation>Privacy Agent bereit %1/%2</translation>
+    </message>
+    <message>
+        <source>Privacy Agent Failed: %1</source>
+        <translation>Privacy Agent fehlgeschlagen: %1</translation>
+    </message>
+    <message>
+        <source>Do you want to close Major Privacy?</source>
+        <translation>Möchtest du Major Privacy schließen?</translation>
+    </message>
+    <message>
+        <source>Lost connection to Service, do you want to reconnect?</source>
+        <translation>Verbindung zum Dienst verloren. Möchtest du erneut verbinden?</translation>
+    </message>
+    <message>
+        <source>Mem Usage: %1 + %2 (Logs)</source>
+        <translation>Speichernutzung: %1 + %2 (Logs)</translation>
+    </message>
+    <message>
+        <source>Disconnected from privacy agent</source>
+        <translation>Vom Privacy Agent getrennt</translation>
+    </message>
+    <message>
+        <source>&amp;Maintenance</source>
+        <translation>&amp;Wartung</translation>
+    </message>
+    <message>
+        <source>Import Options</source>
+        <translation>Optionen importieren</translation>
+    </message>
+    <message>
+        <source>Export Options</source>
+        <translation>Optionen exportieren</translation>
+    </message>
+    <message>
+        <source>&amp;Advanced</source>
+        <translation>&amp;Erweitert</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation>Verbinden</translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation>Trennen</translation>
+    </message>
+    <message>
+        <source>Install Services</source>
+        <translation>Dienste installieren</translation>
+    </message>
+    <message>
+        <source>Remove Services</source>
+        <translation>Dienste entfernen</translation>
+    </message>
+    <message>
+        <source>Open User Data Folder</source>
+        <translation>Benutzerdatenordner öffnen</translation>
+    </message>
+    <message>
+        <source>Open System Data Folder</source>
+        <translation>Systemdatenordner öffnen</translation>
+    </message>
+    <message>
+        <source>Open *.dat Editor</source>
+        <translation>*.dat-Editor öffnen</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>Beenden</translation>
+    </message>
+    <message>
+        <source>Toggle Program Tree</source>
+        <translation>Programmbaum ein-/ausblenden</translation>
+    </message>
+    <message>
+        <source>Stack Panels</source>
+        <translation>Paneele stapeln</translation>
+    </message>
+    <message>
+        <source>Merge Panels</source>
+        <translation>Paneele zusammenführen</translation>
+    </message>
+    <message>
+        <source>Separate Column Sets</source>
+        <translation>Spaltensätze trennen</translation>
+    </message>
+    <message>
+        <source>Show Tab Labels</source>
+        <translation>Reiterbeschriftungen anzeigen</translation>
+    </message>
+    <message>
+        <source>Always on Top</source>
+        <translation>Immer im Vordergrund</translation>
+    </message>
+    <message>
+        <source>Add and Mount Volume Image</source>
+        <translation>Volume-Image hinzufügen und einbinden</translation>
+    </message>
+    <message>
+        <source>Unmount All Volumes</source>
+        <translation>Alle Volumes aushängen</translation>
+    </message>
+    <message>
+        <source>Create Volume</source>
+        <translation>Volume erstellen</translation>
+    </message>
+    <message>
+        <source>Sign File</source>
+        <translation>Datei signieren</translation>
+    </message>
+    <message>
+        <source>Signature Database</source>
+        <translation>Signaturdatenbank</translation>
+    </message>
+    <message>
+        <source>Unload Protection</source>
+        <translation>Schutz entladen</translation>
+    </message>
+    <message>
+        <source>Enable Rule Protection</source>
+        <translation>Regelschutz aktivieren</translation>
+    </message>
+    <message>
+        <source>Disable Rules Protection</source>
+        <translation>Regelschutz deaktivieren</translation>
+    </message>
+    <message>
+        <source>Setup User Key</source>
+        <translation>Benutzerschlüssel einrichten</translation>
+    </message>
+    <message>
+        <source>Remove User Key</source>
+        <translation>Benutzerschlüssel entfernen</translation>
+    </message>
+    <message>
+        <source>CleanUp Program List</source>
+        <translation>Programmliste bereinigen</translation>
+    </message>
+    <message>
+        <source>Re-Group all Programs</source>
+        <translation>Alle Programme neu gruppieren</translation>
+    </message>
+    <message>
+        <source>&amp;Advanced Tools</source>
+        <translation>&amp;Erweiterte Werkzeuge</translation>
+    </message>
+    <message>
+        <source>Mount Manager</source>
+        <translation>Mount-Manager</translation>
+    </message>
+    <message>
+        <source>Virtual Disks</source>
+        <translation>Virtuelle Laufwerke</translation>
+    </message>
+    <message>
+        <source>Clear All Trace Logs</source>
+        <translation>Alle Protokolle löschen</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <source>Unlock Config</source>
+        <translation>Konfiguration entsperren</translation>
+    </message>
+    <message>
+        <source>Commit Changes</source>
+        <translation>Änderungen übernehmen</translation>
+    </message>
+    <message>
+        <source>Discard Changes</source>
+        <translation>Änderungen verwerfen</translation>
+    </message>
+    <message>
+        <source>Clear Ignore List</source>
+        <translation>Ignorierliste leeren</translation>
+    </message>
+    <message>
+        <source>Reset All Prompts</source>
+        <translation>Alle Hinweise zurücksetzen</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Hilfe</translation>
+    </message>
+    <message>
+        <source>Visit Support Forum</source>
+        <translation>Support-Forum besuchen</translation>
+    </message>
+    <message>
+        <source>About the Qt Framework</source>
+        <translation>Über das Qt-Framework</translation>
+    </message>
+    <message>
+        <source>About MajorPrivacy</source>
+        <translation>Über MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>System Overview</source>
+        <translation>Systemübersicht</translation>
+    </message>
+    <message>
+        <source>Process Security</source>
+        <translation>Prozesssicherheit</translation>
+    </message>
+    <message>
+        <source>Secure Enclaves</source>
+        <translation>Sichere Enklaven</translation>
+    </message>
+    <message>
+        <source>Resource Protection</source>
+        <translation>Ressourcenschutz</translation>
+    </message>
+    <message>
+        <source>Secure Volumes</source>
+        <translation>Gesicherte Volumes</translation>
+    </message>
+    <message>
+        <source>Network Firewall</source>
+        <translation>Netzwerk-Firewall</translation>
+    </message>
+    <message>
+        <source>DNS Filtering</source>
+        <translation>DNS-Filterung</translation>
+    </message>
+    <message>
+        <source>Privacy Tweaks</source>
+        <translation>Datenschutzanpassungen</translation>
+    </message>
+    <message>
+        <source>Set Time Filter</source>
+        <translation>Zeitfilter setzen</translation>
+    </message>
+    <message>
+        <source>Any time</source>
+        <translation>Beliebige Zeit</translation>
+    </message>
+    <message>
+        <source>Last 5 Seconds</source>
+        <translation>Letzte 5 Sekunden</translation>
+    </message>
+    <message>
+        <source>Last 10 Seconds</source>
+        <translation>Letzte 10 Sekunden</translation>
+    </message>
+    <message>
+        <source>Last 30 Seconds</source>
+        <translation>Letzte 30 Sekunden</translation>
+    </message>
+    <message>
+        <source>Last Minute</source>
+        <translation>Letzte Minute</translation>
+    </message>
+    <message>
+        <source>Last 3 Minutes</source>
+        <translation>Letzte 3 Minuten</translation>
+    </message>
+    <message>
+        <source>Last 5 Minutes</source>
+        <translation>Letzte 5 Minuten</translation>
+    </message>
+    <message>
+        <source>Last 15 Minutes</source>
+        <translation>Letzte 15 Minuten</translation>
+    </message>
+    <message>
+        <source>Last 30 Minutes</source>
+        <translation>Letzte 30 Minuten</translation>
+    </message>
+    <message>
+        <source>Last Hour</source>
+        <translation>Letzte Stunde</translation>
+    </message>
+    <message>
+        <source>Last 3 Hours</source>
+        <translation>Letzte 3 Stunden</translation>
+    </message>
+    <message>
+        <source>Last 12 Hours</source>
+        <translation>Letzte 12 Stunden</translation>
+    </message>
+    <message>
+        <source>Last 24 Hours</source>
+        <translation>Letzte 24 Stunden</translation>
+    </message>
+    <message>
+        <source>Last 48 Hours</source>
+        <translation>Letzte 48 Stunden</translation>
+    </message>
+    <message>
+        <source>Last Week</source>
+        <translation>Letzte Woche</translation>
+    </message>
+    <message>
+        <source>Last 2 Weeks</source>
+        <translation>Letzte 2 Wochen</translation>
+    </message>
+    <message>
+        <source>Last Month</source>
+        <translation>Letzter Monat</translation>
+    </message>
+    <message>
+        <source>Show/Hide</source>
+        <translation>Einblenden/Ausblenden</translation>
+    </message>
+    <message>
+        <source>Process Protection Popups</source>
+        <translation>Popupmeldungen für Prozessschutz</translation>
+    </message>
+    <message>
+        <source>Resource Access Popups</source>
+        <translation>Popupmeldungen für Ressourcenzugriffe</translation>
+    </message>
+    <message>
+        <source>Network Firewall Popups</source>
+        <translation>Popupmeldungen für Netzwerk-Firewall</translation>
+    </message>
+    <message>
+        <source>Firewall Profile</source>
+        <translation>Firewall-Profil</translation>
+    </message>
+    <message>
+        <source>Use Allow List</source>
+        <translation>Erlaubnisliste verwenden</translation>
+    </message>
+    <message>
+        <source>Use Block List</source>
+        <translation>Sperrliste verwenden</translation>
+    </message>
+    <message>
+        <source>Disabled Firewall</source>
+        <translation>Firewall deaktiviert</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to sign a file</source>
+        <translation>Geben Sie das Passwort für die sichere Konfiguration ein, um eine Datei zu signieren</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to sign a certificate</source>
+        <translation>Geben Sie das Passwort für die sichere Konfiguration ein, um ein Zertifikat zu signieren</translation>
+    </message>
+    <message>
+        <source>
 				Enter Secure Configuration Password, to enable rule protection.
 				Once that is done you can not change rules (except windows firewall) without using the user key.
 			</source>
-			<translation>
+        <translation>
 				Geben Sie das Passwort für die sichere Konfiguration ein, um den Regelschutz zu aktivieren.
 				Danach können Regeln (außer der Windows-Firewall) nur noch mit dem Benutzerschlüssel geändert werden.
 			</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to disable rule protection.</source>
-			<translation>Geben Sie das Passwort für die sichere Konfiguration ein, um den Regelschutz zu deaktivieren.</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to allow rule editing.</source>
-			<translation>Geben Sie das Passwort für die sichere Konfiguration ein, um das Bearbeiten von Regeln zu erlauben.</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to commit changes.</source>
-			<translation>Geben Sie das Passwort für die sichere Konfiguration ein, um Änderungen zu übernehmen.</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to remove the user key.</source>
-			<translation>Geben Sie das Passwort für die sichere Konfiguration ein, um den Benutzerschlüssel zu entfernen.</translation>
-		</message>
-		<message>
-			<source>Remember Password to sign more items for:</source>
-			<translation>Passwort merken, um weitere Objekte zu signieren für:</translation>
-		</message>
-		<message>
-			<source>Remember Password and commit changes after:</source>
-			<translation>Passwort merken und Änderungen übernehmen nach:</translation>
-		</message>
-		<message>
-			<source>Select Files</source>
-			<translation>Dateien auswählen</translation>
-		</message>
-		<message>
-			<source>All Files (*.*)</source>
-			<translation>Alle Dateien (*.*)</translation>
-		</message>
-		<message>
-			<source>This setting required the service to be restarted to tak effect</source>
-			<translation>Diese Einstellung erfordert einen Neustart des Dienstes, um wirksam zu werden</translation>
-		</message>
-		<message>
-			<source>Don&apos;t show this message again.</source>
-			<translation>Diese Meldung nicht erneut anzeigen.</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to disable rule protection.</source>
+        <translation>Geben Sie das Passwort für die sichere Konfiguration ein, um den Regelschutz zu deaktivieren.</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to allow rule editing.</source>
+        <translation>Geben Sie das Passwort für die sichere Konfiguration ein, um das Bearbeiten von Regeln zu erlauben.</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to commit changes.</source>
+        <translation>Geben Sie das Passwort für die sichere Konfiguration ein, um Änderungen zu übernehmen.</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to remove the user key.</source>
+        <translation>Geben Sie das Passwort für die sichere Konfiguration ein, um den Benutzerschlüssel zu entfernen.</translation>
+    </message>
+    <message>
+        <source>Remember Password to sign more items for:</source>
+        <translation>Passwort merken, um weitere Objekte zu signieren für:</translation>
+    </message>
+    <message>
+        <source>Remember Password and commit changes after:</source>
+        <translation>Passwort merken und Änderungen übernehmen nach:</translation>
+    </message>
+    <message>
+        <source>Select Files</source>
+        <translation>Dateien auswählen</translation>
+    </message>
+    <message>
+        <source>All Files (*.*)</source>
+        <translation>Alle Dateien (*.*)</translation>
+    </message>
+    <message>
+        <source>This setting required the service to be restarted to tak effect</source>
+        <translation>Diese Einstellung erfordert einen Neustart des Dienstes, um wirksam zu werden</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>Diese Meldung nicht erneut anzeigen.</translation>
+    </message>
+    <message>
+        <source>
 				Would you like to lock down the user key (Yes), or only enable user key signature-based rule protection (No)?
 
 				Locking down the user key will prevent it from being removed or changed, and rule protection cannot be disabled until the system is rebooted.
 
 				If the driver is set to auto-start, it will automatically re-lock the key on reboot!
 			</source>
-			<translation>
+        <translation>
 				Möchten Sie den Benutzerschlüssel sperren (Ja), oder nur den schlüsselbasierten Regelschutz aktivieren (Nein)?
 
 				Das Sperren des Schlüssels verhindert dessen Entfernung oder Änderung. Der Regelschutz kann dann erst nach einem Neustart deaktiviert werden.
 
 				Wenn der Treiber auf Autostart gesetzt ist, wird der Schlüssel beim Neustart automatisch wieder gesperrt!
 			</translation>
-		</message>
-		<message>
-			<source>The user key is locked. Please reboot the system to complete the removal of the config protection.</source>
-			<translation>Der Benutzerschlüssel ist gesperrt. Bitte starten Sie das System neu, um den Konfigurationsschutz vollständig zu entfernen.</translation>
-		</message>
-		<message>
-			<source>Do you really want to discard all changes?</source>
-			<translation>Möchten Sie wirklich alle Änderungen verwerfen?</translation>
-		</message>
-		<message>
-			<source>Set new Secure Configuration Password</source>
-			<translation>Neues Konfigurationsschutz-Passwort festlegen</translation>
-		</message>
-		<message>
-			<source>Program not found.</source>
-			<translation>Programm nicht gefunden.</translation>
-		</message>
-		<message>
-			<source>Program already exists.</source>
-			<translation>Programm existiert bereits.</translation>
-		</message>
-		<message>
-			<source>This Operation can not be performed on a program which has rules.</source>
-			<translation>Diese Operation kann nicht an einem Programm mit vorhandenen Regeln durchgeführt werden.</translation>
-		</message>
-		<message>
-			<source>Parent program not found.</source>
-			<translation>Übergeordnetes Programm nicht gefunden.</translation>
-		</message>
-		<message>
-			<source>Can&apos;t remove from pattern.</source>
-			<translation>Kann nicht aus Muster entfernt werden.</translation>
-		</message>
-		<message>
-			<source>Parent program not valid.</source>
-			<translation>Übergeordnetes Programm ist ungültig.</translation>
-		</message>
-		<message>
-			<source>Removing program items which are auto generated and represent found components can not be removed.</source>
-			<translation>Automatisch erzeugte Programmobjekte, die gefundene Komponenten darstellen, können nicht entfernt werden.</translation>
-		</message>
-		<message>
-			<source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
-			<translation>Bevor Sie eine Binärdatei signieren können, müssen Sie Ihren Benutzerschlüssel erstellen. Verwenden Sie dazu den Menüpunkt „Sicherheit → Benutzerschlüssel einrichten“.</translation>
-		</message>
-		<message>
-			<source>Wrong Password!</source>
-			<translation>Falsches Passwort!</translation>
-		</message>
-		<message>
-			<source>Error 0x%1</source>
-			<translation>Fehler 0x%1</translation>
-		</message>
-		<message>
-			<source>MajorPrivacy - Error</source>
-			<translation>MajorPrivacy – Fehler</translation>
-		</message>
-		<message>
-			<source>Operation failed for %1 item(s).</source>
-			<translation>Vorgang fehlgeschlagen für %1 Element(e).</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the All trace logs for all program items?</source>
-			<translation>Möchten Sie wirklich alle Protokolleinträge für alle Programme löschen?</translation>
-		</message>
-		<message>
-			<source>Cleanup done.</source>
-			<translation>Bereinigung abgeschlossen.</translation>
-		</message>
-		<message>
-			<source>Cleanup %1/%2</source>
-			<translation>Bereinige %1/%2</translation>
-		</message>
-		<message>
-			<source>Do you want to clean up the Program List? Choosing 'Yes' will remove all missing program entries, including those with rules. Choosing 'No' will remove only missing entries without rules. Select 'Cancel' to abort the operation.</source>
-			<translation>Möchten Sie die Programmliste bereinigen? Mit „Ja“ werden alle fehlenden Einträge entfernt, einschließlich jener mit Regeln. Mit „Nein“ werden nur fehlende Einträge ohne Regeln entfernt. Wählen Sie „Abbrechen“, um den Vorgang abzubrechen.</translation>
-		</message>
-		<message>
-			<source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
-			<translation>Möchten Sie alle Programme neu gruppieren? Dadurch werden alle Programme aus automatisch zugewiesenen Gruppen entfernt und anhand der Standardregeln neu zugewiesen.</translation>
-		</message>
-		<message>
-			<source>Do you really want to clear the ignore list?</source>
-			<translation>Möchten Sie die Ignorierliste wirklich leeren?</translation>
-		</message>
-		<message>
-			<source>Do you also want to reset all hidden message boxes?</source>
-			<translation>Möchten Sie auch alle ausgeblendeten Nachrichtenfenster zurücksetzen?</translation>
-		</message>
-		<message>
-			<source>Options Files (*.xml)</source>
-			<translation>Optionsdateien (*.xml)</translation>
-		</message>
-		<message>
-			<source>Failed to parse XML data!</source>
-			<translation>Fehler beim Verarbeiten der XML-Daten!</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>The user key is locked. Please reboot the system to complete the removal of the config protection.</source>
+        <translation>Der Benutzerschlüssel ist gesperrt. Bitte starten Sie das System neu, um den Konfigurationsschutz vollständig zu entfernen.</translation>
+    </message>
+    <message>
+        <source>Do you really want to discard all changes?</source>
+        <translation>Möchten Sie wirklich alle Änderungen verwerfen?</translation>
+    </message>
+    <message>
+        <source>Set new Secure Configuration Password</source>
+        <translation>Neues Konfigurationsschutz-Passwort festlegen</translation>
+    </message>
+    <message>
+        <source>Program not found.</source>
+        <translation>Programm nicht gefunden.</translation>
+    </message>
+    <message>
+        <source>Program already exists.</source>
+        <translation>Programm existiert bereits.</translation>
+    </message>
+    <message>
+        <source>This Operation can not be performed on a program which has rules.</source>
+        <translation>Diese Operation kann nicht an einem Programm mit vorhandenen Regeln durchgeführt werden.</translation>
+    </message>
+    <message>
+        <source>Parent program not found.</source>
+        <translation>Übergeordnetes Programm nicht gefunden.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t remove from pattern.</source>
+        <translation>Kann nicht aus Muster entfernt werden.</translation>
+    </message>
+    <message>
+        <source>Parent program not valid.</source>
+        <translation>Übergeordnetes Programm ist ungültig.</translation>
+    </message>
+    <message>
+        <source>Removing program items which are auto generated and represent found components can not be removed.</source>
+        <translation>Automatisch erzeugte Programmobjekte, die gefundene Komponenten darstellen, können nicht entfernt werden.</translation>
+    </message>
+    <message>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
+        <translation>Bevor Sie eine Binärdatei signieren können, müssen Sie Ihren Benutzerschlüssel erstellen. Verwenden Sie dazu den Menüpunkt „Sicherheit → Benutzerschlüssel einrichten“.</translation>
+    </message>
+    <message>
+        <source>Wrong Password!</source>
+        <translation>Falsches Passwort!</translation>
+    </message>
+    <message>
+        <source>Error 0x%1</source>
+        <translation>Fehler 0x%1</translation>
+    </message>
+    <message>
+        <source>MajorPrivacy - Error</source>
+        <translation>MajorPrivacy – Fehler</translation>
+    </message>
+    <message>
+        <source>Operation failed for %1 item(s).</source>
+        <translation>Vorgang fehlgeschlagen für %1 Element(e).</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the All trace logs for all program items?</source>
+        <translation>Möchten Sie wirklich alle Protokolleinträge für alle Programme löschen?</translation>
+    </message>
+    <message>
+        <source>Cleanup done.</source>
+        <translation>Bereinigung abgeschlossen.</translation>
+    </message>
+    <message>
+        <source>Cleanup %1/%2</source>
+        <translation>Bereinige %1/%2</translation>
+    </message>
+    <message>
+        <source>Do you want to clean up the Program List? Choosing &apos;Yes&apos; will remove all missing program entries, including those with rules. Choosing &apos;No&apos; will remove only missing entries without rules. Select &apos;Cancel&apos; to abort the operation.</source>
+        <translation>Möchten Sie die Programmliste bereinigen? Mit „Ja“ werden alle fehlenden Einträge entfernt, einschließlich jener mit Regeln. Mit „Nein“ werden nur fehlende Einträge ohne Regeln entfernt. Wählen Sie „Abbrechen“, um den Vorgang abzubrechen.</translation>
+    </message>
+    <message>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
+        <translation>Möchten Sie alle Programme neu gruppieren? Dadurch werden alle Programme aus automatisch zugewiesenen Gruppen entfernt und anhand der Standardregeln neu zugewiesen.</translation>
+    </message>
+    <message>
+        <source>Do you really want to clear the ignore list?</source>
+        <translation>Möchten Sie die Ignorierliste wirklich leeren?</translation>
+    </message>
+    <message>
+        <source>Do you also want to reset all hidden message boxes?</source>
+        <translation>Möchten Sie auch alle ausgeblendeten Nachrichtenfenster zurücksetzen?</translation>
+    </message>
+    <message>
+        <source>Options Files (*.xml)</source>
+        <translation>Optionsdateien (*.xml)</translation>
+    </message>
+    <message>
+        <source>Failed to parse XML data!</source>
+        <translation>Fehler beim Verarbeiten der XML-Daten!</translation>
+    </message>
+    <message>
+        <source>
 				Do you want to stop the Privacy Agent and unload the Kernel Isolator?
 				CAUTION: This will disable protection.
 			</source>
-			<translation>
+        <translation>
 				Möchten Sie den Privacy Agent beenden und den Kernel-Isolator entladen?
 				ACHTUNG: Der Schutz wird dadurch deaktiviert.
 			</translation>
-		</message>
-		<message>
-			<source>Volume Protection Rule for: %1</source>
-			<translation>Schutzregel für Volume: %1</translation>
-		</message>
-		<message>
-			<source>Volume Unmount Rule for: %1</source>
-			<translation>Volume-Aushängeregel für: %1</translation>
-		</message>
-		<message>
-			<source>Temporary rule</source>
-			<translation>Temporäre Regel</translation>
-		</message>
-		<message>
-			<source>%1 - MajorPrivacy Rule</source>
-			<translation>%1 – MajorPrivacy-Regel</translation>
-		</message>
-		<message>
-			<source>%1 - MajorPrivacy Rule Template</source>
-			<translation>%1 – MajorPrivacy-Regelvorlage</translation>
-		</message>
-		<message>
-			<source>Reset Columns</source>
-			<translation>Spalten zurücksetzen</translation>
-		</message>
-		<message>
-			<source>Copy Cell</source>
-			<translation>Zelle kopieren</translation>
-		</message>
-		<message>
-			<source>Copy Row</source>
-			<translation>Zeile kopieren</translation>
-		</message>
-		<message>
-			<source>Copy Panel</source>
-			<translation>Panel kopieren</translation>
-		</message>
-		<message>
-			<source>Case Sensitive</source>
-			<translation>Groß-/Kleinschreibung beachten</translation>
-		</message>
-		<message>
-			<source>Use Regular Expressions</source>
-			<translation>Reguläre Ausdrücke verwenden</translation>
-		</message>
-		<message>
-			<source>Highlight Items</source>
-			<translation>Einträge hervorheben</translation>
-		</message>
-		<message>
-			<source>Close</source>
-			<translation>Schließen</translation>
-		</message>
-		<message>
-			<source>&amp;Find ...</source>
-			<translation>&amp;Suchen ...</translation>
-		</message>
-		<message>
-			<source>All columns</source>
-			<translation>Alle Spalten</translation>
-		</message>
-		<message>
-			<source>Search ...</source>
-			<translation>Suchen ...</translation>
-		</message>
-		<message>
-			<source>Toggle Search Bar</source>
-			<translation>Suchleiste ein-/ausblenden</translation>
-		</message>
-		<message>
-			<source>&lt;h3&gt;About MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</source>
-			<translation>&lt;h3&gt;Über MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</translation>
-		</message>
-		<message>
-			<source>This version is licensed to %1.</source>
-			<translation>Diese Version ist lizenziert für %1.</translation>
-		</message>
-		<message>
-			<source>This version was licensed to %1, but its no longer valid.</source>
-			<translation>Diese Version war lizenziert für %1, ist jedoch nicht mehr gültig.</translation>
-		</message>
-		<message>
-			<source>&lt;p&gt;MajorPrivacy is a program that helps you to protect your privacy and security.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; for more information.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI Config Dir: &lt;br /&gt;%2&lt;br /&gt;Core Config Dir: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</source>
-			<translation>&lt;p&gt;MajorPrivacy ist ein Programm, das Ihnen hilft, Ihre Privatsphäre und Sicherheit zu schützen.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Besuchen Sie &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; für weitere Informationen.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI-Konfigurationsverzeichnis: &lt;br /&gt;%2&lt;br /&gt;Kern-Konfigurationsverzeichnis: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons von &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</translation>
-		</message>
-		<message>
-			<source>Enter the path of a program that will be created in a sandbox.</source>
-			<translation>Geben Sie den Pfad eines Programms an, das in einer Sandbox erstellt werden soll.</translation>
-		</message>
-	</context>
-	<context>
-		<name>CMountMgrWnd</name>
-		<message>
-			<source>Volume|Device Path</source>
-			<translation>Volume|Gerätepfad</translation>
-		</message>
-		<message>
-			<source>Refresh</source>
-			<translation>Aktualisieren</translation>
-		</message>
-	</context>
-	<context>
-		<name>CNetTraceModel</name>
-		<message>
-			<source>Unknown Program</source>
-			<translation>Unbekanntes Programm</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>PROCESS MISSING</source>
-			<translation>PROZESS FEHLT</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokoll</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Direction</source>
-			<translation>Richtung</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Entfernte Adresse</translation>
-		</message>
-		<message>
-			<source>Remote Port</source>
-			<translation>Entfernter Port</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Lokale Adresse</translation>
-		</message>
-		<message>
-			<source>Local Port</source>
-			<translation>Lokaler Port</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Hochgeladen</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Heruntergeladen</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CNetTraceView</name>
-		<message>
-			<source>All Directions</source>
-			<translation>Alle Richtungen</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Eingehend</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Ausgehend</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>All Protocols</source>
-			<translation>Alle Protokolle</translation>
-		</message>
-		<message>
-			<source>HTTP(S)</source>
-			<translation>HTTP(S)</translation>
-		</message>
-		<message>
-			<source>TCP Sockets</source>
-			<translation>TCP-Sockets</translation>
-		</message>
-		<message>
-			<source>TCP Clients</source>
-			<translation>TCP-Clients</translation>
-		</message>
-		<message>
-			<source>TCP Servers</source>
-			<translation>TCP-Server</translation>
-		</message>
-		<message>
-			<source>UDP Sockets</source>
-			<translation>UDP-Sockets</translation>
-		</message>
-		<message>
-			<source>Area Filter</source>
-			<translation>Bereichsfilter</translation>
-		</message>
-		<message>
-			<source>Internet</source>
-			<translation>Internet</translation>
-		</message>
-		<message>
-			<source>Local Area</source>
-			<translation>Lokaler Bereich</translation>
-		</message>
-		<message>
-			<source>Local Host</source>
-			<translation>Lokaler Host</translation>
-		</message>
-		<message>
-			<source>Auto Scroll</source>
-			<translation>Automatisch scrollen</translation>
-		</message>
-		<message>
-			<source>Hold updates</source>
-			<translation>Aktualisierungen anhalten</translation>
-		</message>
-		<message>
-			<source>Clear Trace Log</source>
-			<translation>Verbindungsprotokoll löschen</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CNetworkPage</name>
-		<message>
-			<source>Firewall Rules</source>
-			<translation>Firewall-Regeln</translation>
-		</message>
-		<message>
-			<source>Open Socket</source>
-			<translation>Offene Verbindungen</translation>
-		</message>
-		<message>
-			<source>Traffic Monitor</source>
-			<translation>Datenverkehrsmonitor</translation>
-		</message>
-		<message>
-			<source>Connection Log</source>
-			<translation>Verbindungsprotokoll</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>COptionsTransferWnd</name>
-		<message>
-			<source>Select the data you want to import</source>
-			<translation>Wählen Sie die Daten aus, die Sie importieren möchten</translation>
-		</message>
-		<message>
-			<source>Select the data you want to export</source>
-			<translation>Wählen Sie die Daten aus, die Sie exportieren möchten</translation>
-		</message>
-	</context>
-	<context>
-		<name>CPopUpWindow</name>
-		<message>
-			<source>MajorPrivacy Notifications</source>
-			<translation>MajorPrivacy-Benachrichtigungen</translation>
-		</message>
-		<message>
-			<source>Permanent</source>
-			<translation>Dauerhaft</translation>
-		</message>
-		<message>
-			<source>Untill Restart</source>
-			<translation>Bis zum Neustart</translation>
-		</message>
-		<message>
-			<source>for 1 Minute</source>
-			<translation>für 1 Minute</translation>
-		</message>
-		<message>
-			<source>for 5 Minutes</source>
-			<translation>für 5 Minuten</translation>
-		</message>
-		<message>
-			<source>for 15 Minutes</source>
-			<translation>für 15 Minuten</translation>
-		</message>
-		<message>
-			<source>for 30 Minutes</source>
-			<translation>für 30 Minuten</translation>
-		</message>
-		<message>
-			<source>for 60 Minutes</source>
-			<translation>für 60 Minuten</translation>
-		</message>
-		<message>
-			<source>Always Ignore this Program</source>
-			<translation>Dieses Programm immer ignorieren</translation>
-		</message>
-		<message>
-			<source>Create Custom Rule</source>
-			<translation>Benutzerdefinierte Regel erstellen</translation>
-		</message>
-		<message>
-			<source>Always Ignore this Path</source>
-			<translation>Diesen Pfad immer ignorieren</translation>
-		</message>
-		<message>
-			<source>Allow Read Only Access</source>
-			<translation>Nur Lesezugriff erlauben</translation>
-		</message>
-		<message>
-			<source>Allow Directory Listing ONLY</source>
-			<translation>Nur Verzeichnisauflistung erlauben</translation>
-		</message>
-		<message>
-			<source>Always Ignore this Binary</source>
-			<translation>Diesen Binärdatei immer ignorieren</translation>
-		</message>
-		<message>
-			<source>Sign Certificate</source>
-			<translation>Zertifikat signieren</translation>
-		</message>
-		<message>
-			<source>%1/%2</source>
-			<translation>%1/%2</translation>
-		</message>
-		<message>
-			<source>%1:%2</source>
-			<translation>%1:%2</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>%1 - Rule</source>
-			<translation>%1 - Regel</translation>
-		</message>
-		<message>
-			<source>Please select a resource to create a rule for.</source>
-			<translation>Bitte wählen Sie eine Ressource aus, für die eine Regel erstellt werden soll.</translation>
-		</message>
-		<message>
-			<source>Please select a binnary file to sign with the your User Key.</source>
-			<translation>Bitte wählen Sie eine Binärdatei aus, die mit Ihrem Benutzerschlüssel signiert werden soll.</translation>
-		</message>
-		<message>
-			<source>Selected Items do not have Certificates!</source>
-			<translation>Die ausgewählten Elemente haben keine Zertifikate!</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProcess</name>
-		<message>
-			<source>Sec: %1</source>
-			<translation>Sek: %1</translation>
-		</message>
-		<message>
-			<source>%1 (</source>
-			<translation>%1 (</translation>
-		</message>
-		<message>
-			<source>%1</source>
-			<translation>%1</translation>
-		</message>
-		<message>
-			<source>%1+%2</source>
-			<translation>%1+%2</translation>
-		</message>
-		<message>
-			<source>/%1/%2/%3)</source>
-			<translation>/%1/%2/%3)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProcessModel</name>
-		<message>
-			<source>Process</source>
-			<translation>Prozess</translation>
-		</message>
-		<message>
-			<source>PID</source>
-			<translation>PID</translation>
-		</message>
-		<message>
-			<source>Parent PID</source>
-			<translation>Eltern-PID</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Vertrauensstufe</translation>
-		</message>
-		<message>
-			<source>User Name</source>
-			<translation>Benutzername</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Image Loads (MS/V/S/U)</source>
-			<translation>Image-Ladevorgänge (MS/V/S/U)</translation>
-		</message>
-		<message>
-			<source>File Name</source>
-			<translation>Dateiname</translation>
-		</message>
-	</context>
-	<context>
-		<message>
-			<source>Process Rules</source>
-			<translation>Prozessregeln</translation>
-		</message>
-		<message>
-			<source>Running Processes</source>
-			<translation>Laufende Prozesse</translation>
-		</message>
-		<message>
-			<source>Loaded Modules</source>
-			<translation>Geladene Module</translation>
-		</message>
-		<message>
-			<source>Execution Monitor</source>
-			<translation>Ausführungsmonitor</translation>
-		</message>
-		<message>
-			<source>Ingress Monitor</source>
-			<translation>Ingress-Monitor</translation>
-		</message>
-		<message>
-			<source>Trace Log</source>
-			<translation>Protokoll</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProcessTraceModel</name>
-		<message>
-			<source>PROGRAM MISSING</source>
-			<translation>PROGRAMM FEHLT</translation>
-		</message>
-		<message>
-			<source> [%1]</source>
-			<translation> [%1]</translation>
-		</message>
-		<message>
-			<source>MODULE MISSING</source>
-			<translation>MODUL FEHLT</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Role</source>
-			<translation>Rolle</translation>
-		</message>
-		<message>
-			<source>Operation</source>
-			<translation>Operation</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Subject</source>
-			<translation>Subjekt</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProcessTraceView</name>
-		<message>
-			<source>Any Role</source>
-			<translation>Beliebige Rolle</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Akteur</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Ziel</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Beliebiger Status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Auto Scroll</source>
-			<translation>Automatisch scrollen</translation>
-		</message>
-		<message>
-			<source>Hold updates</source>
-			<translation>Aktualisierungen anhalten</translation>
-		</message>
-		<message>
-			<source>Clear Trace Log</source>
-			<translation>Protokoll löschen</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProcessView</name>
-		<message>
-			<source>All</source>
-			<translation>Alle</translation>
-		</message>
-		<message>
-			<source>User</source>
-			<translation>Benutzer</translation>
-		</message>
-		<message>
-			<source>System</source>
-			<translation>System</translation>
-		</message>
-		<message>
-			<source>Show Tree</source>
-			<translation>Baumstruktur anzeigen</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramFile</name>
-		<message>
-			<source> (CI: Level 0)</source>
-			<translation> (CI: Stufe 0)</translation>
-		</message>
-		<message>
-			<source> (CI: Enterprise)</source>
-			<translation> (CI: Enterprise)</translation>
-		</message>
-		<message>
-			<source> (CI: Developer)</source>
-			<translation> (CI: Entwickler)</translation>
-		</message>
-		<message>
-			<source> (CI: Authenticode)</source>
-			<translation> (CI: Authenticode)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 2)</source>
-			<translation> (CI: Stufe 2)</translation>
-		</message>
-		<message>
-			<source> (CI: Store)</source>
-			<translation> (CI: Store)</translation>
-		</message>
-		<message>
-			<source> (CI: Antimalware)</source>
-			<translation> (CI: Antimalware)</translation>
-		</message>
-		<message>
-			<source> (CI: Microsoft)</source>
-			<translation> (CI: Microsoft)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 4)</source>
-			<translation> (CI: Stufe 4)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 5)</source>
-			<translation> (CI: Stufe 5)</translation>
-		</message>
-		<message>
-			<source> (CI: Code Gene.)</source>
-			<translation> (CI: Codegenerierung)</translation>
-		</message>
-		<message>
-			<source> (CI: Windows)</source>
-			<translation> (CI: Windows)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 7)</source>
-			<translation> (CI: Stufe 7)</translation>
-		</message>
-		<message>
-			<source> (CI: Windows TCB)</source>
-			<translation> (CI: Windows TCB)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 6)</source>
-			<translation> (CI: Stufe 6)</translation>
-		</message>
-		<message>
-			<source>None</source>
-			<translation>Keine</translation>
-		</message>
-		<message>
-			<source>Microsoft</source>
-			<translation>Microsoft</translation>
-		</message>
-		<message>
-			<source>Test</source>
-			<translation>Test</translation>
-		</message>
-		<message>
-			<source>Code</source>
-			<translation>Code</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-		<message>
-			<source>DMD</source>
-			<translation>DMD</translation>
-		</message>
-		<message>
-			<source>DMD Test</source>
-			<translation>DMD-Test</translation>
-		</message>
-		<message>
-			<source>3rd Party</source>
-			<translation>Drittanbieter</translation>
-		</message>
-		<message>
-			<source>Trusted Boot</source>
-			<translation>Vertrauenswürdiger Start</translation>
-		</message>
-		<message>
-			<source>UEFI</source>
-			<translation>UEFI</translation>
-		</message>
-		<message>
-			<source>Flight</source>
-			<translation>Flight</translation>
-		</message>
-		<message>
-			<source>Other</source>
-			<translation>Andere</translation>
-		</message>
-		<message>
-			<source>Error: %1</source>
-			<translation>Fehler: %1</translation>
-		</message>
-		<message>
-			<source> (Root: %1)</source>
-			<translation> (Stamm: %1)</translation>
-		</message>
-		<message>
-			<source> (Roots: %1)</source>
-			<translation> (Stämme: %1)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramItem</name>
-		<message>
-			<source>Executable File</source>
-			<translation>Ausführbare Datei</translation>
-		</message>
-		<message>
-			<source>File Path Pattern</source>
-			<translation>Dateipfadmuster</translation>
-		</message>
-		<message>
-			<source>Installation</source>
-			<translation>Installation</translation>
-		</message>
-		<message>
-			<source>Windows Service</source>
-			<translation>Windows-Dienst</translation>
-		</message>
-		<message>
-			<source>Application Package</source>
-			<translation>Anwendungspaket</translation>
-		</message>
-		<message>
-			<source>Program Set</source>
-			<translation>Programmsatz</translation>
-		</message>
-		<message>
-			<source>Program List</source>
-			<translation>Programmliste</translation>
-		</message>
-		<message>
-			<source>Program Group</source>
-			<translation>Programmgruppe</translation>
-		</message>
-		<message>
-			<source>All Programs</source>
-			<translation>Alle Programme</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramModel</name>
-		<message>
-			<source>%1/%2</source>
-			<translation>%1/%2</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Processes</source>
-			<translation>Prozesse</translation>
-		</message>
-		<message>
-			<source>Program Rules</source>
-			<translation>Programmregeln</translation>
-		</message>
-		<message>
-			<source>Last Execution</source>
-			<translation>Letzte Ausführung</translation>
-		</message>
-		<message>
-			<source>Accessed Files</source>
-			<translation>Zugegriffene Dateien</translation>
-		</message>
-		<message>
-			<source>Access Rules</source>
-			<translation>Zugriffsregeln</translation>
-		</message>
-		<message>
-			<source>Open Sockets</source>
-			<translation>Offene Sockets</translation>
-		</message>
-		<message>
-			<source>FW Rules</source>
-			<translation>FW-Regeln</translation>
-		</message>
-		<message>
-			<source>Last Net Activity</source>
-			<translation>Letzte Netzwerkaktivität</translation>
-		</message>
-		<message>
-			<source>Upload</source>
-			<translation>Upload</translation>
-		</message>
-		<message>
-			<source>Download</source>
-			<translation>Download</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Hochgeladen</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Heruntergeladen</translation>
-		</message>
-		<message>
-			<source>Log Size</source>
-			<translation>Protokollgröße</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Pfad</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramPicker</name>
-		<message>
-			<source>MajorPrivacy - Select Program</source>
-			<translation>MajorPrivacy – Programm auswählen</translation>
-		</message>
-		<message>
-			<source>Please select a program</source>
-			<translation>Bitte wählen Sie ein Programm aus</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramRule</name>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Schützen</translation>
-		</message>
-		<message>
-			<source>Isolate</source>
-			<translation>Isolieren</translation>
-		</message>
-		<message>
-			<source>Audit</source>
-			<translation>Überwachen</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramRuleModel</name>
-		<message>
-			<source>%1 - %2</source>
-			<translation>%1 – %2</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Ja</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nein</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Aktiviert</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Vertrauensebene</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Regel aktivieren</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Regel deaktivieren</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Regel löschen</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Regel bearbeiten</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Regel duplizieren</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Regel erstellen</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Alle Aktionen</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Schützen</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Deaktivierte Regeln ausblenden</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Regeln aktualisieren</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Möchten Sie die ausgewählten Regel-Einträge löschen?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramRuleWnd</name>
-		<message>
-			<source>Create Program Rule</source>
-			<translation>Programmregel erstellen</translation>
-		</message>
-		<message>
-			<source>Edit Program Rule</source>
-			<translation>Programmregel bearbeiten</translation>
-		</message>
-		<message>
-			<source>New Program Rule</source>
-			<translation>Neue Programmregel</translation>
-		</message>
-		<message>
-			<source>Global (Any/No Enclave)</source>
-			<translation>Global (Beliebige/Keine Enklave)</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Schützen</translation>
-		</message>
-		<message>
-			<source>Audit</source>
-			<translation>Überwachen</translation>
-		</message>
-		<message>
-			<source>Unconfigured</source>
-			<translation>Nicht konfiguriert</translation>
-		</message>
-		<message>
-			<source>User Signature ONLY (not recommended)</source>
-			<translation>Nur Benutzersignatur (nicht empfohlen)</translation>
-		</message>
-		<message>
-			<source>User + Microsoft/AV Signature</source>
-			<translation>Benutzer + Microsoft/AV-Signatur</translation>
-		</message>
-		<message>
-			<source>User + Trusted by Microsoft (Code Root)</source>
-			<translation>Benutzer + Von Microsoft vertraut (Code-Stamm)</translation>
-		</message>
-		<message>
-			<source>Any Signature (Unknown Root)</source>
-			<translation>Beliebige Signatur (unbekannter Stamm)</translation>
-		</message>
-		<message>
-			<source>No Signature</source>
-			<translation>Keine Signatur</translation>
-		</message>
-		<message>
-			<source>Error</source>
-			<translation>Fehler</translation>
-		</message>
-		<message>
-			<source>Please select an enclave for a protection rule.</source>
-			<translation>Bitte wählen Sie eine Enklave für eine Schutzregel aus.</translation>
-		</message>
-		<message>
-			<source>The sellected program type is not supported for this rule type</source>
-			<translation>Der ausgewählte Programmtyp wird für diesen Regeltyp nicht unterstützt</translation>
-		</message>
-		<message>
-			<source>%1 %2</source>
-			<translation>%1 %2</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramView</name>
-		<message>
-			<source>Type Filters</source>
-			<translation>Typ-Filter</translation>
-		</message>
-		<message>
-			<source>Programs</source>
-			<translation>Programme</translation>
-		</message>
-		<message>
-			<source>Apps</source>
-			<translation>Apps</translation>
-		</message>
-		<message>
-			<source>System</source>
-			<translation>System</translation>
-		</message>
-		<message>
-			<source>Groups</source>
-			<translation>Gruppen</translation>
-		</message>
-		<message>
-			<source>Run Filters</source>
-			<translation>Ausführungsfilter</translation>
-		</message>
-		<message>
-			<source>Ran Recently</source>
-			<translation>Kürzlich ausgeführt</translation>
-		</message>
-		<message>
-			<source>Rule Filters</source>
-			<translation>Regel-Filter</translation>
-		</message>
-		<message>
-			<source>Execution Rules</source>
-			<translation>Ausführungsregeln</translation>
-		</message>
-		<message>
-			<source>Access Rules</source>
-			<translation>Zugriffsregeln</translation>
-		</message>
-		<message>
-			<source>Firewall Rules</source>
-			<translation>Firewall-Regeln</translation>
-		</message>
-		<message>
-			<source>Traffic Filters</source>
-			<translation>Verkehrsfilter</translation>
-		</message>
-		<message>
-			<source>Recent Traffic</source>
-			<translation>Letzter Datenverkehr</translation>
-		</message>
-		<message>
-			<source>Blocked Traffic</source>
-			<translation>Blockierter Datenverkehr</translation>
-		</message>
-		<message>
-			<source>Allowed Traffic</source>
-			<translation>Erlaubter Datenverkehr</translation>
-		</message>
-		<message>
-			<source>Socket Filters</source>
-			<translation>Socket-Filter</translation>
-		</message>
-		<message>
-			<source>CleanUp Program List</source>
-			<translation>Programmliste bereinigen</translation>
-		</message>
-		<message>
-			<source>Re-Group all Programs</source>
-			<translation>Alle Programme neu gruppieren</translation>
-		</message>
-		<message>
-			<source>Add Program Item</source>
-			<translation>Programmelement hinzufügen</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-		<message>
-			<source>Edit Program</source>
-			<translation>Programm bearbeiten</translation>
-		</message>
-		<message>
-			<source>Clear Trace</source>
-			<translation>Protokolle löschen</translation>
-		</message>
-		<message>
-			<source>Execution Trace</source>
-			<translation>Ausführungsprotokoll</translation>
-		</message>
-		<message>
-			<source>Resource Trace</source>
-			<translation>Ressourcenprotokoll</translation>
-		</message>
-		<message>
-			<source>Network Trace</source>
-			<translation>Netzwerkprotokoll</translation>
-		</message>
-		<message>
-			<source>Trace Config</source>
-			<translation>Protokollkonfiguration</translation>
-		</message>
-		<message>
-			<source>Use Global Preset</source>
-			<translation>Globale Voreinstellung verwenden</translation>
-		</message>
-		<message>
-			<source>Private Trace</source>
-			<translation>Privates Protokoll</translation>
-		</message>
-		<message>
-			<source>Trace</source>
-			<translation>Protokollieren</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Trace</source>
-			<translation>Nicht protokollieren</translation>
-		</message>
-		<message>
-			<source>Store Trace</source>
-			<translation>Protokoll speichern</translation>
-		</message>
-		<message>
-			<source>Save to Disk</source>
-			<translation>Auf Festplatte speichern</translation>
-		</message>
-		<message>
-			<source>Cache only in RAM</source>
-			<translation>Nur im RAM zwischenspeichern</translation>
-		</message>
-		<message>
-			<source>Add to Group</source>
-			<translation>Zur Gruppe hinzufügen</translation>
-		</message>
-		<message>
-			<source>Remove</source>
-			<translation>Entfernen</translation>
-		</message>
-		<message>
-			<source>Add Program</source>
-			<translation>Programm hinzufügen</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Volume Protection Rule for: %1</source>
+        <translation>Schutzregel für Volume: %1</translation>
+    </message>
+    <message>
+        <source>Volume Unmount Rule for: %1</source>
+        <translation>Volume-Aushängeregel für: %1</translation>
+    </message>
+    <message>
+        <source>Temporary rule</source>
+        <translation>Temporäre Regel</translation>
+    </message>
+    <message>
+        <source>%1 - MajorPrivacy Rule</source>
+        <translation>%1 – MajorPrivacy-Regel</translation>
+    </message>
+    <message>
+        <source>%1 - MajorPrivacy Rule Template</source>
+        <translation>%1 – MajorPrivacy-Regelvorlage</translation>
+    </message>
+    <message>
+        <source>Reset Columns</source>
+        <translation>Spalten zurücksetzen</translation>
+    </message>
+    <message>
+        <source>Copy Cell</source>
+        <translation>Zelle kopieren</translation>
+    </message>
+    <message>
+        <source>Copy Row</source>
+        <translation>Zeile kopieren</translation>
+    </message>
+    <message>
+        <source>Copy Panel</source>
+        <translation>Panel kopieren</translation>
+    </message>
+    <message>
+        <source>Case Sensitive</source>
+        <translation>Groß-/Kleinschreibung beachten</translation>
+    </message>
+    <message>
+        <source>Use Regular Expressions</source>
+        <translation>Reguläre Ausdrücke verwenden</translation>
+    </message>
+    <message>
+        <source>Highlight Items</source>
+        <translation>Einträge hervorheben</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Schließen</translation>
+    </message>
+    <message>
+        <source>&amp;Find ...</source>
+        <translation>&amp;Suchen ...</translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation>Alle Spalten</translation>
+    </message>
+    <message>
+        <source>Search ...</source>
+        <translation>Suchen ...</translation>
+    </message>
+    <message>
+        <source>Toggle Search Bar</source>
+        <translation>Suchleiste ein-/ausblenden</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;About MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</source>
+        <translation>&lt;h3&gt;Über MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</translation>
+    </message>
+    <message>
+        <source>This version is licensed to %1.</source>
+        <translation>Diese Version ist lizenziert für %1.</translation>
+    </message>
+    <message>
+        <source>This version was licensed to %1, but its no longer valid.</source>
+        <translation>Diese Version war lizenziert für %1, ist jedoch nicht mehr gültig.</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;MajorPrivacy is a program that helps you to protect your privacy and security.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; for more information.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI Config Dir: &lt;br /&gt;%2&lt;br /&gt;Core Config Dir: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;MajorPrivacy ist ein Programm, das Ihnen hilft, Ihre Privatsphäre und Sicherheit zu schützen.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Besuchen Sie &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; für weitere Informationen.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI-Konfigurationsverzeichnis: &lt;br /&gt;%2&lt;br /&gt;Kern-Konfigurationsverzeichnis: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons von &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Enter the path of a program that will be created in a sandbox.</source>
+        <translation>Geben Sie den Pfad eines Programms an, das in einer Sandbox erstellt werden soll.</translation>
+    </message>
+</context>
+<context>
+    <name>CMountMgrWnd</name>
+    <message>
+        <source>Volume|Device Path</source>
+        <translation>Volume|Gerätepfad</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Aktualisieren</translation>
+    </message>
+</context>
+<context>
+    <name>CNetTraceModel</name>
+    <message>
+        <source>Unknown Program</source>
+        <translation>Unbekanntes Programm</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>PROCESS MISSING</source>
+        <translation>PROZESS FEHLT</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Richtung</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Entfernte Adresse</translation>
+    </message>
+    <message>
+        <source>Remote Port</source>
+        <translation>Entfernter Port</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Lokale Adresse</translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation>Lokaler Port</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Hochgeladen</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Heruntergeladen</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CNetTraceView</name>
+    <message>
+        <source>All Directions</source>
+        <translation>Alle Richtungen</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Eingehend</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Ausgehend</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>All Protocols</source>
+        <translation>Alle Protokolle</translation>
+    </message>
+    <message>
+        <source>HTTP(S)</source>
+        <translation>HTTP(S)</translation>
+    </message>
+    <message>
+        <source>TCP Sockets</source>
+        <translation>TCP-Sockets</translation>
+    </message>
+    <message>
+        <source>TCP Clients</source>
+        <translation>TCP-Clients</translation>
+    </message>
+    <message>
+        <source>TCP Servers</source>
+        <translation>TCP-Server</translation>
+    </message>
+    <message>
+        <source>UDP Sockets</source>
+        <translation>UDP-Sockets</translation>
+    </message>
+    <message>
+        <source>Area Filter</source>
+        <translation>Bereichsfilter</translation>
+    </message>
+    <message>
+        <source>Internet</source>
+        <translation>Internet</translation>
+    </message>
+    <message>
+        <source>Local Area</source>
+        <translation>Lokaler Bereich</translation>
+    </message>
+    <message>
+        <source>Local Host</source>
+        <translation>Lokaler Host</translation>
+    </message>
+    <message>
+        <source>Auto Scroll</source>
+        <translation>Automatisch scrollen</translation>
+    </message>
+    <message>
+        <source>Hold updates</source>
+        <translation>Aktualisierungen anhalten</translation>
+    </message>
+    <message>
+        <source>Clear Trace Log</source>
+        <translation>Verbindungsprotokoll löschen</translation>
+    </message>
+</context>
+<context>
+    <name>CNetworkPage</name>
+    <message>
+        <source>Firewall Rules</source>
+        <translation>Firewall-Regeln</translation>
+    </message>
+    <message>
+        <source>Open Socket</source>
+        <translation>Offene Verbindungen</translation>
+    </message>
+    <message>
+        <source>Traffic Monitor</source>
+        <translation>Datenverkehrsmonitor</translation>
+    </message>
+    <message>
+        <source>Connection Log</source>
+        <translation>Verbindungsprotokoll</translation>
+    </message>
+</context>
+<context>
+    <name>COptionsTransferWnd</name>
+    <message>
+        <source>Select the data you want to import</source>
+        <translation>Wählen Sie die Daten aus, die Sie importieren möchten</translation>
+    </message>
+    <message>
+        <source>Select the data you want to export</source>
+        <translation>Wählen Sie die Daten aus, die Sie exportieren möchten</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpWindow</name>
+    <message>
+        <source>MajorPrivacy Notifications</source>
+        <translation>MajorPrivacy-Benachrichtigungen</translation>
+    </message>
+    <message>
+        <source>Permanent</source>
+        <translation>Dauerhaft</translation>
+    </message>
+    <message>
+        <source>Untill Restart</source>
+        <translation>Bis zum Neustart</translation>
+    </message>
+    <message>
+        <source>for 1 Minute</source>
+        <translation>für 1 Minute</translation>
+    </message>
+    <message>
+        <source>for 5 Minutes</source>
+        <translation>für 5 Minuten</translation>
+    </message>
+    <message>
+        <source>for 15 Minutes</source>
+        <translation>für 15 Minuten</translation>
+    </message>
+    <message>
+        <source>for 30 Minutes</source>
+        <translation>für 30 Minuten</translation>
+    </message>
+    <message>
+        <source>for 60 Minutes</source>
+        <translation>für 60 Minuten</translation>
+    </message>
+    <message>
+        <source>Always Ignore this Program</source>
+        <translation>Dieses Programm immer ignorieren</translation>
+    </message>
+    <message>
+        <source>Create Custom Rule</source>
+        <translation>Benutzerdefinierte Regel erstellen</translation>
+    </message>
+    <message>
+        <source>Always Ignore this Path</source>
+        <translation>Diesen Pfad immer ignorieren</translation>
+    </message>
+    <message>
+        <source>Allow Read Only Access</source>
+        <translation>Nur Lesezugriff erlauben</translation>
+    </message>
+    <message>
+        <source>Allow Directory Listing ONLY</source>
+        <translation>Nur Verzeichnisauflistung erlauben</translation>
+    </message>
+    <message>
+        <source>Always Ignore this Binary</source>
+        <translation>Diesen Binärdatei immer ignorieren</translation>
+    </message>
+    <message>
+        <source>Sign Certificate</source>
+        <translation>Zertifikat signieren</translation>
+    </message>
+    <message>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <source>%1:%2</source>
+        <translation>%1:%2</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>%1 - Rule</source>
+        <translation>%1 - Regel</translation>
+    </message>
+    <message>
+        <source>Please select a resource to create a rule for.</source>
+        <translation>Bitte wählen Sie eine Ressource aus, für die eine Regel erstellt werden soll.</translation>
+    </message>
+    <message>
+        <source>Please select a binnary file to sign with the your User Key.</source>
+        <translation>Bitte wählen Sie eine Binärdatei aus, die mit Ihrem Benutzerschlüssel signiert werden soll.</translation>
+    </message>
+    <message>
+        <source>Selected Items do not have Certificates!</source>
+        <translation>Die ausgewählten Elemente haben keine Zertifikate!</translation>
+    </message>
+</context>
+<context>
+    <name>CProcess</name>
+    <message>
+        <source>Sec: %1</source>
+        <translation>Sek: %1</translation>
+    </message>
+    <message>
+        <source>%1 (</source>
+        <translation>%1 (</translation>
+    </message>
+    <message>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <source>%1+%2</source>
+        <translation>%1+%2</translation>
+    </message>
+    <message>
+        <source>/%1/%2/%3)</source>
+        <translation>/%1/%2/%3)</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessModel</name>
+    <message>
+        <source>Process</source>
+        <translation>Prozess</translation>
+    </message>
+    <message>
+        <source>PID</source>
+        <translation>PID</translation>
+    </message>
+    <message>
+        <source>Parent PID</source>
+        <translation>Eltern-PID</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Vertrauensstufe</translation>
+    </message>
+    <message>
+        <source>User Name</source>
+        <translation>Benutzername</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Image Loads (MS/V/S/U)</source>
+        <translation>Image-Ladevorgänge (MS/V/S/U)</translation>
+    </message>
+    <message>
+        <source>File Name</source>
+        <translation>Dateiname</translation>
+    </message>
+</context>
+<context>
+    <name></name>
+    <message>
+        <source>Process Rules</source>
+        <translation>Prozessregeln</translation>
+    </message>
+    <message>
+        <source>Running Processes</source>
+        <translation>Laufende Prozesse</translation>
+    </message>
+    <message>
+        <source>Loaded Modules</source>
+        <translation>Geladene Module</translation>
+    </message>
+    <message>
+        <source>Execution Monitor</source>
+        <translation>Ausführungsmonitor</translation>
+    </message>
+    <message>
+        <source>Ingress Monitor</source>
+        <translation>Ingress-Monitor</translation>
+    </message>
+    <message>
+        <source>Trace Log</source>
+        <translation>Protokoll</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessTraceModel</name>
+    <message>
+        <source>PROGRAM MISSING</source>
+        <translation>PROGRAMM FEHLT</translation>
+    </message>
+    <message>
+        <source> [%1]</source>
+        <translation> [%1]</translation>
+    </message>
+    <message>
+        <source>MODULE MISSING</source>
+        <translation>MODUL FEHLT</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rolle</translation>
+    </message>
+    <message>
+        <source>Operation</source>
+        <translation>Operation</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Subject</source>
+        <translation>Subjekt</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessTraceView</name>
+    <message>
+        <source>Any Role</source>
+        <translation>Beliebige Rolle</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Akteur</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Ziel</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Beliebiger Status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Auto Scroll</source>
+        <translation>Automatisch scrollen</translation>
+    </message>
+    <message>
+        <source>Hold updates</source>
+        <translation>Aktualisierungen anhalten</translation>
+    </message>
+    <message>
+        <source>Clear Trace Log</source>
+        <translation>Protokoll löschen</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessView</name>
+    <message>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation>Benutzer</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Show Tree</source>
+        <translation>Baumstruktur anzeigen</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramFile</name>
+    <message>
+        <source> (CI: Level 0)</source>
+        <translation> (CI: Stufe 0)</translation>
+    </message>
+    <message>
+        <source> (CI: Enterprise)</source>
+        <translation> (CI: Enterprise)</translation>
+    </message>
+    <message>
+        <source> (CI: Developer)</source>
+        <translation> (CI: Entwickler)</translation>
+    </message>
+    <message>
+        <source> (CI: Authenticode)</source>
+        <translation> (CI: Authenticode)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 2)</source>
+        <translation> (CI: Stufe 2)</translation>
+    </message>
+    <message>
+        <source> (CI: Store)</source>
+        <translation> (CI: Store)</translation>
+    </message>
+    <message>
+        <source> (CI: Antimalware)</source>
+        <translation> (CI: Antimalware)</translation>
+    </message>
+    <message>
+        <source> (CI: Microsoft)</source>
+        <translation> (CI: Microsoft)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 4)</source>
+        <translation> (CI: Stufe 4)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 5)</source>
+        <translation> (CI: Stufe 5)</translation>
+    </message>
+    <message>
+        <source> (CI: Code Gen.)</source>
+        <translation> (CI: Codegenerierung)</translation>
+    </message>
+    <message>
+        <source> (CI: Windows)</source>
+        <translation> (CI: Windows)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 7)</source>
+        <translation> (CI: Stufe 7)</translation>
+    </message>
+    <message>
+        <source> (CI: Windows TCB)</source>
+        <translation> (CI: Windows TCB)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 6)</source>
+        <translation> (CI: Stufe 6)</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Keine</translation>
+    </message>
+    <message>
+        <source>Microsoft</source>
+        <translation>Microsoft</translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message>
+        <source>Code</source>
+        <translation>Code</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>DMD</source>
+        <translation>DMD</translation>
+    </message>
+    <message>
+        <source>DMD Test</source>
+        <translation>DMD-Test</translation>
+    </message>
+    <message>
+        <source>3rd Party</source>
+        <translation>Drittanbieter</translation>
+    </message>
+    <message>
+        <source>Trusted Boot</source>
+        <translation>Vertrauenswürdiger Start</translation>
+    </message>
+    <message>
+        <source>UEFI</source>
+        <translation>UEFI</translation>
+    </message>
+    <message>
+        <source>Flight</source>
+        <translation>Flight</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>Andere</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation>Fehler: %1</translation>
+    </message>
+    <message>
+        <source> (Root: %1)</source>
+        <translation> (Stamm: %1)</translation>
+    </message>
+    <message>
+        <source> (Roots: %1)</source>
+        <translation> (Stämme: %1)</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramItem</name>
+    <message>
+        <source>Executable File</source>
+        <translation>Ausführbare Datei</translation>
+    </message>
+    <message>
+        <source>File Path Pattern</source>
+        <translation>Dateipfadmuster</translation>
+    </message>
+    <message>
+        <source>Installation</source>
+        <translation>Installation</translation>
+    </message>
+    <message>
+        <source>Windows Service</source>
+        <translation>Windows-Dienst</translation>
+    </message>
+    <message>
+        <source>Application Package</source>
+        <translation>Anwendungspaket</translation>
+    </message>
+    <message>
+        <source>Program Set</source>
+        <translation>Programmsatz</translation>
+    </message>
+    <message>
+        <source>Program List</source>
+        <translation>Programmliste</translation>
+    </message>
+    <message>
+        <source>Program Group</source>
+        <translation>Programmgruppe</translation>
+    </message>
+    <message>
+        <source>All Programs</source>
+        <translation>Alle Programme</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramModel</name>
+    <message>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Processes</source>
+        <translation>Prozesse</translation>
+    </message>
+    <message>
+        <source>Program Rules</source>
+        <translation>Programmregeln</translation>
+    </message>
+    <message>
+        <source>Last Execution</source>
+        <translation>Letzte Ausführung</translation>
+    </message>
+    <message>
+        <source>Accessed Files</source>
+        <translation>Zugegriffene Dateien</translation>
+    </message>
+    <message>
+        <source>Access Rules</source>
+        <translation>Zugriffsregeln</translation>
+    </message>
+    <message>
+        <source>Open Sockets</source>
+        <translation>Offene Sockets</translation>
+    </message>
+    <message>
+        <source>FW Rules</source>
+        <translation>FW-Regeln</translation>
+    </message>
+    <message>
+        <source>Last Net Activity</source>
+        <translation>Letzte Netzwerkaktivität</translation>
+    </message>
+    <message>
+        <source>Upload</source>
+        <translation>Upload</translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation>Download</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Hochgeladen</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Heruntergeladen</translation>
+    </message>
+    <message>
+        <source>Log Size</source>
+        <translation>Protokollgröße</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Pfad</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramPicker</name>
+    <message>
+        <source>MajorPrivacy - Select Program</source>
+        <translation>MajorPrivacy – Programm auswählen</translation>
+    </message>
+    <message>
+        <source>Please select a program</source>
+        <translation>Bitte wählen Sie ein Programm aus</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRule</name>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Schützen</translation>
+    </message>
+    <message>
+        <source>Isolate</source>
+        <translation>Isolieren</translation>
+    </message>
+    <message>
+        <source>Audit</source>
+        <translation>Überwachen</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRuleModel</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation>%1 – %2</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nein</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Aktiviert</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Vertrauensebene</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Regel aktivieren</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Regel deaktivieren</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Regel löschen</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Regel bearbeiten</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Regel duplizieren</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Regel erstellen</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Alle Aktionen</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Schützen</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Deaktivierte Regeln ausblenden</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Regeln aktualisieren</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Möchten Sie die ausgewählten Regel-Einträge löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRuleWnd</name>
+    <message>
+        <source>Create Program Rule</source>
+        <translation>Programmregel erstellen</translation>
+    </message>
+    <message>
+        <source>Edit Program Rule</source>
+        <translation>Programmregel bearbeiten</translation>
+    </message>
+    <message>
+        <source>New Program Rule</source>
+        <translation>Neue Programmregel</translation>
+    </message>
+    <message>
+        <source>Global (Any/No Enclave)</source>
+        <translation>Global (Beliebige/Keine Enklave)</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Schützen</translation>
+    </message>
+    <message>
+        <source>Audit</source>
+        <translation>Überwachen</translation>
+    </message>
+    <message>
+        <source>Unconfigured</source>
+        <translation>Nicht konfiguriert</translation>
+    </message>
+    <message>
+        <source>User Signature ONLY (not recommended)</source>
+        <translation>Nur Benutzersignatur (nicht empfohlen)</translation>
+    </message>
+    <message>
+        <source>User + Microsoft/AV Signature</source>
+        <translation>Benutzer + Microsoft/AV-Signatur</translation>
+    </message>
+    <message>
+        <source>User + Trusted by Microsoft (Code Root)</source>
+        <translation>Benutzer + Von Microsoft vertraut (Code-Stamm)</translation>
+    </message>
+    <message>
+        <source>Any Signature (Unknown Root)</source>
+        <translation>Beliebige Signatur (unbekannter Stamm)</translation>
+    </message>
+    <message>
+        <source>No Signature</source>
+        <translation>Keine Signatur</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <source>Please select an enclave for a protection rule.</source>
+        <translation>Bitte wählen Sie eine Enklave für eine Schutzregel aus.</translation>
+    </message>
+    <message>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Der ausgewählte Programmtyp wird für diesen Regeltyp nicht unterstützt</translation>
+    </message>
+    <message>
+        <source>%1 %2</source>
+        <translation>%1 %2</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramView</name>
+    <message>
+        <source>Type Filters</source>
+        <translation>Typ-Filter</translation>
+    </message>
+    <message>
+        <source>Programs</source>
+        <translation>Programme</translation>
+    </message>
+    <message>
+        <source>Apps</source>
+        <translation>Apps</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <translation>Gruppen</translation>
+    </message>
+    <message>
+        <source>Run Filters</source>
+        <translation>Ausführungsfilter</translation>
+    </message>
+    <message>
+        <source>Ran Recently</source>
+        <translation>Kürzlich ausgeführt</translation>
+    </message>
+    <message>
+        <source>Rule Filters</source>
+        <translation>Regel-Filter</translation>
+    </message>
+    <message>
+        <source>Execution Rules</source>
+        <translation>Ausführungsregeln</translation>
+    </message>
+    <message>
+        <source>Access Rules</source>
+        <translation>Zugriffsregeln</translation>
+    </message>
+    <message>
+        <source>Firewall Rules</source>
+        <translation>Firewall-Regeln</translation>
+    </message>
+    <message>
+        <source>Traffic Filters</source>
+        <translation>Verkehrsfilter</translation>
+    </message>
+    <message>
+        <source>Recent Traffic</source>
+        <translation>Letzter Datenverkehr</translation>
+    </message>
+    <message>
+        <source>Blocked Traffic</source>
+        <translation>Blockierter Datenverkehr</translation>
+    </message>
+    <message>
+        <source>Allowed Traffic</source>
+        <translation>Erlaubter Datenverkehr</translation>
+    </message>
+    <message>
+        <source>Socket Filters</source>
+        <translation>Socket-Filter</translation>
+    </message>
+    <message>
+        <source>CleanUp Program List</source>
+        <translation>Programmliste bereinigen</translation>
+    </message>
+    <message>
+        <source>Re-Group all Programs</source>
+        <translation>Alle Programme neu gruppieren</translation>
+    </message>
+    <message>
+        <source>Add Program Item</source>
+        <translation>Programmelement hinzufügen</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+    <message>
+        <source>Edit Program</source>
+        <translation>Programm bearbeiten</translation>
+    </message>
+    <message>
+        <source>Clear Trace</source>
+        <translation>Protokolle löschen</translation>
+    </message>
+    <message>
+        <source>Execution Trace</source>
+        <translation>Ausführungsprotokoll</translation>
+    </message>
+    <message>
+        <source>Resource Trace</source>
+        <translation>Ressourcenprotokoll</translation>
+    </message>
+    <message>
+        <source>Network Trace</source>
+        <translation>Netzwerkprotokoll</translation>
+    </message>
+    <message>
+        <source>Trace Config</source>
+        <translation>Protokollkonfiguration</translation>
+    </message>
+    <message>
+        <source>Use Global Preset</source>
+        <translation>Globale Voreinstellung verwenden</translation>
+    </message>
+    <message>
+        <source>Private Trace</source>
+        <translation>Privates Protokoll</translation>
+    </message>
+    <message>
+        <source>Trace</source>
+        <translation>Protokollieren</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Trace</source>
+        <translation>Nicht protokollieren</translation>
+    </message>
+    <message>
+        <source>Store Trace</source>
+        <translation>Protokoll speichern</translation>
+    </message>
+    <message>
+        <source>Save to Disk</source>
+        <translation>Auf Festplatte speichern</translation>
+    </message>
+    <message>
+        <source>Cache only in RAM</source>
+        <translation>Nur im RAM zwischenspeichern</translation>
+    </message>
+    <message>
+        <source>Add to Group</source>
+        <translation>Zur Gruppe hinzufügen</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Entfernen</translation>
+    </message>
+    <message>
+        <source>Add Program</source>
+        <translation>Programm hinzufügen</translation>
+    </message>
+    <message>
+        <source>
 				Do you want to delete selected Program Items (Yes)?
 				The selected Item has children, do you want to delete them as well (Yes to All)?
 			</source>
-			<translation>
+        <translation>
 				Möchten Sie die ausgewählten Programmelemente löschen (Ja)?
 				Das ausgewählte Element hat untergeordnete Elemente. Möchten Sie diese ebenfalls löschen (Ja zu allem)?
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				Do you want to delete selected Program Items?
-				The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.
+				The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.
 			</source>
-			<translation>
+        <translation>
 				Möchten Sie die ausgewählten Programmelemente löschen?
 				Das ausgewählte Element gehört zu mehreren Gruppen. Um es aus allen Gruppen zu löschen, klicken Sie auf „Ja zu allem“. Mit „Ja“ wird es nur aus der aktuellen Gruppe entfernt.
 			</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Program Items?</source>
-			<translation>Möchten Sie die ausgewählten Programmelemente löschen?</translation>
-		</message>
-		<message>
-			<source>The selected Program Item has rules, do you want to delete them as well?</source>
-			<translation>Das ausgewählte Programmelement enthält Regeln. Möchten Sie diese ebenfalls löschen?</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the Execution/Ingress trace logs for the current program items?</source>
-			<translation>Möchten Sie die Ausführungs-/Eingangsprotokolle der aktuellen Programmelemente wirklich löschen?</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the Resource Access trace logs for the current program items?</source>
-			<translation>Möchten Sie die Ressourcen-Zugriffsprotokolle der aktuellen Programmelemente wirklich löschen?</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the Network Access trace logs for the current program items?</source>
-			<translation>Möchten Sie die Netzwerk-Zugriffsprotokolle der aktuellen Programmelemente wirklich löschen?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramWnd</name>
-		<message>
-			<source>Change Icon</source>
-			<translation>Symbol ändern</translation>
-		</message>
-		<message>
-			<source>Browse for Image</source>
-			<translation>Bild auswählen</translation>
-		</message>
-		<message>
-			<source>Browse for File</source>
-			<translation>Datei auswählen</translation>
-		</message>
-		<message>
-			<source>Browse for Folder</source>
-			<translation>Ordner auswählen</translation>
-		</message>
-		<message>
-			<source>Create Program Item</source>
-			<translation>Programmeintrag erstellen</translation>
-		</message>
-		<message>
-			<source>Edit Program Item</source>
-			<translation>Programmeintrag bearbeiten</translation>
-		</message>
-		<message>
-			<source>Use Global Preset</source>
-			<translation>Globale Voreinstellung verwenden</translation>
-		</message>
-		<message>
-			<source>Private Trace</source>
-			<translation>Privates Protokoll</translation>
-		</message>
-		<message>
-			<source>Trace</source>
-			<translation>Protokollieren</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Trace</source>
-			<translation>Nicht protokollieren</translation>
-		</message>
-		<message>
-			<source>Save to Disk</source>
-			<translation>Auf Festplatte speichern</translation>
-		</message>
-		<message>
-			<source>Cache only in RAM</source>
-			<translation>Nur im RAM zwischenspeichern</translation>
-		</message>
-		<message>
-			<source>New Program Item</source>
-			<translation>Neuer Programmeintrag</translation>
-		</message>
-		<message>
-			<source>Select Image File</source>
-			<translation>Bilddatei auswählen</translation>
-		</message>
-		<message>
-			<source>Image Files (*.png)</source>
-			<translation>Bilddateien (*.png)</translation>
-		</message>
-		<message>
-			<source>Select Program File</source>
-			<translation>Programmdatei auswählen</translation>
-		</message>
-		<message>
-			<source>Executable Files (*.exe)</source>
-			<translation>Ausführbare Dateien (*.exe)</translation>
-		</message>
-		<message>
-			<source>Select Directory</source>
-			<translation>Verzeichnis auswählen</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSettingsWindow</name>
-		<message>
-			<source>Major Privacy - Settings</source>
-			<translation>MajorPrivacy - Einstellungen</translation>
-		</message>
-		<message>
-			<source>Auto Detection</source>
-			<translation>Automatische Erkennung</translation>
-		</message>
-		<message>
-			<source>No Translation</source>
-			<translation>Keine Übersetzung</translation>
-		</message>
-		<message>
-			<source>All</source>
-			<translation>Alle</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Erlaubt</translation>
-		</message>
-		<message>
-			<source>Off</source>
-			<translation>Aus</translation>
-		</message>
-		<message>
-			<source>Search for settings</source>
-			<translation>Nach Einstellungen suchen</translation>
-		</message>
-		<message>
-			<source>Enter Block Lisz URL to be added</source>
-			<translation>URL der Blockliste eingeben</translation>
-		</message>
-		<message>
-			<source>Binary Image</source>
-			<translation>Binärbild</translation>
-		</message>
-		<message>
-			<source>Resource Access</source>
-			<translation>Ressourcenzugriff</translation>
-		</message>
-		<message>
-			<source>Network Access</source>
-			<translation>Netzwerkzugriff</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSidResolver</name>
-		<message>
-			<source>Resolving...</source>
-			<translation>Auflösung läuft ...</translation>
-		</message>
-		<message>
-			<source>Not resolved...</source>
-			<translation>Nicht aufgelöst ...</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSignatureDbWnd</name>
-		<message>
-			<source>Delete Signature</source>
-			<translation>Signatur löschen</translation>
-		</message>
-		<message>
-			<source>Name|Path</source>
-			<translation>Name|Pfad</translation>
-		</message>
-		<message>
-			<source>Refresh</source>
-			<translation>Aktualisieren</translation>
-		</message>
-		<message>
-			<source>MajorPrivacy</source>
-			<translation>MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to delete the signature?</source>
-			<translation>Möchten Sie die Signatur wirklich löschen?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSocket</name>
-		<message>
-			<source>Closed</source>
-			<translation>Geschlossen</translation>
-		</message>
-		<message>
-			<source>Open</source>
-			<translation>Offen</translation>
-		</message>
-		<message>
-			<source>Listen</source>
-			<translation>Lauschen</translation>
-		</message>
-		<message>
-			<source>SYN sent</source>
-			<translation>SYN gesendet</translation>
-		</message>
-		<message>
-			<source>SYN received</source>
-			<translation>SYN empfangen</translation>
-		</message>
-		<message>
-			<source>Established</source>
-			<translation>Verbindung hergestellt</translation>
-		</message>
-		<message>
-			<source>FIN wait 1</source>
-			<translation>FIN-Wartezeit 1</translation>
-		</message>
-		<message>
-			<source>FIN wait 2</source>
-			<translation>FIN-Wartezeit 2</translation>
-		</message>
-		<message>
-			<source>Close wait</source>
-			<translation>Warten auf Schließen</translation>
-		</message>
-		<message>
-			<source>Closing</source>
-			<translation>Schließen</translation>
-		</message>
-		<message>
-			<source>Last ACK</source>
-			<translation>Letztes ACK</translation>
-		</message>
-		<message>
-			<source>Time wait</source>
-			<translation>Wartezeit</translation>
-		</message>
-		<message>
-			<source>Delete TCB</source>
-			<translation>TCB löschen</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source>Unknown %1</source>
-			<translation>Unbekannt %1</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSocketModel</name>
-		<message>
-			<source>Unknown Process</source>
-			<translation>Unbekannter Prozess</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>PROCESS MISSING</source>
-			<translation>PROZESS FEHLT</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokoll</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Entfernte Adresse</translation>
-		</message>
-		<message>
-			<source>Remote Port</source>
-			<translation>Entfernter Port</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Lokale Adresse</translation>
-		</message>
-		<message>
-			<source>Local Port</source>
-			<translation>Lokaler Port</translation>
-		</message>
-		<message>
-			<source>Access</source>
-			<translation>Zugriff</translation>
-		</message>
-		<message>
-			<source>State</source>
-			<translation>Zustand</translation>
-		</message>
-		<message>
-			<source>Last Activity</source>
-			<translation>Letzte Aktivität</translation>
-		</message>
-		<message>
-			<source>Upload</source>
-			<translation>Upload</translation>
-		</message>
-		<message>
-			<source>Download</source>
-			<translation>Download</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Hochgeladen</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Heruntergeladen</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSocketView</name>
-		<message>
-			<source>All Protocols</source>
-			<translation>Alle Protokolle</translation>
-		</message>
-		<message>
-			<source>HTTP(S)</source>
-			<translation>HTTP(S)</translation>
-		</message>
-		<message>
-			<source>TCP Sockets</source>
-			<translation>TCP-Sockets</translation>
-		</message>
-		<message>
-			<source>TCP Clients</source>
-			<translation>TCP-Clients</translation>
-		</message>
-		<message>
-			<source>TCP Servers</source>
-			<translation>TCP-Server</translation>
-		</message>
-		<message>
-			<source>UDP Sockets</source>
-			<translation>UDP-Sockets</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTraceView</name>
-		<message>
-			<source>Loading %1</source>
-			<translation>Lade %1</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the trace logs for the current program items?</source>
-			<translation>Möchten Sie die Protokolle für die aktuellen Programmeinträge wirklich löschen?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTrafficModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Last Activity</source>
-			<translation>Letzte Aktivität</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Hochgeladen</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Heruntergeladen</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTrafficView</name>
-		<message>
-			<source>By Host</source>
-			<translation>Nach Host</translation>
-		</message>
-		<message>
-			<source>By Program</source>
-			<translation>Nach Programm</translation>
-		</message>
-		<message>
-			<source>Area Filter</source>
-			<translation>Bereichsfilter</translation>
-		</message>
-		<message>
-			<source>Internet</source>
-			<translation>Internet</translation>
-		</message>
-		<message>
-			<source>Local Area</source>
-			<translation>Lokales Netzwerk</translation>
-		</message>
-		<message>
-			<source>Local Host</source>
-			<translation>Lokaler Host</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakInfo</name>
-		<message>
-			<source>Apply Tweak</source>
-			<translation>Anpassung anwenden</translation>
-		</message>
-		<message>
-			<source>Undo Tweak</source>
-			<translation>Anpassung rückgängig machen</translation>
-		</message>
-		<message>
-			<source>Tweak Info</source>
-			<translation>Tweak-Information</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Summary</source>
-			<translation>Zusammenfassung</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakList</name>
-		<message>
-			<source>%1 (%2/%3)</source>
-			<translation>%1 (%2/%3)</translation>
-		</message>
-		<message>
-			<source>%1 (%2)</source>
-			<translation>%1 (%2)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Hint</source>
-			<translation>Hinweis</translation>
-		</message>
-		<message>
-			<source>Info</source>
-			<translation>Information</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakView</name>
-		<message>
-			<source>Refresh tweak states</source>
-			<translation>Tweak-Status aktualisieren</translation>
-		</message>
-		<message>
-			<source>Show not available tweaks</source>
-			<translation>Nicht verfügbare Tweaks anzeigen</translation>
-		</message>
-		<message>
-			<source>Approve Current State</source>
-			<translation>Aktuellen Zustand übernehmen</translation>
-		</message>
-		<message>
-			<source>Restore Approved State</source>
-			<translation>Übernommenen Zustand wiederherstellen</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatisch erweitern</translation>
-		</message>
-		<message>
-			<source>This tweak is marked as breaking, hence it may break something. Are you sure you want to apply it?</source>
-			<translation>Diese Anpassung ist als kritisch markiert und könnte etwas beschädigen. Möchten Sie sie wirklich anwenden?</translation>
-		</message>
-		<message>
-			<source>Don&apos;t show this message again.</source>
-			<translation>Diesen Hinweis nicht mehr anzeigen.</translation>
-		</message>
-		<message>
-			<source>MajorPrivacy</source>
-			<translation>MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to approve the current state of all tweaks?</source>
-			<translation>Möchten Sie den aktuellen Zustand aller Tweaks wirklich übernehmen?</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Do you want to delete selected Program Items?</source>
+        <translation>Möchten Sie die ausgewählten Programmelemente löschen?</translation>
+    </message>
+    <message>
+        <source>The selected Program Item has rules, do you want to delete them as well?</source>
+        <translation>Das ausgewählte Programmelement enthält Regeln. Möchten Sie diese ebenfalls löschen?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the Execution/Ingress trace logs for the current program items?</source>
+        <translation>Möchten Sie die Ausführungs-/Eingangsprotokolle der aktuellen Programmelemente wirklich löschen?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the Resource Access trace logs for the current program items?</source>
+        <translation>Möchten Sie die Ressourcen-Zugriffsprotokolle der aktuellen Programmelemente wirklich löschen?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the Network Access trace logs for the current program items?</source>
+        <translation>Möchten Sie die Netzwerk-Zugriffsprotokolle der aktuellen Programmelemente wirklich löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramWnd</name>
+    <message>
+        <source>Change Icon</source>
+        <translation>Symbol ändern</translation>
+    </message>
+    <message>
+        <source>Browse for Image</source>
+        <translation>Bild auswählen</translation>
+    </message>
+    <message>
+        <source>Browse for File</source>
+        <translation>Datei auswählen</translation>
+    </message>
+    <message>
+        <source>Browse for Folder</source>
+        <translation>Ordner auswählen</translation>
+    </message>
+    <message>
+        <source>Create Program Item</source>
+        <translation>Programmeintrag erstellen</translation>
+    </message>
+    <message>
+        <source>Edit Program Item</source>
+        <translation>Programmeintrag bearbeiten</translation>
+    </message>
+    <message>
+        <source>Use Global Preset</source>
+        <translation>Globale Voreinstellung verwenden</translation>
+    </message>
+    <message>
+        <source>Private Trace</source>
+        <translation>Privates Protokoll</translation>
+    </message>
+    <message>
+        <source>Trace</source>
+        <translation>Protokollieren</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Trace</source>
+        <translation>Nicht protokollieren</translation>
+    </message>
+    <message>
+        <source>Save to Disk</source>
+        <translation>Auf Festplatte speichern</translation>
+    </message>
+    <message>
+        <source>Cache only in RAM</source>
+        <translation>Nur im RAM zwischenspeichern</translation>
+    </message>
+    <message>
+        <source>New Program Item</source>
+        <translation>Neuer Programmeintrag</translation>
+    </message>
+    <message>
+        <source>Select Image File</source>
+        <translation>Bilddatei auswählen</translation>
+    </message>
+    <message>
+        <source>Image Files (*.png)</source>
+        <translation>Bilddateien (*.png)</translation>
+    </message>
+    <message>
+        <source>Select Program File</source>
+        <translation>Programmdatei auswählen</translation>
+    </message>
+    <message>
+        <source>Executable Files (*.exe)</source>
+        <translation>Ausführbare Dateien (*.exe)</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>Verzeichnis auswählen</translation>
+    </message>
+</context>
+<context>
+    <name>CSettingsWindow</name>
+    <message>
+        <source>Major Privacy - Settings</source>
+        <translation>MajorPrivacy - Einstellungen</translation>
+    </message>
+    <message>
+        <source>Auto Detection</source>
+        <translation>Automatische Erkennung</translation>
+    </message>
+    <message>
+        <source>No Translation</source>
+        <translation>Keine Übersetzung</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Erlaubt</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Aus</translation>
+    </message>
+    <message>
+        <source>Search for settings</source>
+        <translation>Nach Einstellungen suchen</translation>
+    </message>
+    <message>
+        <source>Enter Block Lisz URL to be added</source>
+        <translation>URL der Blockliste eingeben</translation>
+    </message>
+    <message>
+        <source>Binary Image</source>
+        <translation>Binärbild</translation>
+    </message>
+    <message>
+        <source>Resource Access</source>
+        <translation>Ressourcenzugriff</translation>
+    </message>
+    <message>
+        <source>Network Access</source>
+        <translation>Netzwerkzugriff</translation>
+    </message>
+</context>
+<context>
+    <name>CSidResolver</name>
+    <message>
+        <source>Resolving...</source>
+        <translation>Auflösung läuft ...</translation>
+    </message>
+    <message>
+        <source>Not resolved...</source>
+        <translation>Nicht aufgelöst ...</translation>
+    </message>
+</context>
+<context>
+    <name>CSignatureDbWnd</name>
+    <message>
+        <source>Delete Signature</source>
+        <translation>Signatur löschen</translation>
+    </message>
+    <message>
+        <source>Name|Path</source>
+        <translation>Name|Pfad</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <source>MajorPrivacy</source>
+        <translation>MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete the signature?</source>
+        <translation>Möchten Sie die Signatur wirklich löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CSocket</name>
+    <message>
+        <source>Closed</source>
+        <translation>Geschlossen</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Offen</translation>
+    </message>
+    <message>
+        <source>Listen</source>
+        <translation>Lauschen</translation>
+    </message>
+    <message>
+        <source>SYN sent</source>
+        <translation>SYN gesendet</translation>
+    </message>
+    <message>
+        <source>SYN received</source>
+        <translation>SYN empfangen</translation>
+    </message>
+    <message>
+        <source>Established</source>
+        <translation>Verbindung hergestellt</translation>
+    </message>
+    <message>
+        <source>FIN wait 1</source>
+        <translation>FIN-Wartezeit 1</translation>
+    </message>
+    <message>
+        <source>FIN wait 2</source>
+        <translation>FIN-Wartezeit 2</translation>
+    </message>
+    <message>
+        <source>Close wait</source>
+        <translation>Warten auf Schließen</translation>
+    </message>
+    <message>
+        <source>Closing</source>
+        <translation>Schließen</translation>
+    </message>
+    <message>
+        <source>Last ACK</source>
+        <translation>Letztes ACK</translation>
+    </message>
+    <message>
+        <source>Time wait</source>
+        <translation>Wartezeit</translation>
+    </message>
+    <message>
+        <source>Delete TCB</source>
+        <translation>TCB löschen</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source>Unknown %1</source>
+        <translation>Unbekannt %1</translation>
+    </message>
+</context>
+<context>
+    <name>CSocketModel</name>
+    <message>
+        <source>Unknown Process</source>
+        <translation>Unbekannter Prozess</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>PROCESS MISSING</source>
+        <translation>PROZESS FEHLT</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Entfernte Adresse</translation>
+    </message>
+    <message>
+        <source>Remote Port</source>
+        <translation>Entfernter Port</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Lokale Adresse</translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation>Lokaler Port</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>Zugriff</translation>
+    </message>
+    <message>
+        <source>State</source>
+        <translation>Zustand</translation>
+    </message>
+    <message>
+        <source>Last Activity</source>
+        <translation>Letzte Aktivität</translation>
+    </message>
+    <message>
+        <source>Upload</source>
+        <translation>Upload</translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation>Download</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Hochgeladen</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Heruntergeladen</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+</context>
+<context>
+    <name>CSocketView</name>
+    <message>
+        <source>All Protocols</source>
+        <translation>Alle Protokolle</translation>
+    </message>
+    <message>
+        <source>HTTP(S)</source>
+        <translation>HTTP(S)</translation>
+    </message>
+    <message>
+        <source>TCP Sockets</source>
+        <translation>TCP-Sockets</translation>
+    </message>
+    <message>
+        <source>TCP Clients</source>
+        <translation>TCP-Clients</translation>
+    </message>
+    <message>
+        <source>TCP Servers</source>
+        <translation>TCP-Server</translation>
+    </message>
+    <message>
+        <source>UDP Sockets</source>
+        <translation>UDP-Sockets</translation>
+    </message>
+</context>
+<context>
+    <name>CTraceView</name>
+    <message>
+        <source>Loading %1</source>
+        <translation>Lade %1</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the trace logs for the current program items?</source>
+        <translation>Möchten Sie die Protokolle für die aktuellen Programmeinträge wirklich löschen?</translation>
+    </message>
+</context>
+<context>
+    <name>CTrafficModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Last Activity</source>
+        <translation>Letzte Aktivität</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Hochgeladen</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Heruntergeladen</translation>
+    </message>
+</context>
+<context>
+    <name>CTrafficView</name>
+    <message>
+        <source>By Host</source>
+        <translation>Nach Host</translation>
+    </message>
+    <message>
+        <source>By Program</source>
+        <translation>Nach Programm</translation>
+    </message>
+    <message>
+        <source>Area Filter</source>
+        <translation>Bereichsfilter</translation>
+    </message>
+    <message>
+        <source>Internet</source>
+        <translation>Internet</translation>
+    </message>
+    <message>
+        <source>Local Area</source>
+        <translation>Lokales Netzwerk</translation>
+    </message>
+    <message>
+        <source>Local Host</source>
+        <translation>Lokaler Host</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakInfo</name>
+    <message>
+        <source>Apply Tweak</source>
+        <translation>Anpassung anwenden</translation>
+    </message>
+    <message>
+        <source>Undo Tweak</source>
+        <translation>Anpassung rückgängig machen</translation>
+    </message>
+    <message>
+        <source>Tweak Info</source>
+        <translation>Tweak-Information</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Summary</source>
+        <translation>Zusammenfassung</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakList</name>
+    <message>
+        <source>%1 (%2/%3)</source>
+        <translation>%1 (%2/%3)</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Hint</source>
+        <translation>Hinweis</translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <translation>Information</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakView</name>
+    <message>
+        <source>Refresh tweak states</source>
+        <translation>Tweak-Status aktualisieren</translation>
+    </message>
+    <message>
+        <source>Show not available tweaks</source>
+        <translation>Nicht verfügbare Tweaks anzeigen</translation>
+    </message>
+    <message>
+        <source>Approve Current State</source>
+        <translation>Aktuellen Zustand übernehmen</translation>
+    </message>
+    <message>
+        <source>Restore Approved State</source>
+        <translation>Übernommenen Zustand wiederherstellen</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatisch erweitern</translation>
+    </message>
+    <message>
+        <source>This tweak is marked as breaking, hence it may break something. Are you sure you want to apply it?</source>
+        <translation>Diese Anpassung ist als kritisch markiert und könnte etwas beschädigen. Möchten Sie sie wirklich anwenden?</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>Diesen Hinweis nicht mehr anzeigen.</translation>
+    </message>
+    <message>
+        <source>MajorPrivacy</source>
+        <translation>MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to approve the current state of all tweaks?</source>
+        <translation>Möchten Sie den aktuellen Zustand aller Tweaks wirklich übernehmen?</translation>
+    </message>
+    <message>
+        <source>
 				Are you sure you want to restore the approved state of all tweaks?
 
 				The following operations will be performed:
 			</source>
-			<translation>
+        <translation>
 				Möchten Sie den übernommenen Zustand aller Tweaks wirklich wiederherstellen?
 
 				Folgende Aktionen werden durchgeführt:
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				Undo tweaks:
 			</source>
-			<translation>
+        <translation>
 				Rückgängig machen:
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				Apply tweaks:
 			</source>
-			<translation>
+        <translation>
 				Anwenden:
 			</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVariantEditorWnd</name>
-		<message>
-			<source>File</source>
-			<translation>Datei</translation>
-		</message>
-		<message>
-			<source>Open File</source>
-			<translation>Datei öffnen</translation>
-		</message>
-		<message>
-			<source>Close Editor</source>
-			<translation>Editor schließen</translation>
-		</message>
-		<message>
-			<source>Add to Root</source>
-			<translation>Zur Wurzel hinzufügen</translation>
-		</message>
-		<message>
-			<source>Add</source>
-			<translation>Hinzufügen</translation>
-		</message>
-		<message>
-			<source>Remove</source>
-			<translation>Entfernen</translation>
-		</message>
-		<message>
-			<source>All Files (*.dat)</source>
-			<translation>Alle Dateien (*.dat)</translation>
-		</message>
-		<message>
-			<source>Error</source>
-			<translation>Fehler</translation>
-		</message>
-		<message>
-			<source>Can&apos;t open file</source>
-			<translation>Datei kann nicht geöffnet werden</translation>
-		</message>
-		<message>
-			<source>Can&apos;t parse file</source>
-			<translation>Datei kann nicht geparst werden</translation>
-		</message>
-		<message>
-			<source>Save File</source>
-			<translation>Datei speichern</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVariantModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Value</source>
-			<translation>Wert</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolume</name>
-		<message>
-			<source>Unmounted Volume</source>
-			<translation>Ausgehängtes Volume</translation>
-		</message>
-		<message>
-			<source>Mounted Volume</source>
-			<translation>Eingehängtes Volume</translation>
-		</message>
-		<message>
-			<source>Unprotected Folder</source>
-			<translation>Ungeschützter Ordner</translation>
-		</message>
-		<message>
-			<source>Protected Folder</source>
-			<translation>Geschützter Ordner</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolumeModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Mount Point</source>
-			<translation>Einhängepunkt</translation>
-		</message>
-		<message>
-			<source>Total Size</source>
-			<translation>Gesamtgröße</translation>
-		</message>
-		<message>
-			<source>Full Path</source>
-			<translation>Vollständiger Pfad</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolumeView</name>
-		<message>
-			<source>Mount Volume</source>
-			<translation>Volume einhängen</translation>
-		</message>
-		<message>
-			<source>Unmount Volume</source>
-			<translation>Volume aushängen</translation>
-		</message>
-		<message>
-			<source>Change Volume Password</source>
-			<translation>Volume-Passwort ändern</translation>
-		</message>
-		<message>
-			<source>Rename Volume</source>
-			<translation>Volume umbenennen</translation>
-		</message>
-		<message>
-			<source>Remove Volume</source>
-			<translation>Volume entfernen</translation>
-		</message>
-		<message>
-			<source>Create Volume</source>
-			<translation>Volume erstellen</translation>
-		</message>
-		<message>
-			<source>Add and Mount Volume Image</source>
-			<translation>Volume-Image hinzufügen und einhängen</translation>
-		</message>
-		<message>
-			<source>Add Folder</source>
-			<translation>Ordner hinzufügen</translation>
-		</message>
-		<message>
-			<source>Unmount All Volumes</source>
-			<translation>Alle Volumes aushängen</translation>
-		</message>
-		<message>
-			<source>Do you want to unmount the selected volume?</source>
-			<translation>Möchten Sie das ausgewählte Volume aushängen?</translation>
-		</message>
-		<message>
-			<source>Select Private Volume</source>
-			<translation>Privates Volume auswählen</translation>
-		</message>
-		<message>
-			<source>Private Volume Files (*.pv)</source>
-			<translation>Private Volume-Dateien (*.pv)</translation>
-		</message>
-		<message>
-			<source>Mount Secure Volume</source>
-			<translation>Sicheres Volume einhängen</translation>
-		</message>
-		<message>
-			<source>Creating new volume image, please enter a secure password, and choose a disk image size.</source>
-			<translation>Neues Volume-Image wird erstellt. Bitte ein sicheres Passwort eingeben und eine Größe für das Image auswählen.</translation>
-		</message>
-		<message>
-			<source>This volume content will be placed in an encrypted container file, please note that any corruption of the container&apos;s header will render all its content permanently inaccessible. Corruption can occur as a result of a BSOD, a storage hardware failure, or a malicious application overwriting random files. This feature is provided under a strict &lt;b&gt;No Backup No Mercy&lt;/b&gt; policy, YOU the user are responsible for the data you put into an encrypted box. &lt;br /&gt;&lt;br /&gt;IF YOU AGREE TO TAKE FULL RESPONSIBILITY FOR YOUR DATA PRESS [YES], OTHERWISE PRESS [NO].</source>
-			<translation>Der Inhalt dieses Volumes wird in einer verschlüsselten Containerdatei abgelegt. Bitte beachten Sie, dass jede Beschädigung des Container-Headers dazu führt, dass der gesamte Inhalt dauerhaft unzugänglich wird. Solche Schäden können durch einen BSOD, einen Hardwarefehler oder eine bösartige Anwendung verursacht werden. Diese Funktion wird unter der strikten &lt;b&gt;Keine Sicherung – Kein Mitleid&lt;/b&gt;-Regel bereitgestellt. SIE als Nutzer sind für die Daten im verschlüsselten Container selbst verantwortlich.&lt;br /&gt;&lt;br /&gt;WENN SIE DIE VOLLE VERANTWORTUNG FÜR IHRE DATEN ÜBERNEHMEN, DRÜCKEN SIE [JA], ANDERNFALLS [NEIN].</translation>
-		</message>
-		<message>
-			<source>Don&apos;t show this message again.</source>
-			<translation>Diesen Hinweis nicht erneut anzeigen.</translation>
-		</message>
-		<message>
-			<source>Change Volume Password.</source>
-			<translation>Volume-Passwort ändern.</translation>
-		</message>
-		<message>
-			<source>Please enter a name for the item</source>
-			<translation>Bitte geben Sie einen Namen für das Element ein</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+</context>
+<context>
+    <name>CVariantEditorWnd</name>
+    <message>
+        <source>File</source>
+        <translation>Datei</translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation>Datei öffnen</translation>
+    </message>
+    <message>
+        <source>Close Editor</source>
+        <translation>Editor schließen</translation>
+    </message>
+    <message>
+        <source>Add to Root</source>
+        <translation>Zur Wurzel hinzufügen</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Entfernen</translation>
+    </message>
+    <message>
+        <source>All Files (*.dat)</source>
+        <translation>Alle Dateien (*.dat)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open file</source>
+        <translation>Datei kann nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <source>Can&apos;t parse file</source>
+        <translation>Datei kann nicht geparst werden</translation>
+    </message>
+    <message>
+        <source>Save File</source>
+        <translation>Datei speichern</translation>
+    </message>
+</context>
+<context>
+    <name>CVariantModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Value</source>
+        <translation>Wert</translation>
+    </message>
+</context>
+<context>
+    <name>CVolume</name>
+    <message>
+        <source>Unmounted Volume</source>
+        <translation>Ausgehängtes Volume</translation>
+    </message>
+    <message>
+        <source>Mounted Volume</source>
+        <translation>Eingehängtes Volume</translation>
+    </message>
+    <message>
+        <source>Unprotected Folder</source>
+        <translation>Ungeschützter Ordner</translation>
+    </message>
+    <message>
+        <source>Protected Folder</source>
+        <translation>Geschützter Ordner</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+</context>
+<context>
+    <name>CVolumeModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Mount Point</source>
+        <translation>Einhängepunkt</translation>
+    </message>
+    <message>
+        <source>Total Size</source>
+        <translation>Gesamtgröße</translation>
+    </message>
+    <message>
+        <source>Full Path</source>
+        <translation>Vollständiger Pfad</translation>
+    </message>
+</context>
+<context>
+    <name>CVolumeView</name>
+    <message>
+        <source>Mount Volume</source>
+        <translation>Volume einhängen</translation>
+    </message>
+    <message>
+        <source>Unmount Volume</source>
+        <translation>Volume aushängen</translation>
+    </message>
+    <message>
+        <source>Change Volume Password</source>
+        <translation>Volume-Passwort ändern</translation>
+    </message>
+    <message>
+        <source>Rename Volume</source>
+        <translation>Volume umbenennen</translation>
+    </message>
+    <message>
+        <source>Remove Volume</source>
+        <translation>Volume entfernen</translation>
+    </message>
+    <message>
+        <source>Create Volume</source>
+        <translation>Volume erstellen</translation>
+    </message>
+    <message>
+        <source>Add and Mount Volume Image</source>
+        <translation>Volume-Image hinzufügen und einhängen</translation>
+    </message>
+    <message>
+        <source>Add Folder</source>
+        <translation>Ordner hinzufügen</translation>
+    </message>
+    <message>
+        <source>Unmount All Volumes</source>
+        <translation>Alle Volumes aushängen</translation>
+    </message>
+    <message>
+        <source>Do you want to unmount the selected volume?</source>
+        <translation>Möchten Sie das ausgewählte Volume aushängen?</translation>
+    </message>
+    <message>
+        <source>Select Private Volume</source>
+        <translation>Privates Volume auswählen</translation>
+    </message>
+    <message>
+        <source>Private Volume Files (*.pv)</source>
+        <translation>Private Volume-Dateien (*.pv)</translation>
+    </message>
+    <message>
+        <source>Mount Secure Volume</source>
+        <translation>Sicheres Volume einhängen</translation>
+    </message>
+    <message>
+        <source>Creating new volume image, please enter a secure password, and choose a disk image size.</source>
+        <translation>Neues Volume-Image wird erstellt. Bitte ein sicheres Passwort eingeben und eine Größe für das Image auswählen.</translation>
+    </message>
+    <message>
+        <source>This volume content will be placed in an encrypted container file, please note that any corruption of the container&apos;s header will render all its content permanently inaccessible. Corruption can occur as a result of a BSOD, a storage hardware failure, or a malicious application overwriting random files. This feature is provided under a strict &lt;b&gt;No Backup No Mercy&lt;/b&gt; policy, YOU the user are responsible for the data you put into an encrypted box. &lt;br /&gt;&lt;br /&gt;IF YOU AGREE TO TAKE FULL RESPONSIBILITY FOR YOUR DATA PRESS [YES], OTHERWISE PRESS [NO].</source>
+        <translation>Der Inhalt dieses Volumes wird in einer verschlüsselten Containerdatei abgelegt. Bitte beachten Sie, dass jede Beschädigung des Container-Headers dazu führt, dass der gesamte Inhalt dauerhaft unzugänglich wird. Solche Schäden können durch einen BSOD, einen Hardwarefehler oder eine bösartige Anwendung verursacht werden. Diese Funktion wird unter der strikten &lt;b&gt;Keine Sicherung – Kein Mitleid&lt;/b&gt;-Regel bereitgestellt. SIE als Nutzer sind für die Daten im verschlüsselten Container selbst verantwortlich.&lt;br /&gt;&lt;br /&gt;WENN SIE DIE VOLLE VERANTWORTUNG FÜR IHRE DATEN ÜBERNEHMEN, DRÜCKEN SIE [JA], ANDERNFALLS [NEIN].</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>Diesen Hinweis nicht erneut anzeigen.</translation>
+    </message>
+    <message>
+        <source>Change Volume Password.</source>
+        <translation>Volume-Passwort ändern.</translation>
+    </message>
+    <message>
+        <source>Please enter a name for the item</source>
+        <translation>Bitte geben Sie einen Namen für das Element ein</translation>
+    </message>
+    <message>
+        <source>
 				Do you want to remove selected Volumes from list?
 				Note: The volume image files will remain intact and must be manually deleted.
 			</source>
-			<translation>
+        <translation>
 				Möchten Sie die ausgewählten Volumes aus der Liste entfernen?
 				Hinweis: Die Volume-Image-Dateien bleiben erhalten und müssen manuell gelöscht werden.
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				The security of files and folders on unencrypted volumes cannot be guaranteed if Major Privacy is not running or if the Kernel Isolator driver is not loaded. In this state, folder access control will not be enforced.
 				For non-critical data, folder protection may still provide a basic level of security. However, for highly confidential or sensitive information, it is strongly recommended to use a secure, encrypted volume to ensure robust protection against unauthorized access.
 			</source>
-			<translation>
+        <translation>
 				Die Sicherheit von Dateien und Ordnern auf unverschlüsselten Volumes kann nicht gewährleistet werden, wenn Major Privacy nicht läuft oder der Kernel-Isolator-Treiber nicht geladen ist. In diesem Zustand wird der Ordnerzugriffsschutz nicht durchgesetzt.
 				Für nicht-kritische Daten kann der Ordnerschutz dennoch ein grundlegendes Maß an Sicherheit bieten. Für hochvertrauliche oder sensible Daten wird jedoch dringend empfohlen, ein sicheres, verschlüsseltes Volume zu verwenden, um einen zuverlässigen Schutz vor unbefugtem Zugriff zu gewährleisten.
 			</translation>
-		</message>
-		<message>
-			<source>Select Directory</source>
-			<translation>Verzeichnis auswählen</translation>
-		</message>
-		<message>
-			<source>%1 - Protection</source>
-			<translation>%1 – Schutz</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolumeWindow</name>
-		<message>
-			<source>kilobytes (%1)</source>
-			<translation>Kilobyte (%1)</translation>
-		</message>
-		<message>
-			<source>Passwords don&apos;t match!!!</source>
-			<translation>Passwörter stimmen nicht überein!!!</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>Verzeichnis auswählen</translation>
+    </message>
+    <message>
+        <source>%1 - Protection</source>
+        <translation>%1 – Schutz</translation>
+    </message>
+</context>
+<context>
+    <name>CVolumeWindow</name>
+    <message>
+        <source>kilobytes (%1)</source>
+        <translation>Kilobyte (%1)</translation>
+    </message>
+    <message>
+        <source>Passwords don&apos;t match!!!</source>
+        <translation>Passwörter stimmen nicht überein!!!</translation>
+    </message>
+    <message>
+        <source>
 				WARNING: Short passwords are easy to crack using brute force techniques!
 
 				It is recommended to choose a password consisting of 20 or more characters. Are you sure you want to use a short password?
 			</source>
-			<translation>
+        <translation>
 				WARNUNG: Kurze Passwörter sind mit Brute-Force-Methoden leicht zu knacken!
 
 				Es wird empfohlen, ein Passwort mit mindestens 20 Zeichen zu wählen. Möchten Sie wirklich ein kurzes Passwort verwenden?
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				The password is constrained to a maximum length of 128 characters.
 				This length permits approximately 384 bits of entropy with a passphrase composed of actual English words,
 				increases to 512 bits with the application of Leet (L337) speak modifications, and exceeds 768 bits when composed of entirely random printable ASCII characters.
 			</source>
-			<translation>
+        <translation>
 				Das Passwort ist auf eine maximale Länge von 128 Zeichen beschränkt.
 				Diese Länge erlaubt etwa 384 Bit Entropie bei der Verwendung englischer Wörter,
 				512 Bit bei der Verwendung von Leetspeak (L337) und über 768 Bit bei rein zufälligen druckbaren ASCII-Zeichen.
 			</translation>
-		</message>
-		<message>
-			<source>The Box Disk Image must be at least 256 MB in size, 2GB are recommended.</source>
-			<translation>Das Box-Disk-Image muss mindestens 256 MB groß sein, 2 GB werden empfohlen.</translation>
-		</message>
-		<message>
-			<source>Select Mount Point</source>
-			<translation>Einhängepunkt auswählen</translation>
-		</message>
-		<message>
-			<source>Never</source>
-			<translation>Niemals</translation>
-		</message>
-		<message>
-			<source>5 minutes</source>
-			<translation>5 Minuten</translation>
-		</message>
-		<message>
-			<source>15 minutes</source>
-			<translation>15 Minuten</translation>
-		</message>
-		<message>
-			<source>30 minutes</source>
-			<translation>30 Minuten</translation>
-		</message>
-		<message>
-			<source>1 hour</source>
-			<translation>1 Stunde</translation>
-		</message>
-		<message>
-			<source>%1 hours</source>
-			<translation>%1 Stunden</translation>
-		</message>
-		<message>
-			<source>%1 minutes</source>
-			<translation>%1 Minuten</translation>
-		</message>
-	</context>
-	<context>
-		<name>EnclaveWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formular</translation>
-		</message>
-		<message>
-			<source>Secure Enclave Identity</source>
-			<translation>Sichere Enklaven-Identität</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Code Integrity Presets</source>
-			<translation>Code-Integritätsvorgaben</translation>
-		</message>
-		<message>
-			<source>Require Signature</source>
-			<translation>Signatur erforderlich</translation>
-		</message>
-		<message>
-			<source>Image Load Protection</source>
-			<translation>Schutz beim Laden von Images</translation>
-		</message>
-		<message>
-			<source>Process Spawn Handling</source>
-			<translation>Behandlung von Prozessstarts</translation>
-		</message>
-		<message>
-			<source>On Trusted</source>
-			<translation>Bei vertrauenswürdig</translation>
-		</message>
-		<message>
-			<source>On UN Trusted</source>
-			<translation>Bei nicht vertrauenswürdig</translation>
-		</message>
-		<message>
-			<source>Other Options</source>
-			<translation>Weitere Optionen</translation>
-		</message>
-		<message>
-			<source>Elevate Token Integrity Level, for User Interface Privilege Isolation</source>
-			<translation>Integritätsstufe des Tokens erhöhen (für UIPI – Benutzeroberflächen-Isolation)</translation>
-		</message>
-		<message>
-			<source>Token Integrity (UIPI)</source>
-			<translation>Token-Integrität (UIPI)</translation>
-		</message>
-		<message>
-			<source>Prevent termination</source>
-			<translation>Beenden verhindern</translation>
-		</message>
-		<message>
-			<source>Allow Debuging (INSECURE !!!)</source>
-			<translation>Debugging erlauben (UNSICHER!!!)</translation>
-		</message>
-	</context>
-	<context>
-		<name>FirewallRuleWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formular</translation>
-		</message>
-		<message>
-			<source>Firewall Rule Identity</source>
-			<translation>Firewall-Regelidentität</translation>
-		</message>
-		<message>
-			<source>Group</source>
-			<translation>Gruppe</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Description...</source>
-			<translation>Beschreibung …</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-		<message>
-			<source>Service Tag</source>
-			<translation>Dienst-Tag</translation>
-		</message>
-		<message>
-			<source>Executable</source>
-			<translation>Ausführbare Datei</translation>
-		</message>
-		<message>
-			<source>App Package</source>
-			<translation>App-Paket</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>…</translation>
-		</message>
-		<message>
-			<source>Action &amp;&amp; Scope</source>
-			<translation>Aktion &amp;&amp; Bereich</translation>
-		</message>
-		<message>
-			<source>Sellected:</source>
-			<translation>Ausgewählt:</translation>
-		</message>
-		<message>
-			<source>All Profiles</source>
-			<translation>Alle Profile</translation>
-		</message>
-		<message>
-			<source>LAN</source>
-			<translation>LAN</translation>
-		</message>
-		<message>
-			<source>Private</source>
-			<translation>Privat</translation>
-		</message>
-		<message>
-			<source>WLAN</source>
-			<translation>WLAN</translation>
-		</message>
-		<message>
-			<source>Domain</source>
-			<translation>Domäne</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Specific Types:</source>
-			<translation>Spezifische Typen:</translation>
-		</message>
-		<message>
-			<source>VPN</source>
-			<translation>VPN</translation>
-		</message>
-		<message>
-			<source>Public</source>
-			<translation>Öffentlich</translation>
-		</message>
-		<message>
-			<source>All Interface Types</source>
-			<translation>Alle Schnittstellentypen</translation>
-		</message>
-		<message>
-			<source>Network Properties</source>
-			<translation>Netzwerkeigenschaften</translation>
-		</message>
-		<message>
-			<source>Ok</source>
-			<translation>OK</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Lokale Adresse</translation>
-		</message>
-		<message>
-			<source>Selected Addresses</source>
-			<translation>Ausgewählte Adressen</translation>
-		</message>
-		<message>
-			<source>Local Port</source>
-			<translation>Lokaler Port</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Entfernte Adresse</translation>
-		</message>
-		<message>
-			<source>Any Address</source>
-			<translation>Beliebige Adresse</translation>
-		</message>
-		<message>
-			<source>Direction</source>
-			<translation>Richtung</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokoll</translation>
-		</message>
-		<message>
-			<source>ICMP Type</source>
-			<translation>ICMP-Typ</translation>
-		</message>
-		<message>
-			<source>Remote Port</source>
-			<translation>Entfernter Port</translation>
-		</message>
-	</context>
-	<context>
-		<name>OptionsTransferWnd</name>
-		<message>
-			<source>Option Transfer</source>
-			<translation>Optionen übertragen</translation>
-		</message>
-		<message>
-			<source>OK</source>
-			<translation>OK</translation>
-		</message>
-		<message>
-			<source>Cancel</source>
-			<translation>Abbrechen</translation>
-		</message>
-		<message>
-			<source>User Interface Options</source>
-			<translation>Benutzeroberflächenoptionen</translation>
-		</message>
-		<message>
-			<source>Process Protection Rules</source>
-			<translation>Prozessschutzregeln</translation>
-		</message>
-		<message>
-			<source>Please sellect which options you want to import/export.</source>
-			<translation>Bitte wählen Sie aus, welche Optionen Sie importieren/exportieren möchten.</translation>
-		</message>
-		<message>
-			<source>Resource Access Rules</source>
-			<translation>Ressourcenzugriffsregeln</translation>
-		</message>
-		<message>
-			<source>Full Program List</source>
-			<translation>Komplette Programmliste</translation>
-		</message>
-		<message>
-			<source>Privacy Agent Options</source>
-			<translation>Privacy-Agent-Optionen</translation>
-		</message>
-		<message>
-			<source>User Key (Remains Encrypted with User PW)</source>
-			<translation>Benutzerschlüssel (bleibt mit Benutzerpasswort verschlüsselt)</translation>
-		</message>
-		<message>
-			<source>Trace Log Data</source>
-			<translation>Protokolldaten (Trace Log)</translation>
-		</message>
-		<message>
-			<source>Windows Firewall Rules</source>
-			<translation>Windows-Firewall-Regeln</translation>
-		</message>
-		<message>
-			<source>Kernel Isolator Options</source>
-			<translation>Kernel-Isolator-Optionen</translation>
-		</message>
-		<message>
-			<source>Secure Enclave Configuration</source>
-			<translation>Sichere Enklaven-Konfiguration</translation>
-		</message>
-	</context>
-	<context>
-		<name>PopUpWindow</name>
-		<message>
-			<source>MajorPrivacy Notifications</source>
-			<translation>MajorPrivacy-Benachrichtigungen</translation>
-		</message>
-		<message>
-			<source>Firewall</source>
-			<translation>Firewall</translation>
-		</message>
-		<message>
-			<source>0/0</source>
-			<translation>0/0</translation>
-		</message>
-		<message>
-			<source>Ignore</source>
-			<translation>Ignorieren</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Erlauben</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Blockieren</translation>
-		</message>
-		<message>
-			<source>Previouse</source>
-			<translation>Zurück</translation>
-		</message>
-		<message>
-			<source>Next</source>
-			<translation>Weiter</translation>
-		</message>
-		<message>
-			<source>GroupBox</source>
-			<translation>Gruppenfeld</translation>
-		</message>
-		<message>
-			<source>TextLabel</source>
-			<translation>Textbeschriftung</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokoll</translation>
-		</message>
-		<message>
-			<source>Endpoint</source>
-			<translation>Endpunkt</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Zeitstempel</translation>
-		</message>
-		<message>
-			<source>Process Id</source>
-			<translation>Prozess-ID</translation>
-		</message>
-		<message>
-			<source>Command Line</source>
-			<translation>Befehlszeile</translation>
-		</message>
-		<message>
-			<source>Icon</source>
-			<translation>Symbol</translation>
-		</message>
-		<message>
-			<source>Access</source>
-			<translation>Zugriff</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Pfad</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Tiem Stamp</source>
-			<translation>Zeitstempel</translation>
-			<!-- Schreibfehler im Original ("Tiem") -->
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Process ID</source>
-			<translation>Prozess-ID</translation>
-		</message>
-		<message>
-			<source>Exec</source>
-			<translation>Ausführung</translation>
-		</message>
-		<message>
-			<source>File Name</source>
-			<translation>Dateiname</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Vertrauensebene</translation>
-		</message>
-		<message>
-			<source>Signing Certificate</source>
-			<translation>Signaturzertifikat</translation>
-		</message>
-		<message>
-			<source>File Path</source>
-			<translation>Dateipfad</translation>
-		</message>
-		<message>
-			<source>Sign File</source>
-			<translation>Datei signieren</translation>
-		</message>
-		<message>
-			<source>Tweaks</source>
-			<translation>Anpassungen</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Description</source>
-			<translation>Beschreibung</translation>
-		</message>
-		<message>
-			<source>Approve</source>
-			<translation>Genehmigen</translation>
-		</message>
-		<message>
-			<source>Reject</source>
-			<translation>Ablehnen</translation>
-		</message>
-	</context>
-	<context>
-		<name>ProgramPicker</name>
-		<message>
-			<source>Major Privacy - Select Program</source>
-			<translation>MajorPrivacy – Programm auswählen</translation>
-		</message>
-		<message>
-			<source>All Programs</source>
-			<translation>Alle Programme</translation>
-		</message>
-		<message>
-			<source>Select a program from the list</source>
-			<translation>Wählen Sie ein Programm aus der Liste</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-		<message>
-			<source>Add New Program Item</source>
-			<translation>Neues Programmelement hinzufügen</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>ProgramRuleWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formular</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Path Pattern</source>
-			<translation>Pfadmuster</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklave</translation>
-		</message>
-		<message>
-			<source>Program Rule Identity</source>
-			<translation>Programmeregel-Identität</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Aktion</translation>
-		</message>
-		<message>
-			<source>Require Signature</source>
-			<translation>Signatur erforderlich</translation>
-		</message>
-		<message>
-			<source>Image Load Protection</source>
-			<translation>Schutz beim Laden von Images</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>ProgramWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formular</translation>
-		</message>
-		<message>
-			<source>Program Info</source>
-			<translation>Programminformationen</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Name</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Programm</translation>
-		</message>
-		<message>
-			<source>Exact File Path or Path Pattern (DOS style)</source>
-			<translation>Exakter Dateipfad oder Pfadmuster (DOS-Stil)</translation>
-		</message>
-		<message>
-			<source>Executable Path</source>
-			<translation>Pfad zur ausführbaren Datei</translation>
-		</message>
-		<message>
-			<source>App Package</source>
-			<translation>Anwendungspaket</translation>
-		</message>
-		<message>
-			<source>Service Tag</source>
-			<translation>Dienstkennzeichen</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Trace Logs and Records</source>
-			<translation>Protokolle und Aufzeichnungen</translation>
-		</message>
-		<message>
-			<source>Network Trace</source>
-			<translation>Netzwerküberwachung</translation>
-		</message>
-		<message>
-			<source>Save Trace</source>
-			<translation>Protokoll speichern</translation>
-		</message>
-		<message>
-			<source>Resource Trace</source>
-			<translation>Ressourcenüberwachung</translation>
-		</message>
-		<message>
-			<source>Ingress Trace</source>
-			<translation>Zugriffsüberwachung</translation>
-		</message>
-	</context>
-	<context>
-		<name>QObject</name>
-		<message>
-			<source>Change Permissions</source>
-			<translation>Berechtigungen ändern</translation>
-		</message>
-		<message>
-			<source>Write Data</source>
-			<translation>Daten schreiben</translation>
-		</message>
-		<message>
-			<source>Read Data</source>
-			<translation>Daten lesen</translation>
-		</message>
-		<message>
-			<source>Write Attributes</source>
-			<translation>Attribute schreiben</translation>
-		</message>
-		<message>
-			<source>Read Attributes</source>
-			<translation>Attribute lesen</translation>
-		</message>
-		<message>
-			<source>%1</source>
-			<translation>%1</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Zugelassen</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Blockiert</translation>
-		</message>
-		<message>
-			<source> (0x%1)</source>
-			<translation> (0x%1)</translation>
-		</message>
-		<message>
-			<source>Booth</source>
-			<translation>Beide</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Ausführender</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Ziel</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Unbekannt</translation>
-		</message>
-		<message>
-			<source>Process Started</source>
-			<translation>Prozess gestartet</translation>
-		</message>
-		<message>
-			<source>Image Loaded</source>
-			<translation>Image geladen</translation>
-		</message>
-		<message>
-			<source>Thread Access</source>
-			<translation>Thread-Zugriff</translation>
-		</message>
-		<message>
-			<source>Process Access</source>
-			<translation>Prozesszugriff</translation>
-		</message>
-		<message>
-			<source>Control Execution</source>
-			<translation>Ausführung steuern</translation>
-		</message>
-		<message>
-			<source>Write Memory</source>
-			<translation>Speicher schreiben</translation>
-		</message>
-		<message>
-			<source>Read Memory</source>
-			<translation>Speicher lesen</translation>
-		</message>
-		<message>
-			<source>Special Permissions</source>
-			<translation>Spezielle Berechtigungen</translation>
-		</message>
-		<message>
-			<source>Write Properties</source>
-			<translation>Eigenschaften schreiben</translation>
-		</message>
-		<message>
-			<source>Read Properties</source>
-			<translation>Eigenschaften lesen</translation>
-		</message>
-		<message>
-			<source>Allowed (Untrusted)</source>
-			<translation>Zugelassen (nicht vertrauenswürdig)</translation>
-		</message>
-		<message>
-			<source>Allowed (Ejected)</source>
-			<translation>Zugelassen (ausgeworfen)</translation>
-		</message>
-		<message>
-			<source>Blocked (Protected)</source>
-			<translation>Blockiert (geschützt)</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsWindow</name>
-		<message>
-			<source>Major Privacy Settings</source>
-			<translation>MajorPrivacy-Einstellungen</translation>
-		</message>
-		<message>
-			<source>General Config</source>
-			<translation>Allgemeine Konfiguration</translation>
-		</message>
-		<message>
-			<source>UI Language:</source>
-			<translation>Oberflächensprache:</translation>
-		</message>
-		<message>
-			<source>Major Privacy Options</source>
-			<translation>MajorPrivacy-Optionen</translation>
-		</message>
-		<message>
-			<source>Auto list installed applications in the program tree</source>
-			<translation>Installierte Anwendungen automatisch im Programmbaum auflisten</translation>
-		</message>
-		<message>
-			<source>Interface Config</source>
-			<translation>Oberflächenkonfiguration</translation>
-		</message>
-		<message>
-			<source>Use Dark Theme</source>
-			<translation>Dunkles Design verwenden</translation>
-		</message>
-		<message>
-			<source>Interface Options</source>
-			<translation>Oberflächenoptionen</translation>
-		</message>
-		<message>
-			<source>Use Fusion Theme</source>
-			<translation>Fusion-Design verwenden</translation>
-		</message>
-		<message>
-			<source>Notifications</source>
-			<translation>Benachrichtigungen</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Data</source>
-			<translation>Daten</translation>
-		</message>
-		<message>
-			<source>Ignore List</source>
-			<translation>Ignorierliste</translation>
-		</message>
-		<message>
-			<source>Remove Entry</source>
-			<translation>Eintrag entfernen</translation>
-		</message>
-		<message>
-			<source>When an event notification is displayed you can ignore all future notifications for a specific file, these ignore entries can be removed usin the below list, to add new entries you need to add them from the notification popup.</source>
-			<translation>Wenn eine Ereignisbenachrichtigung angezeigt wird, können Sie alle zukünftigen Benachrichtigungen für eine bestimmte Datei ignorieren. Diese Einträge können über die folgende Liste entfernt werden; neue Einträge müssen über das Benachrichtigungsfenster hinzugefügt werden.</translation>
-		</message>
-		<message>
-			<source>Process Protection</source>
-			<translation>Prozessschutz</translation>
-		</message>
-		<message>
-			<source>Process Protection Logging</source>
-			<translation>Protokollierung des Prozessschutzes</translation>
-		</message>
-		<message>
-			<source>Show Process Protection Notification Popups</source>
-			<translation>Popup-Benachrichtigungen für Prozessschutz anzeigen</translation>
-		</message>
-		<message>
-			<source>Record Process Execution and Ingress to Disk (IngressRecord.dat)</source>
-			<translation>Prozessausführung und -eingänge auf Festplatte speichern (IngressRecord.dat)</translation>
-		</message>
-		<message>
-			<source>Log Process Execution and Ingress (to RAM)</source>
-			<translation>Prozessausführung und -eingänge im RAM protokollieren</translation>
-		</message>
-		<message>
-			<source>Process Execution and Ingress Tracing</source>
-			<translation>Prozessverfolgung und -eingänge</translation>
-		</message>
-		<message>
-			<source>Access Protection</source>
-			<translation>Zugriffsschutz</translation>
-		</message>
-		<message>
-			<source>Save File/Folder Accesses Record to Disk (AccessRecord.dat)</source>
-			<translation>Zugriffe auf Dateien/Ordner auf Festplatte speichern (AccessRecord.dat)</translation>
-		</message>
-		<message>
-			<source>Resource Access Logging</source>
-			<translation>Protokollierung von Ressourcenzugriffen</translation>
-		</message>
-		<message>
-			<source>Show Resource Access Notification Popups</source>
-			<translation>Popup-Benachrichtigungen bei Ressourcenzugriffen anzeigen</translation>
-		</message>
-		<message>
-			<source>List All Open Files</source>
-			<translation>Alle offenen Dateien auflisten</translation>
-		</message>
-		<message>
-			<source>File/Folder Accesses Tracing</source>
-			<translation>Verfolgung von Datei-/Ordnerzugriffen</translation>
-		</message>
-		<message>
-			<source>Trace also access atempts to non existing resources</source>
-			<translation>Auch Zugriffsversuche auf nicht existierende Ressourcen verfolgen</translation>
-		</message>
-		<message>
-			<source>Registry Access Tracing (not recommended, adds some CPU load)</source>
-			<translation>Verfolgung von Registry-Zugriffen (nicht empfohlen, erhöht CPU-Auslastung)</translation>
-		</message>
-		<message>
-			<source>Log all File/Folder Accesses (to RAM)</source>
-			<translation>Alle Datei-/Ordnerzugriffe im RAM protokollieren</translation>
-		</message>
-		<message>
-			<source>Firewall Config</source>
-			<translation>Firewall-Konfiguration</translation>
-		</message>
-		<message>
-			<source>This feature enables the creation of firewall rule templates with path wildcards. When the Privacy Agent detects network activity matching a template without an existing rule, it automatically generates a new firewall rule.</source>
-			<translation>Diese Funktion ermöglicht das Erstellen von Firewall-Regelvorlagen mit Platzhaltern. Erkennt der Privacy Agent Netzwerkaktivität, die einer Vorlage entspricht und für die keine Regel existiert, wird automatisch eine neue Regel erstellt.</translation>
-		</message>
-		<message>
-			<source>Enhance Windows Firewall with Dynamic Rule Templates</source>
-			<translation>Windows-Firewall mit dynamischen Regelvorlagen erweitern</translation>
-		</message>
-		<message>
-			<source>Save Traffic Record to Disk (TrafficRecord.dat)</source>
-			<translation>Verkehrsprotokoll auf Festplatte speichern (TrafficRecord.dat)</translation>
-		</message>
-		<message>
-			<source>Disable Windows Firewall (not recomended)</source>
-			<translation>Windows-Firewall deaktivieren (nicht empfohlen)</translation>
-		</message>
-		<message>
-			<source>When creating a new (outbound) rule also create an inbound rule</source>
-			<translation>Beim Erstellen einer neuen (ausgehenden) Regel auch eine eingehende Regel erstellen</translation>
-		</message>
-		<message>
-			<source>Block List Mode (Windows default)</source>
-			<translation>Blocklistenmodus (Windows-Standard)</translation>
-		</message>
-		<message>
-			<source>Alow List Mode (recommended)</source>
-			<translation>Erlaubnislistenmodus (empfohlen)</translation>
-		</message>
-		<message>
-			<source>Windows Firewall Logging</source>
-			<translation>Windows-Firewall-Protokollierung</translation>
-		</message>
-		<message>
-			<source>Windows Firewall Mode</source>
-			<translation>Windows-Firewall-Modus</translation>
-		</message>
-		<message>
-			<source>Use Simple Domain Resolution</source>
-			<translation>Einfache Namensauflösung verwenden</translation>
-		</message>
-		<message>
-			<source>Use Reverse DNS</source>
-			<translation>Reverse DNS verwenden</translation>
-		</message>
-		<message>
-			<source>Show Connection Notification Popups</source>
-			<translation>Verbindungsbenachrichtigungen anzeigen</translation>
-		</message>
-		<message>
-			<source>Log all Network Access (to RAM)</source>
-			<translation>Alle Netzwerkzugriffe im RAM protokollieren</translation>
-		</message>
-		<message>
-			<source>Firewall Audit Policy</source>
-			<translation>Firewall-Prüfrichtlinie</translation>
-		</message>
-		<message>
-			<source>Load Windows Firewall Log on start (can be very slow)</source>
-			<translation>Windows-Firewall-Log beim Start laden (kann sehr langsam sein)</translation>
-		</message>
-		<message>
-			<source>(Should be set to All)</source>
-			<translation>(Sollte auf Alle gesetzt sein)</translation>
-		</message>
-		<message>
-			<source>Record Network Traffic</source>
-			<translation>Netzwerkverkehr aufzeichnen</translation>
-		</message>
-		<message>
-			<source>Dns Filter</source>
-			<translation>DNS-Filter</translation>
-		</message>
-		<message>
-			<source>Setup DNS Proxy as default DNS in Windows</source>
-			<translation>DNS-Proxy als Standard-DNS in Windows einrichten</translation>
-		</message>
-		<message>
-			<source>Remove</source>
-			<translation>Entfernen</translation>
-		</message>
-		<message>
-			<source>Load DNS Blocklists</source>
-			<translation>DNS-Blocklisten laden</translation>
-		</message>
-		<message>
-			<source>Upstream DNS Resolvers</source>
-			<translation>Upstream-DNS-Resolver</translation>
-		</message>
-		<message>
-			<source>DNS Filter</source>
-			<translation>DNS-Filter</translation>
-		</message>
-		<message>
-			<source>Enable Filtering DNS Proxy</source>
-			<translation>Filternder DNS-Proxy aktivieren</translation>
-		</message>
-		<message>
-			<source>8.8.8.8;1.1.1.1</source>
-			<translation>8.8.8.8;1.1.1.1</translation>
-		</message>
-		<message>
-			<source>Add List</source>
-			<translation>Liste hinzufügen</translation>
-		</message>
-		<message>
-			<source>Url</source>
-			<translation>URL</translation>
-		</message>
-		<message>
-			<source>Entries</source>
-			<translation>Einträge</translation>
-		</message>
-		<message>
-			<source>Advanced</source>
-			<translation>Erweitert</translation>
-		</message>
-		<message>
-			<source>Trace Log Entry Limit:</source>
-			<translation>Protokolleintragsgrenze:</translation>
-		</message>
-		<message>
-			<source>Trace Log Options</source>
-			<translation>Protokolloptionen</translation>
-		</message>
-		<message>
-			<source>Trace Log Retention Tme:</source>
-			<translation>Protokoll-Aufbewahrungsdauer:</translation>
-		</message>
-		<message>
-			<source>Hours</source>
-			<translation>Stunden</translation>
-		</message>
-		<message>
-			<source>Support &amp;&amp; Updates</source>
-			<translation>Support &amp;&amp; Updates</translation>
-		</message>
-		<message>
-			<source>Get</source>
-			<translation>Holen</translation>
-		</message>
-		<message>
-			<source>In the future, don&apos;t notify about certificate expiration</source>
-			<translation>Künftig nicht mehr über Zertifikatsablauf benachrichtigen</translation>
-		</message>
-		<message>
-			<source>PRIV_-_____-_____-_____-_____</source>
-			<translation>PRIV_-_____-_____-_____-_____</translation>
-		</message>
-		<message>
-			<source>Please enter your Supporter Certificate or License Serial Number:</source>
-			<translation>Bitte geben Sie Ihr Supporter-Zertifikat oder Ihre Lizenz-Seriennummer ein:</translation>
-		</message>
-		<message>
-			<source>Hotpatches for the installed version, updates to the Templates.ini and translations.</source>
-			<translation>Hotpatches für die installierte Version, Updates für Templates.ini und Übersetzungen.</translation>
-		</message>
-		<message>
-			<source>Incremental Updates</source>
-			<translation>Inkrementelle Updates</translation>
-		</message>
-		<message>
-			<source>The preview channel contains the latest GitHub pre-releases.</source>
-			<translation>Der Vorschaukanal enthält die neuesten GitHub-Vorabversionen.</translation>
-		</message>
-		<message>
-			<source>Search in the Preview channel</source>
-			<translation>Im Vorschaukanal suchen</translation>
-		</message>
-		<message>
-			<source>Update Settings</source>
-			<translation>Update-Einstellungen</translation>
-		</message>
-		<message>
-			<source>The stable channel contains the latest stable GitHub releases.</source>
-			<translation>Der stabile Kanal enthält die neuesten stabilen GitHub-Versionen.</translation>
-		</message>
-		<message>
-			<source>Search in the Stable channel</source>
-			<translation>Im stabilen Kanal suchen</translation>
-		</message>
-		<message>
-			<source>New full installers from the selected release channel.</source>
-			<translation>Neue Vollinstallationen aus dem gewählten Release-Kanal.</translation>
-		</message>
-		<message>
-			<source>Full Upgrades</source>
-			<translation>Vollständige Upgrades</translation>
-		</message>
-		<message>
-			<source>Update Check Interval</source>
-			<translation>Intervall für Update-Prüfung</translation>
-		</message>
-		<message>
-			<source>Check periodically for new versions</source>
-			<translation>Regelmäßig auf neue Versionen prüfen</translation>
-		</message>
-		<message>
-			<source>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Certificate usage guide&lt;/a&gt;</source>
-			<translation>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Zertifikatsanleitung&lt;/a&gt;</translation>
-		</message>
-		<message>
-			<source>This supporter certificate has expired, please &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;get an updated certificate&lt;/a&gt;.</source>
-			<translation>Dieses Supporter-Zertifikat ist abgelaufen. Bitte &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;holen Sie ein aktualisiertes Zertifikat&lt;/a&gt;.</translation>
-		</message>
-		<message>
-			<source>Enter the support certificate here</source>
-			<translation>Supporter-Zertifikat hier eingeben</translation>
-		</message>
-		<message>
-			<source>Retrieve/Upgrade/Renew certificate using Serial Number</source>
-			<translation>Zertifikat mit Seriennummer abrufen/aktualisieren/erneuern</translation>
-		</message>
-	</context>
-	<context>
-		<name>VolumeWindow</name>
-		<message>
-			<source>Form</source>
-			<translation>Formular</translation>
-		</message>
-		<message>
-			<source>Load volume access protection rules</source>
-			<translation>Schutzregeln für Volume-Zugriff laden</translation>
-		</message>
-		<message>
-			<source>Select directory as mount point</source>
-			<translation>Verzeichnis als Einhängepunkt auswählen</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Mount Point</source>
-			<translation>Einhängepunkt</translation>
-		</message>
-		<message>
-			<source>New Password</source>
-			<translation>Neues Passwort</translation>
-		</message>
-		<message>
-			<source>Repeat Password</source>
-			<translation>Passwort wiederholen</translation>
-		</message>
-		<message>
-			<source>kilobytes</source>
-			<translation>Kilobyte</translation>
-		</message>
-		<message>
-			<source>TextLabel</source>
-			<translation>TextEtikett</translation>
-		</message>
-		<message>
-			<source>Encryption Cipher</source>
-			<translation>Verschlüsselungsalgorithmus</translation>
-		</message>
-		<message>
-			<source>Show Password</source>
-			<translation>Passwort anzeigen</translation>
-		</message>
-		<message>
-			<source>Enter Password</source>
-			<translation>Passwort eingeben</translation>
-		</message>
-		<message>
-			<source>Disk Image Size</source>
-			<translation>Größe des Datenträgerabbilds</translation>
-		</message>
-		<message>
-			<source>Auto Lock after</source>
-			<translation>Automatisch sperren nach</translation>
-		</message>
-	</context>
+    </message>
+    <message>
+        <source>The Box Disk Image must be at least 256 MB in size, 2GB are recommended.</source>
+        <translation>Das Box-Disk-Image muss mindestens 256 MB groß sein, 2 GB werden empfohlen.</translation>
+    </message>
+    <message>
+        <source>Select Mount Point</source>
+        <translation>Einhängepunkt auswählen</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation>Niemals</translation>
+    </message>
+    <message>
+        <source>5 minutes</source>
+        <translation>5 Minuten</translation>
+    </message>
+    <message>
+        <source>15 minutes</source>
+        <translation>15 Minuten</translation>
+    </message>
+    <message>
+        <source>30 minutes</source>
+        <translation>30 Minuten</translation>
+    </message>
+    <message>
+        <source>1 hour</source>
+        <translation>1 Stunde</translation>
+    </message>
+    <message>
+        <source>%1 hours</source>
+        <translation>%1 Stunden</translation>
+    </message>
+    <message>
+        <source>%1 minutes</source>
+        <translation>%1 Minuten</translation>
+    </message>
+</context>
+<context>
+    <name>EnclaveWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <source>Secure Enclave Identity</source>
+        <translation>Sichere Enklaven-Identität</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Code Integrity Presets</source>
+        <translation>Code-Integritätsvorgaben</translation>
+    </message>
+    <message>
+        <source>Require Signature</source>
+        <translation>Signatur erforderlich</translation>
+    </message>
+    <message>
+        <source>Image Load Protection</source>
+        <translation>Schutz beim Laden von Images</translation>
+    </message>
+    <message>
+        <source>Process Spawn Handling</source>
+        <translation>Behandlung von Prozessstarts</translation>
+    </message>
+    <message>
+        <source>On Trusted</source>
+        <translation>Bei vertrauenswürdig</translation>
+    </message>
+    <message>
+        <source>On UN Trusted</source>
+        <translation>Bei nicht vertrauenswürdig</translation>
+    </message>
+    <message>
+        <source>Other Options</source>
+        <translation>Weitere Optionen</translation>
+    </message>
+    <message>
+        <source>Elevate Token Integrity Level, for User Interface Privilege Isolation</source>
+        <translation>Integritätsstufe des Tokens erhöhen (für UIPI – Benutzeroberflächen-Isolation)</translation>
+    </message>
+    <message>
+        <source>Token Integrity (UIPI)</source>
+        <translation>Token-Integrität (UIPI)</translation>
+    </message>
+    <message>
+        <source>Prevent termination</source>
+        <translation>Beenden verhindern</translation>
+    </message>
+    <message>
+        <source>Allow Debugging (INSECURE !!!)</source>
+        <translation>Debugging erlauben (UNSICHER!!!)</translation>
+    </message>
+</context>
+<context>
+    <name>FirewallRuleWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <source>Firewall Rule Identity</source>
+        <translation>Firewall-Regelidentität</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Gruppe</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Description...</source>
+        <translation>Beschreibung …</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+    <message>
+        <source>Service Tag</source>
+        <translation>Dienst-Tag</translation>
+    </message>
+    <message>
+        <source>Executable</source>
+        <translation>Ausführbare Datei</translation>
+    </message>
+    <message>
+        <source>App Package</source>
+        <translation>App-Paket</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>…</translation>
+    </message>
+    <message>
+        <source>Action &amp;&amp; Scope</source>
+        <translation>Aktion &amp;&amp; Bereich</translation>
+    </message>
+    <message>
+        <source>Selected:</source>
+        <translation>Ausgewählt:</translation>
+    </message>
+    <message>
+        <source>All Profiles</source>
+        <translation>Alle Profile</translation>
+    </message>
+    <message>
+        <source>LAN</source>
+        <translation>LAN</translation>
+    </message>
+    <message>
+        <source>Private</source>
+        <translation>Privat</translation>
+    </message>
+    <message>
+        <source>WLAN</source>
+        <translation>WLAN</translation>
+    </message>
+    <message>
+        <source>Domain</source>
+        <translation>Domäne</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Specific Types:</source>
+        <translation>Spezifische Typen:</translation>
+    </message>
+    <message>
+        <source>VPN</source>
+        <translation>VPN</translation>
+    </message>
+    <message>
+        <source>Public</source>
+        <translation>Öffentlich</translation>
+    </message>
+    <message>
+        <source>All Interface Types</source>
+        <translation>Alle Schnittstellentypen</translation>
+    </message>
+    <message>
+        <source>Network Properties</source>
+        <translation>Netzwerkeigenschaften</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Lokale Adresse</translation>
+    </message>
+    <message>
+        <source>Selected Addresses</source>
+        <translation>Ausgewählte Adressen</translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation>Lokaler Port</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Entfernte Adresse</translation>
+    </message>
+    <message>
+        <source>Any Address</source>
+        <translation>Beliebige Adresse</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Richtung</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <source>ICMP Type</source>
+        <translation>ICMP-Typ</translation>
+    </message>
+    <message>
+        <source>Remote Port</source>
+        <translation>Entfernter Port</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsTransferWnd</name>
+    <message>
+        <source>Option Transfer</source>
+        <translation>Optionen übertragen</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <source>User Interface Options</source>
+        <translation>Benutzeroberflächenoptionen</translation>
+    </message>
+    <message>
+        <source>Process Protection Rules</source>
+        <translation>Prozessschutzregeln</translation>
+    </message>
+    <message>
+        <source>Please select which options you want to import/export.</source>
+        <translation>Bitte wählen Sie aus, welche Optionen Sie importieren/exportieren möchten.</translation>
+    </message>
+    <message>
+        <source>Resource Access Rules</source>
+        <translation>Ressourcenzugriffsregeln</translation>
+    </message>
+    <message>
+        <source>Full Program List</source>
+        <translation>Komplette Programmliste</translation>
+    </message>
+    <message>
+        <source>Privacy Agent Options</source>
+        <translation>Privacy-Agent-Optionen</translation>
+    </message>
+    <message>
+        <source>User Key (Remains Encrypted with User PW)</source>
+        <translation>Benutzerschlüssel (bleibt mit Benutzerpasswort verschlüsselt)</translation>
+    </message>
+    <message>
+        <source>Trace Log Data</source>
+        <translation>Protokolldaten (Trace Log)</translation>
+    </message>
+    <message>
+        <source>Windows Firewall Rules</source>
+        <translation>Windows-Firewall-Regeln</translation>
+    </message>
+    <message>
+        <source>Kernel Isolator Options</source>
+        <translation>Kernel-Isolator-Optionen</translation>
+    </message>
+    <message>
+        <source>Secure Enclave Configuration</source>
+        <translation>Sichere Enklaven-Konfiguration</translation>
+    </message>
+</context>
+<context>
+    <name>PopUpWindow</name>
+    <message>
+        <source>MajorPrivacy Notifications</source>
+        <translation>MajorPrivacy-Benachrichtigungen</translation>
+    </message>
+    <message>
+        <source>Firewall</source>
+        <translation>Firewall</translation>
+    </message>
+    <message>
+        <source>0/0</source>
+        <translation>0/0</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation>Ignorieren</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Erlauben</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Blockieren</translation>
+    </message>
+    <message>
+        <source>Previous</source>
+        <translation>Zurück</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>Weiter</translation>
+    </message>
+    <message>
+        <source>GroupBox</source>
+        <translation>Gruppenfeld</translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation>Textbeschriftung</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <source>Endpoint</source>
+        <translation>Endpunkt</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Zeitstempel</translation>
+    </message>
+    <message>
+        <source>Process Id</source>
+        <translation>Prozess-ID</translation>
+    </message>
+    <message>
+        <source>Command Line</source>
+        <translation>Befehlszeile</translation>
+    </message>
+    <message>
+        <source>Icon</source>
+        <translation>Symbol</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>Zugriff</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Pfad</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Process ID</source>
+        <translation>Prozess-ID</translation>
+    </message>
+    <message>
+        <source>Exec</source>
+        <translation>Ausführung</translation>
+    </message>
+    <message>
+        <source>File Name</source>
+        <translation>Dateiname</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Vertrauensebene</translation>
+    </message>
+    <message>
+        <source>Signing Certificate</source>
+        <translation>Signaturzertifikat</translation>
+    </message>
+    <message>
+        <source>File Path</source>
+        <translation>Dateipfad</translation>
+    </message>
+    <message>
+        <source>Sign File</source>
+        <translation>Datei signieren</translation>
+    </message>
+    <message>
+        <source>Tweaks</source>
+        <translation>Anpassungen</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Description</source>
+        <translation>Beschreibung</translation>
+    </message>
+    <message>
+        <source>Approve</source>
+        <translation>Genehmigen</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation>Ablehnen</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramPicker</name>
+    <message>
+        <source>Major Privacy - Select Program</source>
+        <translation>MajorPrivacy – Programm auswählen</translation>
+    </message>
+    <message>
+        <source>All Programs</source>
+        <translation>Alle Programme</translation>
+    </message>
+    <message>
+        <source>Select a program from the list</source>
+        <translation>Wählen Sie ein Programm aus der Liste</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+    <message>
+        <source>Add New Program Item</source>
+        <translation>Neues Programmelement hinzufügen</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramRuleWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Path Pattern</source>
+        <translation>Pfadmuster</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklave</translation>
+    </message>
+    <message>
+        <source>Program Rule Identity</source>
+        <translation>Programmeregel-Identität</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <source>Require Signature</source>
+        <translation>Signatur erforderlich</translation>
+    </message>
+    <message>
+        <source>Image Load Protection</source>
+        <translation>Schutz beim Laden von Images</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <source>Program Info</source>
+        <translation>Programminformationen</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Programm</translation>
+    </message>
+    <message>
+        <source>Exact File Path or Path Pattern (DOS style)</source>
+        <translation>Exakter Dateipfad oder Pfadmuster (DOS-Stil)</translation>
+    </message>
+    <message>
+        <source>Executable Path</source>
+        <translation>Pfad zur ausführbaren Datei</translation>
+    </message>
+    <message>
+        <source>App Package</source>
+        <translation>Anwendungspaket</translation>
+    </message>
+    <message>
+        <source>Service Tag</source>
+        <translation>Dienstkennzeichen</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Trace Logs and Records</source>
+        <translation>Protokolle und Aufzeichnungen</translation>
+    </message>
+    <message>
+        <source>Network Trace</source>
+        <translation>Netzwerküberwachung</translation>
+    </message>
+    <message>
+        <source>Save Trace</source>
+        <translation>Protokoll speichern</translation>
+    </message>
+    <message>
+        <source>Resource Trace</source>
+        <translation>Ressourcenüberwachung</translation>
+    </message>
+    <message>
+        <source>Ingress Trace</source>
+        <translation>Zugriffsüberwachung</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Change Permissions</source>
+        <translation>Berechtigungen ändern</translation>
+    </message>
+    <message>
+        <source>Write Data</source>
+        <translation>Daten schreiben</translation>
+    </message>
+    <message>
+        <source>Read Data</source>
+        <translation>Daten lesen</translation>
+    </message>
+    <message>
+        <source>Write Attributes</source>
+        <translation>Attribute schreiben</translation>
+    </message>
+    <message>
+        <source>Read Attributes</source>
+        <translation>Attribute lesen</translation>
+    </message>
+    <message>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Zugelassen</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
+    </message>
+    <message>
+        <source> (0x%1)</source>
+        <translation> (0x%1)</translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation>Beide</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Ausführender</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Ziel</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>Process Started</source>
+        <translation>Prozess gestartet</translation>
+    </message>
+    <message>
+        <source>Image Loaded</source>
+        <translation>Image geladen</translation>
+    </message>
+    <message>
+        <source>Thread Access</source>
+        <translation>Thread-Zugriff</translation>
+    </message>
+    <message>
+        <source>Process Access</source>
+        <translation>Prozesszugriff</translation>
+    </message>
+    <message>
+        <source>Control Execution</source>
+        <translation>Ausführung steuern</translation>
+    </message>
+    <message>
+        <source>Write Memory</source>
+        <translation>Speicher schreiben</translation>
+    </message>
+    <message>
+        <source>Read Memory</source>
+        <translation>Speicher lesen</translation>
+    </message>
+    <message>
+        <source>Special Permissions</source>
+        <translation>Spezielle Berechtigungen</translation>
+    </message>
+    <message>
+        <source>Write Properties</source>
+        <translation>Eigenschaften schreiben</translation>
+    </message>
+    <message>
+        <source>Read Properties</source>
+        <translation>Eigenschaften lesen</translation>
+    </message>
+    <message>
+        <source>Allowed (Untrusted)</source>
+        <translation>Zugelassen (nicht vertrauenswürdig)</translation>
+    </message>
+    <message>
+        <source>Allowed (Ejected)</source>
+        <translation>Zugelassen (ausgeworfen)</translation>
+    </message>
+    <message>
+        <source>Blocked (Protected)</source>
+        <translation>Blockiert (geschützt)</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>Major Privacy Settings</source>
+        <translation>MajorPrivacy-Einstellungen</translation>
+    </message>
+    <message>
+        <source>General Config</source>
+        <translation>Allgemeine Konfiguration</translation>
+    </message>
+    <message>
+        <source>UI Language:</source>
+        <translation>Oberflächensprache:</translation>
+    </message>
+    <message>
+        <source>Major Privacy Options</source>
+        <translation>MajorPrivacy-Optionen</translation>
+    </message>
+    <message>
+        <source>Auto list installed applications in the program tree</source>
+        <translation>Installierte Anwendungen automatisch im Programmbaum auflisten</translation>
+    </message>
+    <message>
+        <source>Interface Config</source>
+        <translation>Oberflächenkonfiguration</translation>
+    </message>
+    <message>
+        <source>Use Dark Theme</source>
+        <translation>Dunkles Design verwenden</translation>
+    </message>
+    <message>
+        <source>Interface Options</source>
+        <translation>Oberflächenoptionen</translation>
+    </message>
+    <message>
+        <source>Use Fusion Theme</source>
+        <translation>Fusion-Design verwenden</translation>
+    </message>
+    <message>
+        <source>Notifications</source>
+        <translation>Benachrichtigungen</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Data</source>
+        <translation>Daten</translation>
+    </message>
+    <message>
+        <source>Ignore List</source>
+        <translation>Ignorierliste</translation>
+    </message>
+    <message>
+        <source>Remove Entry</source>
+        <translation>Eintrag entfernen</translation>
+    </message>
+    <message>
+        <source>When an event notification is displayed you can ignore all future notifications for a specific file, these ignore entries can be removed usin the below list, to add new entries you need to add them from the notification popup.</source>
+        <translation>Wenn eine Ereignisbenachrichtigung angezeigt wird, können Sie alle zukünftigen Benachrichtigungen für eine bestimmte Datei ignorieren. Diese Einträge können über die folgende Liste entfernt werden; neue Einträge müssen über das Benachrichtigungsfenster hinzugefügt werden.</translation>
+    </message>
+    <message>
+        <source>Process Protection</source>
+        <translation>Prozessschutz</translation>
+    </message>
+    <message>
+        <source>Process Protection Logging</source>
+        <translation>Protokollierung des Prozessschutzes</translation>
+    </message>
+    <message>
+        <source>Show Process Protection Notification Popups</source>
+        <translation>Popup-Benachrichtigungen für Prozessschutz anzeigen</translation>
+    </message>
+    <message>
+        <source>Record Process Execution and Ingress to Disk (IngressRecord.dat)</source>
+        <translation>Prozessausführung und -eingänge auf Festplatte speichern (IngressRecord.dat)</translation>
+    </message>
+    <message>
+        <source>Log Process Execution and Ingress (to RAM)</source>
+        <translation>Prozessausführung und -eingänge im RAM protokollieren</translation>
+    </message>
+    <message>
+        <source>Process Execution and Ingress Tracing</source>
+        <translation>Prozessverfolgung und -eingänge</translation>
+    </message>
+    <message>
+        <source>Access Protection</source>
+        <translation>Zugriffsschutz</translation>
+    </message>
+    <message>
+        <source>Save File/Folder Accesses Record to Disk (AccessRecord.dat)</source>
+        <translation>Zugriffe auf Dateien/Ordner auf Festplatte speichern (AccessRecord.dat)</translation>
+    </message>
+    <message>
+        <source>Resource Access Logging</source>
+        <translation>Protokollierung von Ressourcenzugriffen</translation>
+    </message>
+    <message>
+        <source>Show Resource Access Notification Popups</source>
+        <translation>Popup-Benachrichtigungen bei Ressourcenzugriffen anzeigen</translation>
+    </message>
+    <message>
+        <source>List All Open Files</source>
+        <translation>Alle offenen Dateien auflisten</translation>
+    </message>
+    <message>
+        <source>File/Folder Accesses Tracing</source>
+        <translation>Verfolgung von Datei-/Ordnerzugriffen</translation>
+    </message>
+    <message>
+        <source>Trace also access attempts to non existing resources</source>
+        <translation>Auch Zugriffsversuche auf nicht existierende Ressourcen verfolgen</translation>
+    </message>
+    <message>
+        <source>Registry Access Tracing (not recommended, adds some CPU load)</source>
+        <translation>Verfolgung von Registry-Zugriffen (nicht empfohlen, erhöht CPU-Auslastung)</translation>
+    </message>
+    <message>
+        <source>Log all File/Folder Accesses (to RAM)</source>
+        <translation>Alle Datei-/Ordnerzugriffe im RAM protokollieren</translation>
+    </message>
+    <message>
+        <source>Firewall Config</source>
+        <translation>Firewall-Konfiguration</translation>
+    </message>
+    <message>
+        <source>This feature enables the creation of firewall rule templates with path wildcards. When the Privacy Agent detects network activity matching a template without an existing rule, it automatically generates a new firewall rule.</source>
+        <translation>Diese Funktion ermöglicht das Erstellen von Firewall-Regelvorlagen mit Platzhaltern. Erkennt der Privacy Agent Netzwerkaktivität, die einer Vorlage entspricht und für die keine Regel existiert, wird automatisch eine neue Regel erstellt.</translation>
+    </message>
+    <message>
+        <source>Enhance Windows Firewall with Dynamic Rule Templates</source>
+        <translation>Windows-Firewall mit dynamischen Regelvorlagen erweitern</translation>
+    </message>
+    <message>
+        <source>Save Traffic Record to Disk (TrafficRecord.dat)</source>
+        <translation>Verkehrsprotokoll auf Festplatte speichern (TrafficRecord.dat)</translation>
+    </message>
+    <message>
+        <source>Disable Windows Firewall (not recomended)</source>
+        <translation>Windows-Firewall deaktivieren (nicht empfohlen)</translation>
+    </message>
+    <message>
+        <source>When creating a new (outbound) rule also create an inbound rule</source>
+        <translation>Beim Erstellen einer neuen (ausgehenden) Regel auch eine eingehende Regel erstellen</translation>
+    </message>
+    <message>
+        <source>Block List Mode (Windows default)</source>
+        <translation>Blocklistenmodus (Windows-Standard)</translation>
+    </message>
+    <message>
+        <source>Allow List Mode (recommended)</source>
+        <translation>Erlaubnislistenmodus (empfohlen)</translation>
+    </message>
+    <message>
+        <source>Windows Firewall Logging</source>
+        <translation>Windows-Firewall-Protokollierung</translation>
+    </message>
+    <message>
+        <source>Windows Firewall Mode</source>
+        <translation>Windows-Firewall-Modus</translation>
+    </message>
+    <message>
+        <source>Use Simple Domain Resolution</source>
+        <translation>Einfache Namensauflösung verwenden</translation>
+    </message>
+    <message>
+        <source>Use Reverse DNS</source>
+        <translation>Reverse DNS verwenden</translation>
+    </message>
+    <message>
+        <source>Show Connection Notification Popups</source>
+        <translation>Verbindungsbenachrichtigungen anzeigen</translation>
+    </message>
+    <message>
+        <source>Log all Network Access (to RAM)</source>
+        <translation>Alle Netzwerkzugriffe im RAM protokollieren</translation>
+    </message>
+    <message>
+        <source>Firewall Audit Policy</source>
+        <translation>Firewall-Prüfrichtlinie</translation>
+    </message>
+    <message>
+        <source>Load Windows Firewall Log on start (can be very slow)</source>
+        <translation>Windows-Firewall-Log beim Start laden (kann sehr langsam sein)</translation>
+    </message>
+    <message>
+        <source>(Should be set to All)</source>
+        <translation>(Sollte auf Alle gesetzt sein)</translation>
+    </message>
+    <message>
+        <source>Record Network Traffic</source>
+        <translation>Netzwerkverkehr aufzeichnen</translation>
+    </message>
+    <message>
+        <source>Dns Filter</source>
+        <translation>DNS-Filter</translation>
+    </message>
+    <message>
+        <source>Setup DNS Proxy as default DNS in Windows</source>
+        <translation>DNS-Proxy als Standard-DNS in Windows einrichten</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Entfernen</translation>
+    </message>
+    <message>
+        <source>Load DNS Blocklists</source>
+        <translation>DNS-Blocklisten laden</translation>
+    </message>
+    <message>
+        <source>Upstream DNS Resolvers</source>
+        <translation>Upstream-DNS-Resolver</translation>
+    </message>
+    <message>
+        <source>DNS Filter</source>
+        <translation>DNS-Filter</translation>
+    </message>
+    <message>
+        <source>Enable Filtering DNS Proxy</source>
+        <translation>Filternder DNS-Proxy aktivieren</translation>
+    </message>
+    <message>
+        <source>8.8.8.8;1.1.1.1</source>
+        <translation>8.8.8.8;1.1.1.1</translation>
+    </message>
+    <message>
+        <source>Add List</source>
+        <translation>Liste hinzufügen</translation>
+    </message>
+    <message>
+        <source>Url</source>
+        <translation>URL</translation>
+    </message>
+    <message>
+        <source>Entries</source>
+        <translation>Einträge</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation>Erweitert</translation>
+    </message>
+    <message>
+        <source>Trace Log Entry Limit:</source>
+        <translation>Protokolleintragsgrenze:</translation>
+    </message>
+    <message>
+        <source>Trace Log Options</source>
+        <translation>Protokolloptionen</translation>
+    </message>
+    <message>
+        <source>Trace Log Retention Time:</source>
+        <translation>Protokoll-Aufbewahrungsdauer:</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Stunden</translation>
+    </message>
+    <message>
+        <source>Support &amp;&amp; Updates</source>
+        <translation>Support &amp;&amp; Updates</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation>Holen</translation>
+    </message>
+    <message>
+        <source>In the future, don&apos;t notify about certificate expiration</source>
+        <translation>Künftig nicht mehr über Zertifikatsablauf benachrichtigen</translation>
+    </message>
+    <message>
+        <source>PRIV_-_____-_____-_____-_____</source>
+        <translation>PRIV_-_____-_____-_____-_____</translation>
+    </message>
+    <message>
+        <source>Please enter your Supporter Certificate or License Serial Number:</source>
+        <translation>Bitte geben Sie Ihr Supporter-Zertifikat oder Ihre Lizenz-Seriennummer ein:</translation>
+    </message>
+    <message>
+        <source>Hotpatches for the installed version, updates to the Templates.ini and translations.</source>
+        <translation>Hotpatches für die installierte Version, Updates für Templates.ini und Übersetzungen.</translation>
+    </message>
+    <message>
+        <source>Incremental Updates</source>
+        <translation>Inkrementelle Updates</translation>
+    </message>
+    <message>
+        <source>The preview channel contains the latest GitHub pre-releases.</source>
+        <translation>Der Vorschaukanal enthält die neuesten GitHub-Vorabversionen.</translation>
+    </message>
+    <message>
+        <source>Search in the Preview channel</source>
+        <translation>Im Vorschaukanal suchen</translation>
+    </message>
+    <message>
+        <source>Update Settings</source>
+        <translation>Update-Einstellungen</translation>
+    </message>
+    <message>
+        <source>The stable channel contains the latest stable GitHub releases.</source>
+        <translation>Der stabile Kanal enthält die neuesten stabilen GitHub-Versionen.</translation>
+    </message>
+    <message>
+        <source>Search in the Stable channel</source>
+        <translation>Im stabilen Kanal suchen</translation>
+    </message>
+    <message>
+        <source>New full installers from the selected release channel.</source>
+        <translation>Neue Vollinstallationen aus dem gewählten Release-Kanal.</translation>
+    </message>
+    <message>
+        <source>Full Upgrades</source>
+        <translation>Vollständige Upgrades</translation>
+    </message>
+    <message>
+        <source>Update Check Interval</source>
+        <translation>Intervall für Update-Prüfung</translation>
+    </message>
+    <message>
+        <source>Check periodically for new versions</source>
+        <translation>Regelmäßig auf neue Versionen prüfen</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Certificate usage guide&lt;/a&gt;</source>
+        <translation>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Zertifikatsanleitung&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>This supporter certificate has expired, please &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;get an updated certificate&lt;/a&gt;.</source>
+        <translation>Dieses Supporter-Zertifikat ist abgelaufen. Bitte &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;holen Sie ein aktualisiertes Zertifikat&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <source>Enter the support certificate here</source>
+        <translation>Supporter-Zertifikat hier eingeben</translation>
+    </message>
+    <message>
+        <source>Retrieve/Upgrade/Renew certificate using Serial Number</source>
+        <translation>Zertifikat mit Seriennummer abrufen/aktualisieren/erneuern</translation>
+    </message>
+</context>
+<context>
+    <name>VolumeWindow</name>
+    <message>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <source>Load volume access protection rules</source>
+        <translation>Schutzregeln für Volume-Zugriff laden</translation>
+    </message>
+    <message>
+        <source>Select directory as mount point</source>
+        <translation>Verzeichnis als Einhängepunkt auswählen</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Mount Point</source>
+        <translation>Einhängepunkt</translation>
+    </message>
+    <message>
+        <source>New Password</source>
+        <translation>Neues Passwort</translation>
+    </message>
+    <message>
+        <source>Repeat Password</source>
+        <translation>Passwort wiederholen</translation>
+    </message>
+    <message>
+        <source>kilobytes</source>
+        <translation>Kilobyte</translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation>TextEtikett</translation>
+    </message>
+    <message>
+        <source>Encryption Cipher</source>
+        <translation>Verschlüsselungsalgorithmus</translation>
+    </message>
+    <message>
+        <source>Show Password</source>
+        <translation>Passwort anzeigen</translation>
+    </message>
+    <message>
+        <source>Enter Password</source>
+        <translation>Passwort eingeben</translation>
+    </message>
+    <message>
+        <source>Disk Image Size</source>
+        <translation>Größe des Datenträgerabbilds</translation>
+    </message>
+    <message>
+        <source>Auto Lock after</source>
+        <translation>Automatisch sperren nach</translation>
+    </message>
+</context>
 </TS>

--- a/MajorPrivacy/MajorPrivacy_es.ts
+++ b/MajorPrivacy/MajorPrivacy_es.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es">
+<TS version="2.1" language="es_ES">
 <context>
     <name>AccessRuleWnd</name>
     <message>
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/MajorPrivacy_fr.ts
+++ b/MajorPrivacy/MajorPrivacy_fr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fr">
+<TS version="2.1" language="fr_FR">
 <context>
     <name>AccessRuleWnd</name>
     <message>
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/MajorPrivacy_it.ts
+++ b/MajorPrivacy/MajorPrivacy_it.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="it">
+<TS version="2.1" language="it_IT">
 <context>
     <name>AccessRuleWnd</name>
     <message>
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/MajorPrivacy_ja.ts
+++ b/MajorPrivacy/MajorPrivacy_ja.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja">
+<TS version="2.1" language="ja_JP">
 <context>
     <name>AccessRuleWnd</name>
     <message>
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/MajorPrivacy_ko.ts
+++ b/MajorPrivacy/MajorPrivacy_ko.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ko">
+<TS version="2.1" language="ko_KR">
 <context>
     <name>AccessRuleWnd</name>
     <message>
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/MajorPrivacy_pl.ts
+++ b/MajorPrivacy/MajorPrivacy_pl.ts
@@ -1,5280 +1,5248 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pl">
-	<context>
-		<name>AccessRuleWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formularz</translation>
-		</message>
-		<message>
-			<source>Access Rule Identity</source>
-			<translation>Tożsamość reguły dostępu</translation>
-		</message>
-		<message>
-			<source>Description...</source>
-			<translation>Opis...</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Path Pattern</source>
-			<translation>Wzorzec ścieżki</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Path &amp;&amp; Action</source>
-			<translation>Ścieżka i akcja</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Akcja</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Ścieżka</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAbstractTweak</name>
-		<message>
-			<source>Tweak Group</source>
-			<translation>Grupa ustawień</translation>
-		</message>
-		<message>
-			<source>Tweak Bundle</source>
-			<translation>Zestaw ustawień</translation>
-		</message>
-		<message>
-			<source>Set Registry Option</source>
-			<translation>Ustaw opcję rejestru</translation>
-		</message>
-		<message>
-			<source>Configure Group Policy</source>
-			<translation>Skonfiguruj zasady grupy</translation>
-		</message>
-		<message>
-			<source>Disable System Service</source>
-			<translation>Wyłącz usługę systemową</translation>
-		</message>
-		<message>
-			<source>Disable Scheduled Task</source>
-			<translation>Wyłącz zaplanowane zadanie</translation>
-		</message>
-		<message>
-			<source>Resource Access Rule</source>
-			<translation>Reguła dostępu do zasobów</translation>
-		</message>
-		<message>
-			<source>Execution Control Rule</source>
-			<translation>Reguła kontroli uruchamiania</translation>
-		</message>
-		<message>
-			<source>Firewall Rule</source>
-			<translation>Reguła zapory</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznane</translation>
-		</message>
-		<message>
-			<source>Not set</source>
-			<translation>Nie ustawiono</translation>
-		</message>
-		<message>
-			<source>Applied</source>
-			<translation>Zastosowano</translation>
-		</message>
-		<message>
-			<source>Set</source>
-			<translation>Ustawione</translation>
-		</message>
-		<message>
-			<source>Missing</source>
-			<translation>Brak</translation>
-		</message>
-		<message>
-			<source>Ineffective</source>
-			<translation>Nieskuteczne</translation>
-		</message>
-		<message>
-			<source>Custom</source>
-			<translation>Niestandardowe</translation>
-		</message>
-		<message>
-			<source>Group</source>
-			<translation>Grupa</translation>
-		</message>
-		<message>
-			<source>Not available</source>
-			<translation>Niedostępne</translation>
-		</message>
-		<message>
-			<source>Recommended</source>
-			<translation>Zalecane</translation>
-		</message>
-		<message>
-			<source>Not recommended</source>
-			<translation>Niezalecane</translation>
-		</message>
-		<message>
-			<source>Breaking</source>
-			<translation>Krytyczne</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessListModel</name>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Last Access</source>
-			<translation>Ostatni dostęp</translation>
-		</message>
-		<message>
-			<source>Access</source>
-			<translation>Dostęp</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessListView</name>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatyczne rozwijanie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Last Access</source>
-			<translation>Ostatni dostęp</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessPage</name>
-		<message>
-			<source>Access Rules</source>
-			<translation>Reguły dostępu</translation>
-		</message>
-		<message>
-			<source>Open Resources</source>
-			<translation>Otwórz zasoby</translation>
-		</message>
-		<message>
-			<source>Access Monitor</source>
-			<translation>Monitor dostępu</translation>
-		</message>
-		<message>
-			<source>Trace Log</source>
-			<translation>Dziennik śledzenia</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessRule</name>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Allow Read-Only</source>
-			<translation>Zezwól tylko do odczytu</translation>
-		</message>
-		<message>
-			<source>Allow Listing</source>
-			<translation>Zezwól na listowanie</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Chroń</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Log</source>
-			<translation>Nie zapisuj w logu</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessRuleModel</name>
-		<message>
-			<source>%1 - %2</source>
-			<translation>%1 – %2</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Tak</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nie</translation>
-		</message>
-		<message>
-			<source> (Hidden)</source>
-			<translation> (Ukryte)</translation>
-		</message>
-		<message>
-			<source> (Temporary)</source>
-			<translation> (Tymczasowe)</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Włączone</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Akcja</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Ścieżka</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Włącz regułę</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Wyłącz regułę</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Usuń regułę</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Edytuj regułę</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Duplikuj regułę</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Utwórz regułę</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Wszystkie akcje</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Allow Read-Only</source>
-			<translation>Zezwól tylko do odczytu</translation>
-		</message>
-		<message>
-			<source>Allow Listing</source>
-			<translation>Zezwól na listowanie</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Chroń</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Log</source>
-			<translation>Nie zapisuj w logu</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Ukryj wyłączone reguły</translation>
-		</message>
-		<message>
-			<source>Show Hidden Rules</source>
-			<translation>Pokaż ukryte reguły</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Odśwież reguły</translation>
-		</message>
-		<message>
-			<source>Remove Temporary Rules</source>
-			<translation>Usuń tymczasowe reguły</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Czy chcesz usunąć zaznaczone reguły?</translation>
-		</message>
-		<message>
-			<source>Do you want to delete all Temporary Rules?</source>
-			<translation>Czy chcesz usunąć wszystkie tymczasowe reguły?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessRuleWnd</name>
-		<message>
-			<source>Create Program Rule</source>
-			<translation>Utwórz regułę programu</translation>
-		</message>
-		<message>
-			<source>Edit Program Rule</source>
-			<translation>Edytuj regułę programu</translation>
-		</message>
-		<message>
-			<source>New Access Rule</source>
-			<translation>Nowa reguła dostępu</translation>
-		</message>
-		<message>
-			<source>Global (Any/No Enclave)</source>
-			<translation>Globalna (dowolna/brak enklawy)</translation>
-		</message>
-		<message>
-			<source>Browse for Folder</source>
-			<translation>Przeglądaj folder</translation>
-		</message>
-		<message>
-			<source>Browse for File</source>
-			<translation>Przeglądaj plik</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Read Only</source>
-			<translation>Tylko do odczytu</translation>
-		</message>
-		<message>
-			<source>Directory Listing</source>
-			<translation>Listowanie katalogu</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Chroń</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Log</source>
-			<translation>Nie zapisuj w logu</translation>
-		</message>
-		<message>
-			<source>Select Directory</source>
-			<translation>Wybierz katalog</translation>
-		</message>
-		<message>
-			<source>Select File</source>
-			<translation>Wybierz plik</translation>
-		</message>
-		<message>
-			<source>The path must be contained within the volume.</source>
-			<translation>Ścieżka musi znajdować się wewnątrz woluminu.</translation>
-		</message>
-		<message>
-			<source>The sellected program type is not supported for this rule type</source>
-			<translation>Wybrany typ programu nie jest obsługiwany dla tego typu reguły</translation>
-		</message>
-		<message>
-			<source>%1 %2 %3</source>
-			<translation>%1 %2 %3</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessTraceModel</name>
-		<message>
-			<source>Unknown Program</source>
-			<translation>Nieznany program</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>PROGRAM MISSING</source>
-			<translation>BRAK PROGRAMU</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Ścieżka</translation>
-		</message>
-		<message>
-			<source>Operation</source>
-			<translation>Operacja</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Program (Actor)</source>
-			<translation>Program (Aktor)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessTraceView</name>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Auto Scroll</source>
-			<translation>Auto przewijanie</translation>
-		</message>
-		<message>
-			<source>Hold updates</source>
-			<translation>Wstrzymaj aktualizacje</translation>
-		</message>
-		<message>
-			<source>Clear Trace Log</source>
-			<translation>Wyczyść dziennik śledzenia</translation>
-		</message>
-	</context>
-	<context>
-		<name>CAccessView</name>
-		<message>
-			<source>Any Access</source>
-			<translation>Dowolny dostęp</translation>
-		</message>
-		<message>
-			<source>Read/Write</source>
-			<translation>Odczyt/zapis</translation>
-		</message>
-		<message>
-			<source>Write Only</source>
-			<translation>Tylko zapis</translation>
-		</message>
-		<message>
-			<source>Reload Access Tree</source>
-			<translation>Przeładuj drzewo dostępu</translation>
-		</message>
-		<message>
-			<source>CleanUp Access Tree</source>
-			<translation>Wyczyść drzewo dostępu</translation>
-		</message>
-		<message>
-			<source>Copy Path</source>
-			<translation>Kopiuj ścieżkę</translation>
-		</message>
-		<message>
-			<source>My Computer</source>
-			<translation>Mój komputer</translation>
-		</message>
-		<message>
-			<source>\\.\</source>
-			<translation>\\.\</translation>
-		</message>
-		<message>
-			<source>Registry</source>
-			<translation>Rejestr</translation>
-		</message>
-		<message>
-			<source>Network</source>
-			<translation>Sieć</translation>
-		</message>
-		<message>
-			<source>Loading %1</source>
-			<translation>Ładowanie %1</translation>
-		</message>
-		<message>
-			<source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
-			<translation>Czy chcesz wyczyścić drzewo dostępu? Spowoduje to usunięcie wszystkich plików i folderów, które nie są już obecne w systemie. Zostaną również usunięte odniesienia do plików i folderów znajdujących się na obecnie niezmontowanych woluminach. Operacja spróbuje uzyskać dostęp do wszystkich zapisanych lokalizacji i zajmie trochę czasu. Po zakończeniu widok zostanie odświeżony.</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsCacheEntry</name>
-		<message>
-			<source>UNKNOWN (%1)</source>
-			<translation>NIEZNANE (%1)</translation>
-		</message>
-		<message>
-			<source>Cached</source>
-			<translation>W pamięci podręcznej</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznane</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsCacheModel</name>
-		<message>
-			<source>Host name</source>
-			<translation>Nazwa hosta</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>TTL (sec)</source>
-			<translation>TTL (sek)</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Last seen</source>
-			<translation>Ostatnio widziany</translation>
-		</message>
-		<message>
-			<source>Counter</source>
-			<translation>Licznik</translation>
-		</message>
-		<message>
-			<source>Resolved data</source>
-			<translation>Rozwiązane dane</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsCacheView</name>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Cached</source>
-			<translation>W pamięci podręcznej</translation>
-		</message>
-		<message>
-			<source>Any Type</source>
-			<translation>Dowolny typ</translation>
-		</message>
-		<message>
-			<source>A or AAAA</source>
-			<translation>A lub AAAA</translation>
-		</message>
-		<message>
-			<source>A</source>
-			<translation>A</translation>
-		</message>
-		<message>
-			<source>AAAA</source>
-			<translation>AAAA</translation>
-		</message>
-		<message>
-			<source>CNAME</source>
-			<translation>CNAME</translation>
-		</message>
-		<message>
-			<source>MX</source>
-			<translation>MX</translation>
-		</message>
-		<message>
-			<source>PTR</source>
-			<translation>PTR</translation>
-		</message>
-		<message>
-			<source>SRV</source>
-			<translation>SRV</translation>
-		</message>
-		<message>
-			<source>TXT</source>
-			<translation>TXT</translation>
-		</message>
-		<message>
-			<source>WKS</source>
-			<translation>WKS</translation>
-		</message>
-		<message>
-			<source>Clear System DNS Cache</source>
-			<translation>Wyczyść systemową pamięć podręczną DNS</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsPage</name>
-		<message>
-			<source>Dns Rules</source>
-			<translation>Reguły DNS</translation>
-		</message>
-		<message>
-			<source>DnsCache</source>
-			<translation>Pamięć podręczna DNS</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsRule</name>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>None</source>
-			<translation>Brak</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsRuleModel</name>
-		<message>
-			<source>Yes</source>
-			<translation>Tak</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nie</translation>
-		</message>
-		<message>
-			<source> (Temporary)</source>
-			<translation> (Tymczasowe)</translation>
-		</message>
-		<message>
-			<source>Host Name</source>
-			<translation>Nazwa hosta</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Włączone</translation>
-		</message>
-		<message>
-			<source>Hit Count</source>
-			<translation>Liczba trafień</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Akcja</translation>
-		</message>
-	</context>
-	<context>
-		<name>CDnsRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Włącz regułę</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Wyłącz regułę</translation>
-		</message>
-		<message>
-			<source>Set Blocking</source>
-			<translation>Ustaw blokowanie</translation>
-		</message>
-		<message>
-			<source>Set Allowing</source>
-			<translation>Ustaw zezwalanie</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Usuń regułę</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Edytuj regułę</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Duplikuj regułę</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Utwórz regułę</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Wszystkie akcje</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Ukryj wyłączone reguły</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Odśwież reguły</translation>
-		</message>
-		<message>
-			<source>Edit Dns Rule</source>
-			<translation>Edytuj regułę DNS</translation>
-		</message>
-		<message>
-			<source>Enter Host Name</source>
-			<translation>Wprowadź nazwę hosta</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Czy chcesz usunąć zaznaczone reguły?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclave</name>
-		<message>
-			<source>Developer Signed</source>
-			<translation>Podpisane przez dewelopera</translation>
-		</message>
-		<message>
-			<source>User Signed</source>
-			<translation>Podpisane przez użytkownika</translation>
-		</message>
-		<message>
-			<source>Microsoft</source>
-			<translation>Microsoft</translation>
-		</message>
-		<message>
-			<source>Microsoft/AV</source>
-			<translation>Microsoft/Antywirus</translation>
-		</message>
-		<message>
-			<source>Microsoft Trusted</source>
-			<translation>Zaufane przez Microsoft</translation>
-		</message>
-		<message>
-			<source>Unknown Root</source>
-			<translation>Nieznany root</translation>
-		</message>
-		<message>
-			<source>None</source>
-			<translation>Brak</translation>
-		</message>
-		<message>
-			<source>Undetermined</source>
-			<translation>Nieustalone</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Eject</source>
-			<translation>Wyrzuć</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclaveManager</name>
-		<message>
-			<source>Major Privacy&apos;s Private Enclave</source>
-			<translation>Prywatna enklawa Major Privacy</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclaveModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>ID</source>
-			<translation>ID</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Poziom zaufania</translation>
-		</message>
-		<message>
-			<source>Trusted Spawn/UnTrusted</source>
-			<translation>Zaufane uruchomienie/Niezaufane</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclaveView</name>
-		<message>
-			<source>Run in Enclave</source>
-			<translation>Uruchom w enklawie</translation>
-		</message>
-		<message>
-			<source>Terminate All Processes</source>
-			<translation>Zakończ wszystkie procesy</translation>
-		</message>
-		<message>
-			<source>Delete Enclave</source>
-			<translation>Usuń enklawę</translation>
-		</message>
-		<message>
-			<source>Edit Enclave</source>
-			<translation>Edytuj enklawę</translation>
-		</message>
-		<message>
-			<source>Duplicate Enclave</source>
-			<translation>Duplikuj enklawę</translation>
-		</message>
-		<message>
-			<source>Create Enclave</source>
-			<translation>Utwórz enklawę</translation>
-		</message>
-		<message>
-			<source>Open Parent Folder</source>
-			<translation>Otwórz folder nadrzędny</translation>
-		</message>
-		<message>
-			<source>File Properties</source>
-			<translation>Właściwości pliku</translation>
-		</message>
-		<message>
-			<source>Terminate Process</source>
-			<translation>Zakończ proces</translation>
-		</message>
-		<message>
-			<source>%1 can&apos;t be edited!</source>
-			<translation>%1 nie może zostać edytowany!</translation>
-		</message>
-		<message>
-			<source>The process was ejected form the enclave, and is running unprotected, probably due to insuficient signature level!</source>
-			<translation>Proces został wyrzucony z enklawy i działa niezabezpieczony, prawdopodobnie z powodu niewystarczającego poziomu podpisu!</translation>
-		</message>
-		<message>
-			<source>Failed to start process!</source>
-			<translation>Nie udało się uruchomić procesu!</translation>
-		</message>
-		<message>
-			<source>Do you want to terminate all processes in the sellected enclaves?</source>
-			<translation>Czy chcesz zakończyć wszystkie procesy w wybranych enklawach?</translation>
-		</message>
-		<message>
-			<source>Terminate without asking</source>
-			<translation>Zakończ bez pytania</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Enclave?</source>
-			<translation>Czy chcesz usunąć wybraną enklawę?</translation>
-		</message>
-		<message>
-			<source>Do you want to terminate %1?</source>
-			<translation>Czy chcesz zakończyć %1?</translation>
-		</message>
-		<message>
-			<source>the selected processes</source>
-			<translation>wybrane procesy</translation>
-		</message>
-	</context>
-	<context>
-		<name>CEnclaveWnd</name>
-		<message>
-			<source>Change Icon</source>
-			<translation>Zmień ikonę</translation>
-		</message>
-		<message>
-			<source>Browse for Image</source>
-			<translation>Wybierz obraz</translation>
-		</message>
-		<message>
-			<source>Create Secure Enclave</source>
-			<translation>Utwórz bezpieczną enklawę</translation>
-		</message>
-		<message>
-			<source>Edit Secure Enclave</source>
-			<translation>Edytuj bezpieczną enklawę</translation>
-		</message>
-		<message>
-			<source>New Secure Enclave</source>
-			<translation>Nowa bezpieczna enklawa</translation>
-		</message>
-		<message>
-			<source>User Signature ONLY (not recommended)</source>
-			<translation>Tylko podpis użytkownika (niezalecane)</translation>
-		</message>
-		<message>
-			<source>User + Microsoft/AV Signature</source>
-			<translation>Użytkownik + podpis Microsoft/Antywirus</translation>
-		</message>
-		<message>
-			<source>User + Trusted by Microsoft (Code Root)</source>
-			<translation>Użytkownik + zaufany przez Microsoft (root kodu)</translation>
-		</message>
-		<message>
-			<source>Any Signature (Unknown Root)</source>
-			<translation>Dowolny podpis (nieznany root)</translation>
-		</message>
-		<message>
-			<source>No Signature</source>
-			<translation>Brak podpisu</translation>
-		</message>
-		<message>
-			<source>Allow Execution</source>
-			<translation>Zezwól na uruchamianie</translation>
-		</message>
-		<message>
-			<source>Eject from Secure Enclave</source>
-			<translation>Wyrzuć z bezpiecznej enklawy</translation>
-		</message>
-		<message>
-			<source>Prevent Execution</source>
-			<translation>Blokuj uruchamianie</translation>
-		</message>
-		<message>
-			<source>Don&apos;t change</source>
-			<translation>Nie zmieniaj</translation>
-		</message>
-		<message>
-			<source>Medium +</source>
-			<translation>Średni +</translation>
-		</message>
-		<message>
-			<source>High</source>
-			<translation>Wysoki</translation>
-		</message>
-		<message>
-			<source>System</source>
-			<translation>System</translation>
-		</message>
-		<message>
-			<source>Select Image File</source>
-			<translation>Wybierz plik obrazu</translation>
-		</message>
-		<message>
-			<source>Image Files (*.png)</source>
-			<translation>Pliki obrazów (*.png)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CExecutionModel</name>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Role</source>
-			<translation>Rola</translation>
-		</message>
-		<message>
-			<source>Last Status</source>
-			<translation>Ostatni status</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-	<context>
-		<name>CExecutionView</name>
-		<message>
-			<source>Any Role</source>
-			<translation>Dowolna rola</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Inicjator</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Cel</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Show entries per UPID</source>
-			<translation>Pokaż wpisy według UPID</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatyczne rozwijanie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CFirewallRuleWnd</name>
-		<message>
-			<source>Create Firewall Rule</source>
-			<translation>Utwórz regułę zapory</translation>
-		</message>
-		<message>
-			<source>Edit Firewall Rule</source>
-			<translation>Edytuj regułę zapory</translation>
-		</message>
-		<message>
-			<source>&amp;MP-Rule, New Firewall Rule</source>
-			<translation>&amp;MP-Reguła, nowa reguła zapory</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Bidirectional</source>
-			<translation>Dwukierunkowa</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Przychodząca</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Wychodząca</translation>
-		</message>
-		<message>
-			<source>Any Protocol</source>
-			<translation>Dowolny protokół</translation>
-		</message>
-		<message>
-			<source>[Add IP]</source>
-			<translation>[Dodaj IP]</translation>
-		</message>
-		<message>
-			<source>The sellected program type is not supported for this rule type</source>
-			<translation>Wybrany typ programu nie jest obsługiwany dla tego typu reguły</translation>
-		</message>
-		<message>
-			<source>All Types</source>
-			<translation>Wszystkie typy</translation>
-		</message>
-		<message>
-			<source>Invalid Sub Net</source>
-			<translation>Nieprawidłowa podsieć</translation>
-		</message>
-		<message>
-			<source>Invalid IP Address</source>
-			<translation>Nieprawidłowy adres IP</translation>
-		</message>
-		<message>
-			<source>Invalid IP Range</source>
-			<translation>Nieprawidłowy zakres IP</translation>
-		</message>
-		<message>
-			<source>%4, %1 %2 %3</source>
-			<translation>%4, %1 %2 %3</translation>
-		</message>
-	</context>
-	<context>
-		<name>CFwRule</name>
-		<message>
-			<source>All</source>
-			<translation>Wszystko</translation>
-		</message>
-		<message>
-			<source>Domain</source>
-			<translation>Domena</translation>
-		</message>
-		<message>
-			<source>Private</source>
-			<translation>Prywatna</translation>
-		</message>
-		<message>
-			<source>Public</source>
-			<translation>Publiczna</translation>
-		</message>
-		<message>
-			<source>Any</source>
-			<translation>Dowolna</translation>
-		</message>
-		<message>
-			<source>LAN</source>
-			<translation>LAN</translation>
-		</message>
-		<message>
-			<source>WiFi</source>
-			<translation>WiFi</translation>
-		</message>
-		<message>
-			<source>VPN</source>
-			<translation>VPN</translation>
-		</message>
-		<message>
-			<source>FromLog</source>
-			<translation>Z logu</translation>
-		</message>
-		<message>
-			<source>UnRuled</source>
-			<translation>Bez reguły</translation>
-		</message>
-		<message>
-			<source>Rule Allowed</source>
-			<translation>Reguła zezwala</translation>
-		</message>
-		<message>
-			<source>Rule Blocked</source>
-			<translation>Reguła blokuje</translation>
-		</message>
-		<message>
-			<source>Rule Error</source>
-			<translation>Błąd reguły</translation>
-		</message>
-		<message>
-			<source>Rule Generated</source>
-			<translation>Reguła wygenerowana</translation>
-		</message>
-		<message>
-			<source>Undefined</source>
-			<translation>Niezdefiniowane</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Przychodząca</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Wychodząca</translation>
-		</message>
-		<message>
-			<source>Bidirectional</source>
-			<translation>Dwukierunkowa</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznane</translation>
-		</message>
-	</context>
-	<context>
-		<name>CFwRuleModel</name>
-		<message>
-			<source>%1 - %2</source>
-			<translation>%1 – %2</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Tak</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nie</translation>
-		</message>
-		<message>
-			<source> (Temporary)</source>
-			<translation> (Tymczasowe)</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Grouping</source>
-			<translation>Grupowanie</translation>
-		</message>
-		<message>
-			<source>Index</source>
-			<translation>Indeks</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Włączone</translation>
-		</message>
-		<message>
-			<source>Hit Count</source>
-			<translation>Liczba trafień</translation>
-		</message>
-		<message>
-			<source>Profiles</source>
-			<translation>Profile</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Akcja</translation>
-		</message>
-		<message>
-			<source>Direction</source>
-			<translation>Kierunek</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokół</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Adres zdalny</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Adres lokalny</translation>
-		</message>
-		<message>
-			<source>Remote Ports</source>
-			<translation>Porty zdalne</translation>
-		</message>
-		<message>
-			<source>Local Ports</source>
-			<translation>Porty lokalne</translation>
-		</message>
-		<message>
-			<source>ICMP Options</source>
-			<translation>Opcje ICMP</translation>
-		</message>
-		<message>
-			<source>Interfaces</source>
-			<translation>Interfejsy</translation>
-		</message>
-		<message>
-			<source>Edge Traversal</source>
-			<translation>Przechodzenie przez brzeg sieci</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-	<context>
-		<name>CFwRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Włącz regułę</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Wyłącz regułę</translation>
-		</message>
-		<message>
-			<source>Set Blocking</source>
-			<translation>Ustaw jako blokującą</translation>
-		</message>
-		<message>
-			<source>Set Allowing</source>
-			<translation>Ustaw jako zezwalającą</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Usuń regułę</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Edytuj regułę</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Duplikuj regułę</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Utwórz regułę</translation>
-		</message>
-		<message>
-			<source>All Directions</source>
-			<translation>Wszystkie kierunki</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Przychodząca</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Wychodząca</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Wszystkie akcje</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Ukryj wyłączone reguły</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Odśwież reguły</translation>
-		</message>
-		<message>
-			<source>Remove Temporary Rules</source>
-			<translation>Usuń tymczasowe reguły</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Czy chcesz usunąć zaznaczone reguły?</translation>
-		</message>
-		<message>
-			<source>Do you want to delete all Temporary Rules?</source>
-			<translation>Czy chcesz usunąć wszystkie tymczasowe reguły?</translation>
-		</message>
-	</context>
-	<context>
-		<name>CGenericRule</name>
-		<message>
-			<source> (duplicate)</source>
-			<translation> (duplikat)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CHandleModel</name>
-		<message>
-			<source>PROCESS MISSING</source>
-			<translation>PROCES BRAK</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-	<context>
-		<name>CHomePage</name>
-		<message>
-			<source>Time Stamp|Type|Event|Message</source>
-			<translation>Znacznik czasu|Typ|Zdarzenie|Wiadomość</translation>
-		</message>
-		<message>
-			<source>Success</source>
-			<translation>Sukces</translation>
-		</message>
-		<message>
-			<source>Error</source>
-			<translation>Błąd</translation>
-		</message>
-		<message>
-			<source>Warning</source>
-			<translation>Ostrzeżenie</translation>
-		</message>
-		<message>
-			<source>Information</source>
-			<translation>Informacja</translation>
-		</message>
-		<message>
-			<source>Audit Success</source>
-			<translation>Audyt – sukces</translation>
-		</message>
-		<message>
-			<source>Audit Failure</source>
-			<translation>Audyt – niepowodzenie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CInfoView</name>
-		<message>
-			<source>Info</source>
-			<translation>Informacje</translation>
-		</message>
-		<message>
-			<source>Name: %1 (%2)</source>
-			<translation>Nazwa: %1 (%2)</translation>
-		</message>
-		<message>
-			<source>Path: %1</source>
-			<translation>Ścieżka: %1</translation>
-		</message>
-		<message>
-			<source>Groups (%1)</source>
-			<translation>Grupy (%1)</translation>
-		</message>
-		<message>
-			<source>Root (%1)</source>
-			<translation>Root (%1)</translation>
-		</message>
-		<message>
-			<source>%1 (%2)</source>
-			<translation>%1 (%2)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CIngressModel</name>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Role</source>
-			<translation>Rola</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Operation</source>
-			<translation>Operacja</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-	<context>
-		<name>CIngressView</name>
-		<message>
-			<source>Any Role</source>
-			<translation>Dowolna rola</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Inicjator</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Cel</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>All Operations</source>
-			<translation>Wszystkie operacje</translation>
-		</message>
-		<message>
-			<source>Control Execution</source>
-			<translation>Kontrola uruchamiania</translation>
-		</message>
-		<message>
-			<source>Change Permissions</source>
-			<translation>Zmień uprawnienia</translation>
-		</message>
-		<message>
-			<source>Write Memory</source>
-			<translation>Zapisz do pamięci</translation>
-		</message>
-		<message>
-			<source>Read Memory</source>
-			<translation>Odczytaj z pamięci</translation>
-		</message>
-		<message>
-			<source>Special Permissions</source>
-			<translation>Specjalne uprawnienia</translation>
-		</message>
-		<message>
-			<source>Write Properties</source>
-			<translation>Zapisz właściwości</translation>
-		</message>
-		<message>
-			<source>Read Properties</source>
-			<translation>Odczytaj właściwości</translation>
-		</message>
-		<message>
-			<source>Show Private Entries</source>
-			<translation>Pokaż wpisy prywatne</translation>
-		</message>
-		<message>
-			<source>Show entries per UPID</source>
-			<translation>Pokaż wpisy według UPID</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatyczne rozwijanie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CLibraryInfoView</name>
-		<message>
-			<source>Name|Signer|Valid|SHA1 Fingerprint|Certificate Fingerprint</source>
-			<translation>Nazwa|Podpisujący|Ważność|Odcisk SHA1|Odcisk certyfikatu</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Tak</translation>
-		</message>
-		<message>
-			<source>INVALID</source>
-			<translation>NIEWAŻNY</translation>
-		</message>
-		<message>
-			<source>Yes (Catalog)</source>
-			<translation>Tak (Katalog)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CLibraryModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Poziom zaufania</translation>
-		</message>
-		<message>
-			<source>Last Status</source>
-			<translation>Ostatni status</translation>
-		</message>
-		<message>
-			<source>Last Load</source>
-			<translation>Ostatnie załadowanie</translation>
-		</message>
-		<message>
-			<source>Count</source>
-			<translation>Liczba</translation>
-		</message>
-		<message>
-			<source>Signing Certificate</source>
-			<translation>Certyfikat podpisujący</translation>
-		</message>
-		<message>
-			<source>Module</source>
-			<translation>Moduł</translation>
-		</message>
-	</context>
-	<context>
-		<name>CLibraryView</name>
-		<message>
-			<source>Sign File</source>
-			<translation>Podpisz plik</translation>
-		</message>
-		<message>
-			<source>Remove File Signature</source>
-			<translation>Usuń podpis pliku</translation>
-		</message>
-		<message>
-			<source>Sign Certificate</source>
-			<translation>Podpisz certyfikat</translation>
-		</message>
-		<message>
-			<source>Remove Cert Signature</source>
-			<translation>Usuń podpis certyfikatu</translation>
-		</message>
-		<message>
-			<source>Open Parent Folder</source>
-			<translation>Otwórz folder nadrzędny</translation>
-		</message>
-		<message>
-			<source>File Properties</source>
-			<translation>Właściwości pliku</translation>
-		</message>
-		<message>
-			<source>By Program</source>
-			<translation>Według programu</translation>
-		</message>
-		<message>
-			<source>By Library</source>
-			<translation>Według biblioteki</translation>
-		</message>
-		<message>
-			<source>All Signatures</source>
-			<translation>Wszystkie podpisy</translation>
-		</message>
-		<message>
-			<source>User Sign. ONLY</source>
-			<translation>Tylko podpis użytkownika</translation>
-		</message>
-		<message>
-			<source>Microsoft/AV</source>
-			<translation>Microsoft/Antywirus</translation>
-		</message>
-		<message>
-			<source>Trusted by MSFT</source>
-			<translation>Zaufane przez Microsoft</translation>
-		</message>
-		<message>
-			<source>Untrusted/None</source>
-			<translation>Niezaufane/Brak</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Untrusted</source>
-			<translation>Niezaufane</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>CleanUp Libraries</source>
-			<translation>Wyczyść biblioteki</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatyczne rozwijanie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CMajorPrivacy</name>
-		<message>
-			<source>Starting ...</source>
-			<translation>Uruchamianie ...</translation>
-		</message>
-		<message>
-			<source>The driver configuration is corrupted, and could not be loaded, plrease restore from a backup.</source>
-			<translation>Konfiguracja sterownika jest uszkodzona i nie może zostać załadowana, przywróć ją z kopii zapasowej.</translation>
-		</message>
-		<message>
-			<source>The driver configuration is Untrusted (INVALID Signature, or Sequence). Do you want to load ir anyways?</source>
-			<translation>Konfiguracja sterownika jest niezaufana (NIEWAŻNY podpis lub sekwencja). Czy mimo to chcesz ją załadować?</translation>
-		</message>
-		<message>
-			<source>The Privacy Agent is not currently installed as a service. Would you like to install it now (Yes), run it without installation (No), or abort the connection attempt (Cancel)?</source>
-			<translation>Agent ochrony prywatności nie jest obecnie zainstalowany jako usługa. Czy chcesz go teraz zainstalować (Tak), uruchomić bez instalacji (Nie), czy przerwać próbę połączenia (Anuluj)?</translation>
-		</message>
-		<message>
-			<source>Remember this choice.</source>
-			<translation>Zapamiętaj ten wybór.</translation>
-		</message>
-		<message>
-			<source>Major Privacy will now attempt to start the Privacy Agent, please confirm the UAC prompt.</source>
-			<translation>Major Privacy spróbuje teraz uruchomić Agenta ochrony prywatności — potwierdź monit UAC.</translation>
-		</message>
-		<message>
-			<source>Privacy Agent Ready %1/%2</source>
-			<translation>Agent ochrony prywatności gotowy %1/%2</translation>
-		</message>
-		<message>
-			<source>Privacy Agent Failed: %1</source>
-			<translation>Błąd Agenta ochrony prywatności: %1</translation>
-		</message>
-		<message>
-			<source>Do you want to close Major Privacy?</source>
-			<translation>Czy chcesz zamknąć Major Privacy?</translation>
-		</message>
-		<message>
-			<source>Lost connection to Service, do you want to reconnect?</source>
-			<translation>Utracono połączenie z usługą — chcesz się ponownie połączyć?</translation>
-		</message>
-		<message>
-			<source>Mem Usage: %1 + %2 (Logs)</source>
-			<translation>Użycie pamięci: %1 + %2 (logi)</translation>
-		</message>
-		<message>
-			<source>Disconnected from privacy agent</source>
-			<translation>Odłączono od Agenta ochrony prywatności</translation>
-		</message>
-		<message>
-			<source>&amp;Maintenance</source>
-			<translation>&amp;Konserwacja</translation>
-		</message>
-		<message>
-			<source>Import Options</source>
-			<translation>Importuj opcje</translation>
-		</message>
-		<message>
-			<source>Export Options</source>
-			<translation>Eksportuj opcje</translation>
-		</message>
-		<message>
-			<source>&amp;Advanced</source>
-			<translation>&amp;Zaawansowane</translation>
-		</message>
-		<message>
-			<source>Connect</source>
-			<translation>Połącz</translation>
-		</message>
-		<message>
-			<source>Disconnect</source>
-			<translation>Rozłącz</translation>
-		</message>
-		<message>
-			<source>Install Services</source>
-			<translation>Zainstaluj usługi</translation>
-		</message>
-		<message>
-			<source>Remove Services</source>
-			<translation>Usuń usługi</translation>
-		</message>
-		<message>
-			<source>Open User Data Folder</source>
-			<translation>Otwórz folder danych użytkownika</translation>
-		</message>
-		<message>
-			<source>Open System Data Folder</source>
-			<translation>Otwórz folder danych systemowych</translation>
-		</message>
-		<message>
-			<source>Open *.dat Editor</source>
-			<translation>Otwórz edytor plików *.dat</translation>
-		</message>
-		<message>
-			<source>Exit</source>
-			<translation>Zakończ</translation>
-		</message>
-		<message>
-			<source>Toggle Program Tree</source>
-			<translation>Przełącz drzewo programów</translation>
-		</message>
-		<message>
-			<source>Stack Panels</source>
-			<translation>Panel w stosie</translation>
-		</message>
-		<message>
-			<source>Merge Panels</source>
-			<translation>Scalaj panele</translation>
-		</message>
-		<message>
-			<source>Separate Column Sets</source>
-			<translation>Oddziel zestawy kolumn</translation>
-		</message>
-		<message>
-			<source>Show Tab Labels</source>
-			<translation>Pokaż etykiety kart</translation>
-		</message>
-		<message>
-			<source>Always on Top</source>
-			<translation>Zawsze na wierzchu</translation>
-		</message>
-		<message>
-			<source>Add and Mount Volume Image</source>
-			<translation>Dodaj i zamontuj obraz woluminu</translation>
-		</message>
-		<message>
-			<source>Unmount All Volumes</source>
-			<translation>Odmontuj wszystkie woluminy</translation>
-		</message>
-		<message>
-			<source>Create Volume</source>
-			<translation>Utwórz wolumin</translation>
-		</message>
-		<message>
-			<source>Sign File</source>
-			<translation>Podpisz plik</translation>
-		</message>
-		<message>
-			<source>Signature Database</source>
-			<translation>Baza podpisów</translation>
-		</message>
-		<message>
-			<source>Unload Protection</source>
-			<translation>Wyłącz ochronę</translation>
-		</message>
-		<message>
-			<source>Enable Rule Protection</source>
-			<translation>Włącz ochronę reguł</translation>
-		</message>
-		<message>
-			<source>Disable Rules Protection</source>
-			<translation>Wyłącz ochronę reguł</translation>
-		</message>
-		<message>
-			<source>Setup User Key</source>
-			<translation>Utwórz klucz użytkownika</translation>
-		</message>
-		<message>
-			<source>Remove User Key</source>
-			<translation>Usuń klucz użytkownika</translation>
-		</message>
-		<message>
-			<source>CleanUp Program List</source>
-			<translation>Wyczyść listę programów</translation>
-		</message>
-		<message>
-			<source>Re-Group all Programs</source>
-			<translation>Przypisz ponownie programy do grup</translation>
-		</message>
-		<message>
-			<source>&amp;Advanced Tools</source>
-			<translation>&amp;Narzędzia zaawansowane</translation>
-		</message>
-		<message>
-			<source>Mount Manager</source>
-			<translation>Menedżer montowania</translation>
-		</message>
-		<message>
-			<source>Virtual Disks</source>
-			<translation>Dyski wirtualne</translation>
-		</message>
-		<message>
-			<source>Clear All Trace Logs</source>
-			<translation>Wyczyść wszystkie dzienniki śledzenia</translation>
-		</message>
-		<message>
-			<source>Settings</source>
-			<translation>Ustawienia</translation>
-		</message>
-		<message>
-			<source>Unlock Config</source>
-			<translation>Odblokuj konfigurację</translation>
-		</message>
-		<message>
-			<source>Commit Changes</source>
-			<translation>Zatwierdź zmiany</translation>
-		</message>
-		<message>
-			<source>Discard Changes</source>
-			<translation>Odrzuć zmiany</translation>
-		</message>
-		<message>
-			<source>Clear Ignore List</source>
-			<translation>Wyczyść listę ignorowanych</translation>
-		</message>
-		<message>
-			<source>Reset All Prompts</source>
-			<translation>Zresetuj wszystkie monity</translation>
-		</message>
-		<message>
-			<source>&amp;Help</source>
-			<translation>&amp;Pomoc</translation>
-		</message>
-		<message>
-			<source>Visit Support Forum</source>
-			<translation>Odwiedź forum pomocy</translation>
-		</message>
-		<message>
-			<source>About the Qt Framework</source>
-			<translation>O środowisku Qt</translation>
-		</message>
-		<message>
-			<source>About MajorPrivacy</source>
-			<translation>O MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>System Overview</source>
-			<translation>Podgląd systemu</translation>
-		</message>
-		<message>
-			<source>Process Security</source>
-			<translation>Bezpieczeństwo procesów</translation>
-		</message>
-		<message>
-			<source>Secure Enclaves</source>
-			<translation>Bezpieczne enklawy</translation>
-		</message>
-		<message>
-			<source>Resource Protection</source>
-			<translation>Ochrona zasobów</translation>
-		</message>
-		<message>
-			<source>Secure Volumes</source>
-			<translation>Bezpieczne woluminy</translation>
-		</message>
-		<message>
-			<source>Network Firewall</source>
-			<translation>Zapor sieciowa</translation>
-		</message>
-		<message>
-			<source>DNS Filtering</source>
-			<translation>Filtrowanie DNS</translation>
-		</message>
-		<message>
-			<source>Privacy Tweaks</source>
-			<translation>Dostosowania prywatności</translation>
-		</message>
-		<message>
-			<source>Set Time Filter</source>
-			<translation>Ustaw filtr czasu</translation>
-		</message>
-		<message>
-			<source>Any time</source>
-			<translation>Dowolny czas</translation>
-		</message>
-		<message>
-			<source>Last 5 Seconds</source>
-			<translation>Ostatnie 5 sekund</translation>
-		</message>
-		<message>
-			<source>Last 10 Seconds</source>
-			<translation>Ostatnie 10 sekund</translation>
-		</message>
-		<message>
-			<source>Last 30 Seconds</source>
-			<translation>Ostatnie 30 sekund</translation>
-		</message>
-		<message>
-			<source>Last Minute</source>
-			<translation>Ostatnia minuta</translation>
-		</message>
-		<message>
-			<source>Last 3 Minutes</source>
-			<translation>Ostatnie 3 minuty</translation>
-		</message>
-		<message>
-			<source>Last 5 Minutes</source>
-			<translation>Ostatnie 5 minut</translation>
-		</message>
-		<message>
-			<source>Last 15 Minutes</source>
-			<translation>Ostatnie 15 minut</translation>
-		</message>
-		<message>
-			<source>Last 30 Minutes</source>
-			<translation>Ostatnie 30 minut</translation>
-		</message>
-		<message>
-			<source>Last Hour</source>
-			<translation>Ostatnia godzina</translation>
-		</message>
-		<message>
-			<source>Last 3 Hours</source>
-			<translation>Ostatnie 3 godziny</translation>
-		</message>
-		<message>
-			<source>Last 12 Hours</source>
-			<translation>Ostatnie 12 godzin</translation>
-		</message>
-		<message>
-			<source>Last 24 Hours</source>
-			<translation>Ostatnie 24 godziny</translation>
-		</message>
-		<message>
-			<source>Last 48 Hours</source>
-			<translation>Ostatnie 48 godzin</translation>
-		</message>
-		<message>
-			<source>Last Week</source>
-			<translation>Ostatni tydzień</translation>
-		</message>
-		<message>
-			<source>Last 2 Weeks</source>
-			<translation>Ostatnie 2 tygodnie</translation>
-		</message>
-		<message>
-			<source>Last Month</source>
-			<translation>Ostatni miesiąc</translation>
-		</message>
-		<message>
-			<source>Show/Hide</source>
-			<translation>Pokaż/Ukryj</translation>
-		</message>
-		<message>
-			<source>Process Protection Popups</source>
-			<translation>Monity ochrony procesów</translation>
-		</message>
-		<message>
-			<source>Resource Access Popups</source>
-			<translation>Monity dostępu do zasobów</translation>
-		</message>
-		<message>
-			<source>Network Firewall Popups</source>
-			<translation>Monity zapory sieciowej</translation>
-		</message>
-		<message>
-			<source>Firewall Profile</source>
-			<translation>Profil zapory</translation>
-		</message>
-		<message>
-			<source>Use Allow List</source>
-			<translation>Użyj listy dozwolonych</translation>
-		</message>
-		<message>
-			<source>Use Block List</source>
-			<translation>Użyj listy zablokowanych</translation>
-		</message>
-		<message>
-			<source>Disabled Firewall</source>
-			<translation>Zapora wyłączona</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to sign a file</source>
-			<translation>Wprowadź hasło konfiguracji zabezpieczeń, aby podpisać plik</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to sign a certificate</source>
-			<translation>Wprowadź hasło konfiguracji zabezpieczeń, aby podpisać certyfikat</translation>
-		</message>
-		<message>
-			<source>
+<TS version="2.1" language="pl_PL">
+<context>
+    <name>AccessRuleWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formularz</translation>
+    </message>
+    <message>
+        <source>Access Rule Identity</source>
+        <translation>Tożsamość reguły dostępu</translation>
+    </message>
+    <message>
+        <source>Description...</source>
+        <translation>Opis...</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Path Pattern</source>
+        <translation>Wzorzec ścieżki</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Path &amp;&amp; Action</source>
+        <translation>Ścieżka i akcja</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Akcja</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Ścieżka</translation>
+    </message>
+</context>
+<context>
+    <name>CAbstractTweak</name>
+    <message>
+        <source>Tweak Group</source>
+        <translation>Grupa ustawień</translation>
+    </message>
+    <message>
+        <source>Tweak Bundle</source>
+        <translation>Zestaw ustawień</translation>
+    </message>
+    <message>
+        <source>Set Registry Option</source>
+        <translation>Ustaw opcję rejestru</translation>
+    </message>
+    <message>
+        <source>Configure Group Policy</source>
+        <translation>Skonfiguruj zasady grupy</translation>
+    </message>
+    <message>
+        <source>Disable System Service</source>
+        <translation>Wyłącz usługę systemową</translation>
+    </message>
+    <message>
+        <source>Disable Scheduled Task</source>
+        <translation>Wyłącz zaplanowane zadanie</translation>
+    </message>
+    <message>
+        <source>Resource Access Rule</source>
+        <translation>Reguła dostępu do zasobów</translation>
+    </message>
+    <message>
+        <source>Execution Control Rule</source>
+        <translation>Reguła kontroli uruchamiania</translation>
+    </message>
+    <message>
+        <source>Firewall Rule</source>
+        <translation>Reguła zapory</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznane</translation>
+    </message>
+    <message>
+        <source>Not set</source>
+        <translation>Nie ustawiono</translation>
+    </message>
+    <message>
+        <source>Applied</source>
+        <translation>Zastosowano</translation>
+    </message>
+    <message>
+        <source>Set</source>
+        <translation>Ustawione</translation>
+    </message>
+    <message>
+        <source>Missing</source>
+        <translation>Brak</translation>
+    </message>
+    <message>
+        <source>Ineffective</source>
+        <translation>Nieskuteczne</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>Niestandardowe</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Grupa</translation>
+    </message>
+    <message>
+        <source>Not available</source>
+        <translation>Niedostępne</translation>
+    </message>
+    <message>
+        <source>Recommended</source>
+        <translation>Zalecane</translation>
+    </message>
+    <message>
+        <source>Not recommended</source>
+        <translation>Niezalecane</translation>
+    </message>
+    <message>
+        <source>Breaking</source>
+        <translation>Krytyczne</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessListModel</name>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Last Access</source>
+        <translation>Ostatni dostęp</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>Dostęp</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessListView</name>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatyczne rozwijanie</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Last Access</source>
+        <translation>Ostatni dostęp</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessPage</name>
+    <message>
+        <source>Access Rules</source>
+        <translation>Reguły dostępu</translation>
+    </message>
+    <message>
+        <source>Open Resources</source>
+        <translation>Otwórz zasoby</translation>
+    </message>
+    <message>
+        <source>Access Monitor</source>
+        <translation>Monitor dostępu</translation>
+    </message>
+    <message>
+        <source>Trace Log</source>
+        <translation>Dziennik śledzenia</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRule</name>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Allow Read-Only</source>
+        <translation>Zezwól tylko do odczytu</translation>
+    </message>
+    <message>
+        <source>Allow Listing</source>
+        <translation>Zezwól na listowanie</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Chroń</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Log</source>
+        <translation>Nie zapisuj w logu</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRuleModel</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation>%1 – %2</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Tak</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <source> (Hidden)</source>
+        <translation> (Ukryte)</translation>
+    </message>
+    <message>
+        <source> (Temporary)</source>
+        <translation> (Tymczasowe)</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Włączone</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Akcja</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Ścieżka</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Włącz regułę</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Wyłącz regułę</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Usuń regułę</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Edytuj regułę</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Duplikuj regułę</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Utwórz regułę</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Wszystkie akcje</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Allow Read-Only</source>
+        <translation>Zezwól tylko do odczytu</translation>
+    </message>
+    <message>
+        <source>Allow Listing</source>
+        <translation>Zezwól na listowanie</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Chroń</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Log</source>
+        <translation>Nie zapisuj w logu</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Ukryj wyłączone reguły</translation>
+    </message>
+    <message>
+        <source>Show Hidden Rules</source>
+        <translation>Pokaż ukryte reguły</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Odśwież reguły</translation>
+    </message>
+    <message>
+        <source>Remove Temporary Rules</source>
+        <translation>Usuń tymczasowe reguły</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Czy chcesz usunąć zaznaczone reguły?</translation>
+    </message>
+    <message>
+        <source>Do you want to delete all Temporary Rules?</source>
+        <translation>Czy chcesz usunąć wszystkie tymczasowe reguły?</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessRuleWnd</name>
+    <message>
+        <source>Create Program Rule</source>
+        <translation>Utwórz regułę programu</translation>
+    </message>
+    <message>
+        <source>Edit Program Rule</source>
+        <translation>Edytuj regułę programu</translation>
+    </message>
+    <message>
+        <source>New Access Rule</source>
+        <translation>Nowa reguła dostępu</translation>
+    </message>
+    <message>
+        <source>Global (Any/No Enclave)</source>
+        <translation>Globalna (dowolna/brak enklawy)</translation>
+    </message>
+    <message>
+        <source>Browse for Folder</source>
+        <translation>Przeglądaj folder</translation>
+    </message>
+    <message>
+        <source>Browse for File</source>
+        <translation>Przeglądaj plik</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Read Only</source>
+        <translation>Tylko do odczytu</translation>
+    </message>
+    <message>
+        <source>Directory Listing</source>
+        <translation>Listowanie katalogu</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Chroń</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Log</source>
+        <translation>Nie zapisuj w logu</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>Wybierz katalog</translation>
+    </message>
+    <message>
+        <source>Select File</source>
+        <translation>Wybierz plik</translation>
+    </message>
+    <message>
+        <source>The path must be contained within the volume.</source>
+        <translation>Ścieżka musi znajdować się wewnątrz woluminu.</translation>
+    </message>
+    <message>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Wybrany typ programu nie jest obsługiwany dla tego typu reguły</translation>
+    </message>
+    <message>
+        <source>%1 %2 %3</source>
+        <translation>%1 %2 %3</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessTraceModel</name>
+    <message>
+        <source>Unknown Program</source>
+        <translation>Nieznany program</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>PROGRAM MISSING</source>
+        <translation>BRAK PROGRAMU</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Ścieżka</translation>
+    </message>
+    <message>
+        <source>Operation</source>
+        <translation>Operacja</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Program (Actor)</source>
+        <translation>Program (Aktor)</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessTraceView</name>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Auto Scroll</source>
+        <translation>Auto przewijanie</translation>
+    </message>
+    <message>
+        <source>Hold updates</source>
+        <translation>Wstrzymaj aktualizacje</translation>
+    </message>
+    <message>
+        <source>Clear Trace Log</source>
+        <translation>Wyczyść dziennik śledzenia</translation>
+    </message>
+</context>
+<context>
+    <name>CAccessView</name>
+    <message>
+        <source>Any Access</source>
+        <translation>Dowolny dostęp</translation>
+    </message>
+    <message>
+        <source>Read/Write</source>
+        <translation>Odczyt/zapis</translation>
+    </message>
+    <message>
+        <source>Write Only</source>
+        <translation>Tylko zapis</translation>
+    </message>
+    <message>
+        <source>Reload Access Tree</source>
+        <translation>Przeładuj drzewo dostępu</translation>
+    </message>
+    <message>
+        <source>CleanUp Access Tree</source>
+        <translation>Wyczyść drzewo dostępu</translation>
+    </message>
+    <message>
+        <source>Copy Path</source>
+        <translation>Kopiuj ścieżkę</translation>
+    </message>
+    <message>
+        <source>My Computer</source>
+        <translation>Mój komputer</translation>
+    </message>
+    <message>
+        <source>\\.\</source>
+        <translation>\\.\</translation>
+    </message>
+    <message>
+        <source>Registry</source>
+        <translation>Rejestr</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>Sieć</translation>
+    </message>
+    <message>
+        <source>Loading %1</source>
+        <translation>Ładowanie %1</translation>
+    </message>
+    <message>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <translation>Czy chcesz wyczyścić drzewo dostępu? Spowoduje to usunięcie wszystkich plików i folderów, które nie są już obecne w systemie. Zostaną również usunięte odniesienia do plików i folderów znajdujących się na obecnie niezmontowanych woluminach. Operacja spróbuje uzyskać dostęp do wszystkich zapisanych lokalizacji i zajmie trochę czasu. Po zakończeniu widok zostanie odświeżony.</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsCacheEntry</name>
+    <message>
+        <source>UNKNOWN (%1)</source>
+        <translation>NIEZNANE (%1)</translation>
+    </message>
+    <message>
+        <source>Cached</source>
+        <translation>W pamięci podręcznej</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznane</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsCacheModel</name>
+    <message>
+        <source>Host name</source>
+        <translation>Nazwa hosta</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>TTL (sec)</source>
+        <translation>TTL (sek)</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Last seen</source>
+        <translation>Ostatnio widziany</translation>
+    </message>
+    <message>
+        <source>Counter</source>
+        <translation>Licznik</translation>
+    </message>
+    <message>
+        <source>Resolved data</source>
+        <translation>Rozwiązane dane</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsCacheView</name>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Cached</source>
+        <translation>W pamięci podręcznej</translation>
+    </message>
+    <message>
+        <source>Any Type</source>
+        <translation>Dowolny typ</translation>
+    </message>
+    <message>
+        <source>A or AAAA</source>
+        <translation>A lub AAAA</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <source>AAAA</source>
+        <translation>AAAA</translation>
+    </message>
+    <message>
+        <source>CNAME</source>
+        <translation>CNAME</translation>
+    </message>
+    <message>
+        <source>MX</source>
+        <translation>MX</translation>
+    </message>
+    <message>
+        <source>PTR</source>
+        <translation>PTR</translation>
+    </message>
+    <message>
+        <source>SRV</source>
+        <translation>SRV</translation>
+    </message>
+    <message>
+        <source>TXT</source>
+        <translation>TXT</translation>
+    </message>
+    <message>
+        <source>WKS</source>
+        <translation>WKS</translation>
+    </message>
+    <message>
+        <source>Clear System DNS Cache</source>
+        <translation>Wyczyść systemową pamięć podręczną DNS</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsPage</name>
+    <message>
+        <source>Dns Rules</source>
+        <translation>Reguły DNS</translation>
+    </message>
+    <message>
+        <source>DnsCache</source>
+        <translation>Pamięć podręczna DNS</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsRule</name>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Brak</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsRuleModel</name>
+    <message>
+        <source>Yes</source>
+        <translation>Tak</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <source> (Temporary)</source>
+        <translation> (Tymczasowe)</translation>
+    </message>
+    <message>
+        <source>Host Name</source>
+        <translation>Nazwa hosta</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Włączone</translation>
+    </message>
+    <message>
+        <source>Hit Count</source>
+        <translation>Liczba trafień</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Akcja</translation>
+    </message>
+</context>
+<context>
+    <name>CDnsRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Włącz regułę</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Wyłącz regułę</translation>
+    </message>
+    <message>
+        <source>Set Blocking</source>
+        <translation>Ustaw blokowanie</translation>
+    </message>
+    <message>
+        <source>Set Allowing</source>
+        <translation>Ustaw zezwalanie</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Usuń regułę</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Edytuj regułę</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Duplikuj regułę</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Utwórz regułę</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Wszystkie akcje</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Ukryj wyłączone reguły</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Odśwież reguły</translation>
+    </message>
+    <message>
+        <source>Edit Dns Rule</source>
+        <translation>Edytuj regułę DNS</translation>
+    </message>
+    <message>
+        <source>Enter Host Name</source>
+        <translation>Wprowadź nazwę hosta</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Czy chcesz usunąć zaznaczone reguły?</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclave</name>
+    <message>
+        <source>Developer Signed</source>
+        <translation>Podpisane przez dewelopera</translation>
+    </message>
+    <message>
+        <source>User Signed</source>
+        <translation>Podpisane przez użytkownika</translation>
+    </message>
+    <message>
+        <source>Microsoft</source>
+        <translation>Microsoft</translation>
+    </message>
+    <message>
+        <source>Microsoft/AV</source>
+        <translation>Microsoft/Antywirus</translation>
+    </message>
+    <message>
+        <source>Microsoft Trusted</source>
+        <translation>Zaufane przez Microsoft</translation>
+    </message>
+    <message>
+        <source>Unknown Root</source>
+        <translation>Nieznany root</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Brak</translation>
+    </message>
+    <message>
+        <source>Undetermined</source>
+        <translation>Nieustalone</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Eject</source>
+        <translation>Wyrzuć</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveManager</name>
+    <message>
+        <source>Major Privacy&apos;s Private Enclave</source>
+        <translation>Prywatna enklawa Major Privacy</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Poziom zaufania</translation>
+    </message>
+    <message>
+        <source>Trusted Spawn/UnTrusted</source>
+        <translation>Zaufane uruchomienie/Niezaufane</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveView</name>
+    <message>
+        <source>Run in Enclave</source>
+        <translation>Uruchom w enklawie</translation>
+    </message>
+    <message>
+        <source>Terminate All Processes</source>
+        <translation>Zakończ wszystkie procesy</translation>
+    </message>
+    <message>
+        <source>Delete Enclave</source>
+        <translation>Usuń enklawę</translation>
+    </message>
+    <message>
+        <source>Edit Enclave</source>
+        <translation>Edytuj enklawę</translation>
+    </message>
+    <message>
+        <source>Duplicate Enclave</source>
+        <translation>Duplikuj enklawę</translation>
+    </message>
+    <message>
+        <source>Create Enclave</source>
+        <translation>Utwórz enklawę</translation>
+    </message>
+    <message>
+        <source>Open Parent Folder</source>
+        <translation>Otwórz folder nadrzędny</translation>
+    </message>
+    <message>
+        <source>File Properties</source>
+        <translation>Właściwości pliku</translation>
+    </message>
+    <message>
+        <source>Terminate Process</source>
+        <translation>Zakończ proces</translation>
+    </message>
+    <message>
+        <source>%1 can&apos;t be edited!</source>
+        <translation>%1 nie może zostać edytowany!</translation>
+    </message>
+    <message>
+        <source>The process was ejected form the enclave, and is running unprotected, probably due to insuficient signature level!</source>
+        <translation>Proces został wyrzucony z enklawy i działa niezabezpieczony, prawdopodobnie z powodu niewystarczającego poziomu podpisu!</translation>
+    </message>
+    <message>
+        <source>Failed to start process!</source>
+        <translation>Nie udało się uruchomić procesu!</translation>
+    </message>
+    <message>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
+        <translation>Czy chcesz zakończyć wszystkie procesy w wybranych enklawach?</translation>
+    </message>
+    <message>
+        <source>Terminate without asking</source>
+        <translation>Zakończ bez pytania</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Enclave?</source>
+        <translation>Czy chcesz usunąć wybraną enklawę?</translation>
+    </message>
+    <message>
+        <source>Do you want to terminate %1?</source>
+        <translation>Czy chcesz zakończyć %1?</translation>
+    </message>
+    <message>
+        <source>the selected processes</source>
+        <translation>wybrane procesy</translation>
+    </message>
+</context>
+<context>
+    <name>CEnclaveWnd</name>
+    <message>
+        <source>Change Icon</source>
+        <translation>Zmień ikonę</translation>
+    </message>
+    <message>
+        <source>Browse for Image</source>
+        <translation>Wybierz obraz</translation>
+    </message>
+    <message>
+        <source>Create Secure Enclave</source>
+        <translation>Utwórz bezpieczną enklawę</translation>
+    </message>
+    <message>
+        <source>Edit Secure Enclave</source>
+        <translation>Edytuj bezpieczną enklawę</translation>
+    </message>
+    <message>
+        <source>New Secure Enclave</source>
+        <translation>Nowa bezpieczna enklawa</translation>
+    </message>
+    <message>
+        <source>User Signature ONLY (not recommended)</source>
+        <translation>Tylko podpis użytkownika (niezalecane)</translation>
+    </message>
+    <message>
+        <source>User + Microsoft/AV Signature</source>
+        <translation>Użytkownik + podpis Microsoft/Antywirus</translation>
+    </message>
+    <message>
+        <source>User + Trusted by Microsoft (Code Root)</source>
+        <translation>Użytkownik + zaufany przez Microsoft (root kodu)</translation>
+    </message>
+    <message>
+        <source>Any Signature (Unknown Root)</source>
+        <translation>Dowolny podpis (nieznany root)</translation>
+    </message>
+    <message>
+        <source>No Signature</source>
+        <translation>Brak podpisu</translation>
+    </message>
+    <message>
+        <source>Allow Execution</source>
+        <translation>Zezwól na uruchamianie</translation>
+    </message>
+    <message>
+        <source>Eject from Secure Enclave</source>
+        <translation>Wyrzuć z bezpiecznej enklawy</translation>
+    </message>
+    <message>
+        <source>Prevent Execution</source>
+        <translation>Blokuj uruchamianie</translation>
+    </message>
+    <message>
+        <source>Don&apos;t change</source>
+        <translation>Nie zmieniaj</translation>
+    </message>
+    <message>
+        <source>Medium +</source>
+        <translation>Średni +</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Wysoki</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Select Image File</source>
+        <translation>Wybierz plik obrazu</translation>
+    </message>
+    <message>
+        <source>Image Files (*.png)</source>
+        <translation>Pliki obrazów (*.png)</translation>
+    </message>
+</context>
+<context>
+    <name>CExecutionModel</name>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rola</translation>
+    </message>
+    <message>
+        <source>Last Status</source>
+        <translation>Ostatni status</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CExecutionView</name>
+    <message>
+        <source>Any Role</source>
+        <translation>Dowolna rola</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Inicjator</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Cel</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Show entries per UPID</source>
+        <translation>Pokaż wpisy według UPID</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatyczne rozwijanie</translation>
+    </message>
+</context>
+<context>
+    <name>CFirewallRuleWnd</name>
+    <message>
+        <source>Create Firewall Rule</source>
+        <translation>Utwórz regułę zapory</translation>
+    </message>
+    <message>
+        <source>Edit Firewall Rule</source>
+        <translation>Edytuj regułę zapory</translation>
+    </message>
+    <message>
+        <source>&amp;MP-Rule, New Firewall Rule</source>
+        <translation>&amp;MP-Reguła, nowa reguła zapory</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Bidirectional</source>
+        <translation>Dwukierunkowa</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Przychodząca</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Wychodząca</translation>
+    </message>
+    <message>
+        <source>Any Protocol</source>
+        <translation>Dowolny protokół</translation>
+    </message>
+    <message>
+        <source>[Add IP]</source>
+        <translation>[Dodaj IP]</translation>
+    </message>
+    <message>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Wybrany typ programu nie jest obsługiwany dla tego typu reguły</translation>
+    </message>
+    <message>
+        <source>All Types</source>
+        <translation>Wszystkie typy</translation>
+    </message>
+    <message>
+        <source>Invalid Sub Net</source>
+        <translation>Nieprawidłowa podsieć</translation>
+    </message>
+    <message>
+        <source>Invalid IP Address</source>
+        <translation>Nieprawidłowy adres IP</translation>
+    </message>
+    <message>
+        <source>Invalid IP Range</source>
+        <translation>Nieprawidłowy zakres IP</translation>
+    </message>
+    <message>
+        <source>%4, %1 %2 %3</source>
+        <translation>%4, %1 %2 %3</translation>
+    </message>
+</context>
+<context>
+    <name>CFwRule</name>
+    <message>
+        <source>All</source>
+        <translation>Wszystko</translation>
+    </message>
+    <message>
+        <source>Domain</source>
+        <translation>Domena</translation>
+    </message>
+    <message>
+        <source>Private</source>
+        <translation>Prywatna</translation>
+    </message>
+    <message>
+        <source>Public</source>
+        <translation>Publiczna</translation>
+    </message>
+    <message>
+        <source>Any</source>
+        <translation>Dowolna</translation>
+    </message>
+    <message>
+        <source>LAN</source>
+        <translation>LAN</translation>
+    </message>
+    <message>
+        <source>WiFi</source>
+        <translation>WiFi</translation>
+    </message>
+    <message>
+        <source>VPN</source>
+        <translation>VPN</translation>
+    </message>
+    <message>
+        <source>FromLog</source>
+        <translation>Z logu</translation>
+    </message>
+    <message>
+        <source>UnRuled</source>
+        <translation>Bez reguły</translation>
+    </message>
+    <message>
+        <source>Rule Allowed</source>
+        <translation>Reguła zezwala</translation>
+    </message>
+    <message>
+        <source>Rule Blocked</source>
+        <translation>Reguła blokuje</translation>
+    </message>
+    <message>
+        <source>Rule Error</source>
+        <translation>Błąd reguły</translation>
+    </message>
+    <message>
+        <source>Rule Generated</source>
+        <translation>Reguła wygenerowana</translation>
+    </message>
+    <message>
+        <source>Undefined</source>
+        <translation>Niezdefiniowane</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Przychodząca</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Wychodząca</translation>
+    </message>
+    <message>
+        <source>Bidirectional</source>
+        <translation>Dwukierunkowa</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznane</translation>
+    </message>
+</context>
+<context>
+    <name>CFwRuleModel</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation>%1 – %2</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Tak</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <source> (Temporary)</source>
+        <translation> (Tymczasowe)</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Grouping</source>
+        <translation>Grupowanie</translation>
+    </message>
+    <message>
+        <source>Index</source>
+        <translation>Indeks</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Włączone</translation>
+    </message>
+    <message>
+        <source>Hit Count</source>
+        <translation>Liczba trafień</translation>
+    </message>
+    <message>
+        <source>Profiles</source>
+        <translation>Profile</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Akcja</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Kierunek</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokół</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Adres zdalny</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Adres lokalny</translation>
+    </message>
+    <message>
+        <source>Remote Ports</source>
+        <translation>Porty zdalne</translation>
+    </message>
+    <message>
+        <source>Local Ports</source>
+        <translation>Porty lokalne</translation>
+    </message>
+    <message>
+        <source>ICMP Options</source>
+        <translation>Opcje ICMP</translation>
+    </message>
+    <message>
+        <source>Interfaces</source>
+        <translation>Interfejsy</translation>
+    </message>
+    <message>
+        <source>Edge Traversal</source>
+        <translation>Przechodzenie przez brzeg sieci</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CFwRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Włącz regułę</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Wyłącz regułę</translation>
+    </message>
+    <message>
+        <source>Set Blocking</source>
+        <translation>Ustaw jako blokującą</translation>
+    </message>
+    <message>
+        <source>Set Allowing</source>
+        <translation>Ustaw jako zezwalającą</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Usuń regułę</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Edytuj regułę</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Duplikuj regułę</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Utwórz regułę</translation>
+    </message>
+    <message>
+        <source>All Directions</source>
+        <translation>Wszystkie kierunki</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Przychodząca</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Wychodząca</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Wszystkie akcje</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Ukryj wyłączone reguły</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Odśwież reguły</translation>
+    </message>
+    <message>
+        <source>Remove Temporary Rules</source>
+        <translation>Usuń tymczasowe reguły</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Czy chcesz usunąć zaznaczone reguły?</translation>
+    </message>
+    <message>
+        <source>Do you want to delete all Temporary Rules?</source>
+        <translation>Czy chcesz usunąć wszystkie tymczasowe reguły?</translation>
+    </message>
+</context>
+<context>
+    <name>CGenericRule</name>
+    <message>
+        <source> (duplicate)</source>
+        <translation> (duplikat)</translation>
+    </message>
+</context>
+<context>
+    <name>CHandleModel</name>
+    <message>
+        <source>PROCESS MISSING</source>
+        <translation>PROCES BRAK</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CHomePage</name>
+    <message>
+        <source>Time Stamp|Type|Event|Message</source>
+        <translation>Znacznik czasu|Typ|Zdarzenie|Wiadomość</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation>Sukces</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Ostrzeżenie</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>Informacja</translation>
+    </message>
+    <message>
+        <source>Audit Success</source>
+        <translation>Audyt – sukces</translation>
+    </message>
+    <message>
+        <source>Audit Failure</source>
+        <translation>Audyt – niepowodzenie</translation>
+    </message>
+</context>
+<context>
+    <name>CInfoView</name>
+    <message>
+        <source>Info</source>
+        <translation>Informacje</translation>
+    </message>
+    <message>
+        <source>Name: %1 (%2)</source>
+        <translation>Nazwa: %1 (%2)</translation>
+    </message>
+    <message>
+        <source>Path: %1</source>
+        <translation>Ścieżka: %1</translation>
+    </message>
+    <message>
+        <source>Groups (%1)</source>
+        <translation>Grupy (%1)</translation>
+    </message>
+    <message>
+        <source>Root (%1)</source>
+        <translation>Root (%1)</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+</context>
+<context>
+    <name>CIngressModel</name>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rola</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Operation</source>
+        <translation>Operacja</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CIngressView</name>
+    <message>
+        <source>Any Role</source>
+        <translation>Dowolna rola</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Inicjator</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Cel</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>All Operations</source>
+        <translation>Wszystkie operacje</translation>
+    </message>
+    <message>
+        <source>Control Execution</source>
+        <translation>Kontrola uruchamiania</translation>
+    </message>
+    <message>
+        <source>Change Permissions</source>
+        <translation>Zmień uprawnienia</translation>
+    </message>
+    <message>
+        <source>Write Memory</source>
+        <translation>Zapisz do pamięci</translation>
+    </message>
+    <message>
+        <source>Read Memory</source>
+        <translation>Odczytaj z pamięci</translation>
+    </message>
+    <message>
+        <source>Special Permissions</source>
+        <translation>Specjalne uprawnienia</translation>
+    </message>
+    <message>
+        <source>Write Properties</source>
+        <translation>Zapisz właściwości</translation>
+    </message>
+    <message>
+        <source>Read Properties</source>
+        <translation>Odczytaj właściwości</translation>
+    </message>
+    <message>
+        <source>Show Private Entries</source>
+        <translation>Pokaż wpisy prywatne</translation>
+    </message>
+    <message>
+        <source>Show entries per UPID</source>
+        <translation>Pokaż wpisy według UPID</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatyczne rozwijanie</translation>
+    </message>
+</context>
+<context>
+    <name>CLibraryInfoView</name>
+    <message>
+        <source>Name|Signer|Valid|SHA1 Fingerprint|Certificate Fingerprint</source>
+        <translation>Nazwa|Podpisujący|Ważność|Odcisk SHA1|Odcisk certyfikatu</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Tak</translation>
+    </message>
+    <message>
+        <source>INVALID</source>
+        <translation>NIEWAŻNY</translation>
+    </message>
+    <message>
+        <source>Yes (Catalog)</source>
+        <translation>Tak (Katalog)</translation>
+    </message>
+</context>
+<context>
+    <name>CLibraryModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Poziom zaufania</translation>
+    </message>
+    <message>
+        <source>Last Status</source>
+        <translation>Ostatni status</translation>
+    </message>
+    <message>
+        <source>Last Load</source>
+        <translation>Ostatnie załadowanie</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation>Liczba</translation>
+    </message>
+    <message>
+        <source>Signing Certificate</source>
+        <translation>Certyfikat podpisujący</translation>
+    </message>
+    <message>
+        <source>Module</source>
+        <translation>Moduł</translation>
+    </message>
+</context>
+<context>
+    <name>CLibraryView</name>
+    <message>
+        <source>Sign File</source>
+        <translation>Podpisz plik</translation>
+    </message>
+    <message>
+        <source>Remove File Signature</source>
+        <translation>Usuń podpis pliku</translation>
+    </message>
+    <message>
+        <source>Sign Certificate</source>
+        <translation>Podpisz certyfikat</translation>
+    </message>
+    <message>
+        <source>Remove Cert Signature</source>
+        <translation>Usuń podpis certyfikatu</translation>
+    </message>
+    <message>
+        <source>Open Parent Folder</source>
+        <translation>Otwórz folder nadrzędny</translation>
+    </message>
+    <message>
+        <source>File Properties</source>
+        <translation>Właściwości pliku</translation>
+    </message>
+    <message>
+        <source>By Program</source>
+        <translation>Według programu</translation>
+    </message>
+    <message>
+        <source>By Library</source>
+        <translation>Według biblioteki</translation>
+    </message>
+    <message>
+        <source>All Signatures</source>
+        <translation>Wszystkie podpisy</translation>
+    </message>
+    <message>
+        <source>User Sign. ONLY</source>
+        <translation>Tylko podpis użytkownika</translation>
+    </message>
+    <message>
+        <source>Microsoft/AV</source>
+        <translation>Microsoft/Antywirus</translation>
+    </message>
+    <message>
+        <source>Trusted by MSFT</source>
+        <translation>Zaufane przez Microsoft</translation>
+    </message>
+    <message>
+        <source>Untrusted/None</source>
+        <translation>Niezaufane/Brak</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Untrusted</source>
+        <translation>Niezaufane</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>CleanUp Libraries</source>
+        <translation>Wyczyść biblioteki</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatyczne rozwijanie</translation>
+    </message>
+</context>
+<context>
+    <name>CMajorPrivacy</name>
+    <message>
+        <source>Starting ...</source>
+        <translation>Uruchamianie ...</translation>
+    </message>
+    <message>
+        <source>The driver configuration is corrupted, and could not be loaded, plrease restore from a backup.</source>
+        <translation>Konfiguracja sterownika jest uszkodzona i nie może zostać załadowana, przywróć ją z kopii zapasowej.</translation>
+    </message>
+    <message>
+        <source>The driver configuration is Untrusted (INVALID Signature, or Sequence). Do you want to load ir anyways?</source>
+        <translation>Konfiguracja sterownika jest niezaufana (NIEWAŻNY podpis lub sekwencja). Czy mimo to chcesz ją załadować?</translation>
+    </message>
+    <message>
+        <source>The Privacy Agent is not currently installed as a service. Would you like to install it now (Yes), run it without installation (No), or abort the connection attempt (Cancel)?</source>
+        <translation>Agent ochrony prywatności nie jest obecnie zainstalowany jako usługa. Czy chcesz go teraz zainstalować (Tak), uruchomić bez instalacji (Nie), czy przerwać próbę połączenia (Anuluj)?</translation>
+    </message>
+    <message>
+        <source>Remember this choice.</source>
+        <translation>Zapamiętaj ten wybór.</translation>
+    </message>
+    <message>
+        <source>Major Privacy will now attempt to start the Privacy Agent, please confirm the UAC prompt.</source>
+        <translation>Major Privacy spróbuje teraz uruchomić Agenta ochrony prywatności — potwierdź monit UAC.</translation>
+    </message>
+    <message>
+        <source>Privacy Agent Ready %1/%2</source>
+        <translation>Agent ochrony prywatności gotowy %1/%2</translation>
+    </message>
+    <message>
+        <source>Privacy Agent Failed: %1</source>
+        <translation>Błąd Agenta ochrony prywatności: %1</translation>
+    </message>
+    <message>
+        <source>Do you want to close Major Privacy?</source>
+        <translation>Czy chcesz zamknąć Major Privacy?</translation>
+    </message>
+    <message>
+        <source>Lost connection to Service, do you want to reconnect?</source>
+        <translation>Utracono połączenie z usługą — chcesz się ponownie połączyć?</translation>
+    </message>
+    <message>
+        <source>Mem Usage: %1 + %2 (Logs)</source>
+        <translation>Użycie pamięci: %1 + %2 (logi)</translation>
+    </message>
+    <message>
+        <source>Disconnected from privacy agent</source>
+        <translation>Odłączono od Agenta ochrony prywatności</translation>
+    </message>
+    <message>
+        <source>&amp;Maintenance</source>
+        <translation>&amp;Konserwacja</translation>
+    </message>
+    <message>
+        <source>Import Options</source>
+        <translation>Importuj opcje</translation>
+    </message>
+    <message>
+        <source>Export Options</source>
+        <translation>Eksportuj opcje</translation>
+    </message>
+    <message>
+        <source>&amp;Advanced</source>
+        <translation>&amp;Zaawansowane</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation>Połącz</translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation>Rozłącz</translation>
+    </message>
+    <message>
+        <source>Install Services</source>
+        <translation>Zainstaluj usługi</translation>
+    </message>
+    <message>
+        <source>Remove Services</source>
+        <translation>Usuń usługi</translation>
+    </message>
+    <message>
+        <source>Open User Data Folder</source>
+        <translation>Otwórz folder danych użytkownika</translation>
+    </message>
+    <message>
+        <source>Open System Data Folder</source>
+        <translation>Otwórz folder danych systemowych</translation>
+    </message>
+    <message>
+        <source>Open *.dat Editor</source>
+        <translation>Otwórz edytor plików *.dat</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>Zakończ</translation>
+    </message>
+    <message>
+        <source>Toggle Program Tree</source>
+        <translation>Przełącz drzewo programów</translation>
+    </message>
+    <message>
+        <source>Stack Panels</source>
+        <translation>Panel w stosie</translation>
+    </message>
+    <message>
+        <source>Merge Panels</source>
+        <translation>Scalaj panele</translation>
+    </message>
+    <message>
+        <source>Separate Column Sets</source>
+        <translation>Oddziel zestawy kolumn</translation>
+    </message>
+    <message>
+        <source>Show Tab Labels</source>
+        <translation>Pokaż etykiety kart</translation>
+    </message>
+    <message>
+        <source>Always on Top</source>
+        <translation>Zawsze na wierzchu</translation>
+    </message>
+    <message>
+        <source>Add and Mount Volume Image</source>
+        <translation>Dodaj i zamontuj obraz woluminu</translation>
+    </message>
+    <message>
+        <source>Unmount All Volumes</source>
+        <translation>Odmontuj wszystkie woluminy</translation>
+    </message>
+    <message>
+        <source>Create Volume</source>
+        <translation>Utwórz wolumin</translation>
+    </message>
+    <message>
+        <source>Sign File</source>
+        <translation>Podpisz plik</translation>
+    </message>
+    <message>
+        <source>Signature Database</source>
+        <translation>Baza podpisów</translation>
+    </message>
+    <message>
+        <source>Unload Protection</source>
+        <translation>Wyłącz ochronę</translation>
+    </message>
+    <message>
+        <source>Enable Rule Protection</source>
+        <translation>Włącz ochronę reguł</translation>
+    </message>
+    <message>
+        <source>Disable Rules Protection</source>
+        <translation>Wyłącz ochronę reguł</translation>
+    </message>
+    <message>
+        <source>Setup User Key</source>
+        <translation>Utwórz klucz użytkownika</translation>
+    </message>
+    <message>
+        <source>Remove User Key</source>
+        <translation>Usuń klucz użytkownika</translation>
+    </message>
+    <message>
+        <source>CleanUp Program List</source>
+        <translation>Wyczyść listę programów</translation>
+    </message>
+    <message>
+        <source>Re-Group all Programs</source>
+        <translation>Przypisz ponownie programy do grup</translation>
+    </message>
+    <message>
+        <source>&amp;Advanced Tools</source>
+        <translation>&amp;Narzędzia zaawansowane</translation>
+    </message>
+    <message>
+        <source>Mount Manager</source>
+        <translation>Menedżer montowania</translation>
+    </message>
+    <message>
+        <source>Virtual Disks</source>
+        <translation>Dyski wirtualne</translation>
+    </message>
+    <message>
+        <source>Clear All Trace Logs</source>
+        <translation>Wyczyść wszystkie dzienniki śledzenia</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Ustawienia</translation>
+    </message>
+    <message>
+        <source>Unlock Config</source>
+        <translation>Odblokuj konfigurację</translation>
+    </message>
+    <message>
+        <source>Commit Changes</source>
+        <translation>Zatwierdź zmiany</translation>
+    </message>
+    <message>
+        <source>Discard Changes</source>
+        <translation>Odrzuć zmiany</translation>
+    </message>
+    <message>
+        <source>Clear Ignore List</source>
+        <translation>Wyczyść listę ignorowanych</translation>
+    </message>
+    <message>
+        <source>Reset All Prompts</source>
+        <translation>Zresetuj wszystkie monity</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Pomoc</translation>
+    </message>
+    <message>
+        <source>Visit Support Forum</source>
+        <translation>Odwiedź forum pomocy</translation>
+    </message>
+    <message>
+        <source>About the Qt Framework</source>
+        <translation>O środowisku Qt</translation>
+    </message>
+    <message>
+        <source>About MajorPrivacy</source>
+        <translation>O MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>System Overview</source>
+        <translation>Podgląd systemu</translation>
+    </message>
+    <message>
+        <source>Process Security</source>
+        <translation>Bezpieczeństwo procesów</translation>
+    </message>
+    <message>
+        <source>Secure Enclaves</source>
+        <translation>Bezpieczne enklawy</translation>
+    </message>
+    <message>
+        <source>Resource Protection</source>
+        <translation>Ochrona zasobów</translation>
+    </message>
+    <message>
+        <source>Secure Volumes</source>
+        <translation>Bezpieczne woluminy</translation>
+    </message>
+    <message>
+        <source>Network Firewall</source>
+        <translation>Zapor sieciowa</translation>
+    </message>
+    <message>
+        <source>DNS Filtering</source>
+        <translation>Filtrowanie DNS</translation>
+    </message>
+    <message>
+        <source>Privacy Tweaks</source>
+        <translation>Dostosowania prywatności</translation>
+    </message>
+    <message>
+        <source>Set Time Filter</source>
+        <translation>Ustaw filtr czasu</translation>
+    </message>
+    <message>
+        <source>Any time</source>
+        <translation>Dowolny czas</translation>
+    </message>
+    <message>
+        <source>Last 5 Seconds</source>
+        <translation>Ostatnie 5 sekund</translation>
+    </message>
+    <message>
+        <source>Last 10 Seconds</source>
+        <translation>Ostatnie 10 sekund</translation>
+    </message>
+    <message>
+        <source>Last 30 Seconds</source>
+        <translation>Ostatnie 30 sekund</translation>
+    </message>
+    <message>
+        <source>Last Minute</source>
+        <translation>Ostatnia minuta</translation>
+    </message>
+    <message>
+        <source>Last 3 Minutes</source>
+        <translation>Ostatnie 3 minuty</translation>
+    </message>
+    <message>
+        <source>Last 5 Minutes</source>
+        <translation>Ostatnie 5 minut</translation>
+    </message>
+    <message>
+        <source>Last 15 Minutes</source>
+        <translation>Ostatnie 15 minut</translation>
+    </message>
+    <message>
+        <source>Last 30 Minutes</source>
+        <translation>Ostatnie 30 minut</translation>
+    </message>
+    <message>
+        <source>Last Hour</source>
+        <translation>Ostatnia godzina</translation>
+    </message>
+    <message>
+        <source>Last 3 Hours</source>
+        <translation>Ostatnie 3 godziny</translation>
+    </message>
+    <message>
+        <source>Last 12 Hours</source>
+        <translation>Ostatnie 12 godzin</translation>
+    </message>
+    <message>
+        <source>Last 24 Hours</source>
+        <translation>Ostatnie 24 godziny</translation>
+    </message>
+    <message>
+        <source>Last 48 Hours</source>
+        <translation>Ostatnie 48 godzin</translation>
+    </message>
+    <message>
+        <source>Last Week</source>
+        <translation>Ostatni tydzień</translation>
+    </message>
+    <message>
+        <source>Last 2 Weeks</source>
+        <translation>Ostatnie 2 tygodnie</translation>
+    </message>
+    <message>
+        <source>Last Month</source>
+        <translation>Ostatni miesiąc</translation>
+    </message>
+    <message>
+        <source>Show/Hide</source>
+        <translation>Pokaż/Ukryj</translation>
+    </message>
+    <message>
+        <source>Process Protection Popups</source>
+        <translation>Monity ochrony procesów</translation>
+    </message>
+    <message>
+        <source>Resource Access Popups</source>
+        <translation>Monity dostępu do zasobów</translation>
+    </message>
+    <message>
+        <source>Network Firewall Popups</source>
+        <translation>Monity zapory sieciowej</translation>
+    </message>
+    <message>
+        <source>Firewall Profile</source>
+        <translation>Profil zapory</translation>
+    </message>
+    <message>
+        <source>Use Allow List</source>
+        <translation>Użyj listy dozwolonych</translation>
+    </message>
+    <message>
+        <source>Use Block List</source>
+        <translation>Użyj listy zablokowanych</translation>
+    </message>
+    <message>
+        <source>Disabled Firewall</source>
+        <translation>Zapora wyłączona</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to sign a file</source>
+        <translation>Wprowadź hasło konfiguracji zabezpieczeń, aby podpisać plik</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to sign a certificate</source>
+        <translation>Wprowadź hasło konfiguracji zabezpieczeń, aby podpisać certyfikat</translation>
+    </message>
+    <message>
+        <source>
 				Enter Secure Configuration Password, to enable rule protection.
 				Once that is done you can not change rules (except windows firewall) without using the user key.
 			</source>
-			<translation>
+        <translation>
 				Wprowadź hasło konfiguracji zabezpieczeń, aby włączyć ochronę reguł.
 				Po aktywacji zmiana reguł (z wyjątkiem zapory systemu Windows) wymaga klucza użytkownika.
 			</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to disable rule protection.</source>
-			<translation>Wprowadź hasło konfiguracji zabezpieczeń, aby wyłączyć ochronę reguł.</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to allow rule editing.</source>
-			<translation>Wprowadź hasło konfiguracji zabezpieczeń, aby zezwolić na edycję reguł.</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to commit changes.</source>
-			<translation>Wprowadź hasło konfiguracji zabezpieczeń, aby zatwierdzić zmiany.</translation>
-		</message>
-		<message>
-			<source>Enter Secure Configuration Password, to remove the user key.</source>
-			<translation>Wprowadź hasło konfiguracji zabezpieczeń, aby usunąć klucz użytkownika.</translation>
-		</message>
-		<message>
-			<source>Remember Password to sign more items for:</source>
-			<translation>Zapamiętaj hasło do podpisywania kolejnych elementów przez:</translation>
-		</message>
-		<message>
-			<source>Remember Password and commit changes after:</source>
-			<translation>Zapamiętaj hasło i zatwierdź zmiany po:</translation>
-		</message>
-		<message>
-			<source>Select Files</source>
-			<translation>Wybierz pliki</translation>
-		</message>
-		<message>
-			<source>All Files (*.*)</source>
-			<translation>Wszystkie pliki (*.*)</translation>
-		</message>
-		<message>
-			<source>This setting required the service to be restarted to tak effect</source>
-			<translation>Ta zmiana wymaga ponownego uruchomienia usługi, aby zaczęła obowiązywać</translation>
-		</message>
-		<message>
-			<source>Don&apos;t show this message again.</source>
-			<translation>Nie pokazuj ponownie tego komunikatu.</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to disable rule protection.</source>
+        <translation>Wprowadź hasło konfiguracji zabezpieczeń, aby wyłączyć ochronę reguł.</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to allow rule editing.</source>
+        <translation>Wprowadź hasło konfiguracji zabezpieczeń, aby zezwolić na edycję reguł.</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to commit changes.</source>
+        <translation>Wprowadź hasło konfiguracji zabezpieczeń, aby zatwierdzić zmiany.</translation>
+    </message>
+    <message>
+        <source>Enter Secure Configuration Password, to remove the user key.</source>
+        <translation>Wprowadź hasło konfiguracji zabezpieczeń, aby usunąć klucz użytkownika.</translation>
+    </message>
+    <message>
+        <source>Remember Password to sign more items for:</source>
+        <translation>Zapamiętaj hasło do podpisywania kolejnych elementów przez:</translation>
+    </message>
+    <message>
+        <source>Remember Password and commit changes after:</source>
+        <translation>Zapamiętaj hasło i zatwierdź zmiany po:</translation>
+    </message>
+    <message>
+        <source>Select Files</source>
+        <translation>Wybierz pliki</translation>
+    </message>
+    <message>
+        <source>All Files (*.*)</source>
+        <translation>Wszystkie pliki (*.*)</translation>
+    </message>
+    <message>
+        <source>This setting required the service to be restarted to tak effect</source>
+        <translation>Ta zmiana wymaga ponownego uruchomienia usługi, aby zaczęła obowiązywać</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>Nie pokazuj ponownie tego komunikatu.</translation>
+    </message>
+    <message>
+        <source>
 				Would you like to lock down the user key (Yes), or only enable user key signature-based rule protection (No)?
 
 				Locking down the user key will prevent it from being removed or changed, and rule protection cannot be disabled until the system is rebooted.
 
 				If the driver is set to auto-start, it will automatically re-lock the key on reboot!
 			</source>
-			<translation>
+        <translation>
 				Czy chcesz zablokować klucz użytkownika (Tak), czy tylko włączyć ochronę reguł opartą na podpisie (Nie)?
 
 				Zablokowanie klucza uniemożliwi jego usunięcie lub zmianę, a ochrona reguł pozostanie aktywna do ponownego uruchomienia systemu.
 
 				Jeśli sterownik jest ustawiony jako autostart, klucz zostanie ponownie zablokowany przy następnym uruchomieniu!
 			</translation>
-		</message>
-		<message>
-			<source>The user key is locked. Please reboot the system to complete the removal of the config protection.</source>
-			<translation>Klucz użytkownika jest zablokowany. Uruchom ponownie system, aby zakończyć usuwanie ochrony konfiguracji.</translation>
-		</message>
-		<message>
-			<source>Do you really want to discard all changes?</source>
-			<translation>Czy na pewno chcesz odrzucić wszystkie zmiany?</translation>
-		</message>
-		<message>
-			<source>Set new Secure Configuration Password</source>
-			<translation>Ustaw nowe hasło konfiguracji zabezpieczeń</translation>
-		</message>
-		<message>
-			<source>Program not found.</source>
-			<translation>Nie znaleziono programu.</translation>
-		</message>
-		<message>
-			<source>Program already exists.</source>
-			<translation>Program już istnieje.</translation>
-		</message>
-		<message>
-			<source>This Operation can not be performed on a program which has rules.</source>
-			<translation>Tej operacji nie można wykonać na programie posiadającym reguły.</translation>
-		</message>
-		<message>
-			<source>Parent program not found.</source>
-			<translation>Nie znaleziono programu nadrzędnego.</translation>
-		</message>
-		<message>
-			<source>Can&apos;t remove from pattern.</source>
-			<translation>Nie można usunąć ze wzorca.</translation>
-		</message>
-		<message>
-			<source>Parent program not valid.</source>
-			<translation>Nieprawidłowy program nadrzędny.</translation>
-		</message>
-		<message>
-			<source>Removing program items which are auto generated and represent found components can not be removed.</source>
-			<translation>Nie można usunąć automatycznie wygenerowanych elementów programu reprezentujących znalezione komponenty.</translation>
-		</message>
-		<message>
-			<source>Before you can sign a Binary you need to create your User Key, use the 'Security-&gt;Setup User Key' menu comand to do that.</source>
-			<translation>Przed podpisaniem pliku binarnego musisz utworzyć swój klucz użytkownika. Użyj polecenia menu „Bezpieczeństwo → Utwórz klucz użytkownika”.</translation>
-		</message>
-		<message>
-			<source>Wrong Password!</source>
-			<translation>Nieprawidłowe hasło!</translation>
-		</message>
-		<message>
-			<source>Error 0x%1</source>
-			<translation>Błąd 0x%1</translation>
-		</message>
-		<message>
-			<source>MajorPrivacy - Error</source>
-			<translation>MajorPrivacy – Błąd</translation>
-		</message>
-		<message>
-			<source>Operation failed for %1 item(s).</source>
-			<translation>Operacja nie powiodła się dla %1 elementu/ów.</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the All trace logs for all program items?</source>
-			<translation>Czy na pewno chcesz wyczyścić wszystkie dzienniki śledzenia dla wszystkich programów?</translation>
-		</message>
-		<message>
-			<source>Cleanup done.</source>
-			<translation>Czyszczenie zakończone.</translation>
-		</message>
-		<message>
-			<source>Cleanup %1/%2</source>
-			<translation>Czyszczenie %1/%2</translation>
-		</message>
-		<message>
-			<source>Do you want to clean up the Program List? Choosing 'Yes' will remove all missing program entries, including those with rules. Choosing 'No' will remove only missing entries without rules. Select 'Cancel' to abort the operation.</source>
-			<translation>Czy chcesz wyczyścić listę programów? Wybór „Tak” usunie wszystkie brakujące wpisy, także te z regułami. Wybór „Nie” usunie tylko brakujące wpisy bez reguł. „Anuluj” przerwie operację.</translation>
-		</message>
-		<message>
-			<source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
-			<translation>Czy chcesz ponownie pogrupować wszystkie programy? Spowoduje to usunięcie ich z aktualnych grup i przypisanie ich ponownie według domyślnych reguł.</translation>
-		</message>
-		<message>
-			<source>Do you really want to clear the ignore list?</source>
-			<translation>Czy na pewno chcesz wyczyścić listę ignorowanych?</translation>
-		</message>
-		<message>
-			<source>Do you also want to reset all hidden message boxes?</source>
-			<translation>Czy chcesz również zresetować wszystkie ukryte komunikaty?</translation>
-		</message>
-		<message>
-			<source>Options Files (*.xml)</source>
-			<translation>Pliki opcji (*.xml)</translation>
-		</message>
-		<message>
-			<source>Failed to parse XML data!</source>
-			<translation>Nie udało się przetworzyć danych XML!</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>The user key is locked. Please reboot the system to complete the removal of the config protection.</source>
+        <translation>Klucz użytkownika jest zablokowany. Uruchom ponownie system, aby zakończyć usuwanie ochrony konfiguracji.</translation>
+    </message>
+    <message>
+        <source>Do you really want to discard all changes?</source>
+        <translation>Czy na pewno chcesz odrzucić wszystkie zmiany?</translation>
+    </message>
+    <message>
+        <source>Set new Secure Configuration Password</source>
+        <translation>Ustaw nowe hasło konfiguracji zabezpieczeń</translation>
+    </message>
+    <message>
+        <source>Program not found.</source>
+        <translation>Nie znaleziono programu.</translation>
+    </message>
+    <message>
+        <source>Program already exists.</source>
+        <translation>Program już istnieje.</translation>
+    </message>
+    <message>
+        <source>This Operation can not be performed on a program which has rules.</source>
+        <translation>Tej operacji nie można wykonać na programie posiadającym reguły.</translation>
+    </message>
+    <message>
+        <source>Parent program not found.</source>
+        <translation>Nie znaleziono programu nadrzędnego.</translation>
+    </message>
+    <message>
+        <source>Can&apos;t remove from pattern.</source>
+        <translation>Nie można usunąć ze wzorca.</translation>
+    </message>
+    <message>
+        <source>Parent program not valid.</source>
+        <translation>Nieprawidłowy program nadrzędny.</translation>
+    </message>
+    <message>
+        <source>Removing program items which are auto generated and represent found components can not be removed.</source>
+        <translation>Nie można usunąć automatycznie wygenerowanych elementów programu reprezentujących znalezione komponenty.</translation>
+    </message>
+    <message>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
+        <translation>Przed podpisaniem pliku binarnego musisz utworzyć swój klucz użytkownika. Użyj polecenia menu „Bezpieczeństwo → Utwórz klucz użytkownika”.</translation>
+    </message>
+    <message>
+        <source>Wrong Password!</source>
+        <translation>Nieprawidłowe hasło!</translation>
+    </message>
+    <message>
+        <source>Error 0x%1</source>
+        <translation>Błąd 0x%1</translation>
+    </message>
+    <message>
+        <source>MajorPrivacy - Error</source>
+        <translation>MajorPrivacy – Błąd</translation>
+    </message>
+    <message>
+        <source>Operation failed for %1 item(s).</source>
+        <translation>Operacja nie powiodła się dla %1 elementu/ów.</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the All trace logs for all program items?</source>
+        <translation>Czy na pewno chcesz wyczyścić wszystkie dzienniki śledzenia dla wszystkich programów?</translation>
+    </message>
+    <message>
+        <source>Cleanup done.</source>
+        <translation>Czyszczenie zakończone.</translation>
+    </message>
+    <message>
+        <source>Cleanup %1/%2</source>
+        <translation>Czyszczenie %1/%2</translation>
+    </message>
+    <message>
+        <source>Do you want to clean up the Program List? Choosing &apos;Yes&apos; will remove all missing program entries, including those with rules. Choosing &apos;No&apos; will remove only missing entries without rules. Select &apos;Cancel&apos; to abort the operation.</source>
+        <translation>Czy chcesz wyczyścić listę programów? Wybór „Tak” usunie wszystkie brakujące wpisy, także te z regułami. Wybór „Nie” usunie tylko brakujące wpisy bez reguł. „Anuluj” przerwie operację.</translation>
+    </message>
+    <message>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
+        <translation>Czy chcesz ponownie pogrupować wszystkie programy? Spowoduje to usunięcie ich z aktualnych grup i przypisanie ich ponownie według domyślnych reguł.</translation>
+    </message>
+    <message>
+        <source>Do you really want to clear the ignore list?</source>
+        <translation>Czy na pewno chcesz wyczyścić listę ignorowanych?</translation>
+    </message>
+    <message>
+        <source>Do you also want to reset all hidden message boxes?</source>
+        <translation>Czy chcesz również zresetować wszystkie ukryte komunikaty?</translation>
+    </message>
+    <message>
+        <source>Options Files (*.xml)</source>
+        <translation>Pliki opcji (*.xml)</translation>
+    </message>
+    <message>
+        <source>Failed to parse XML data!</source>
+        <translation>Nie udało się przetworzyć danych XML!</translation>
+    </message>
+    <message>
+        <source>
 				Do you want to stop the Privacy Agent and unload the Kernel Isolator?
 				CAUTION: This will disable protection.
 			</source>
-			<translation>
+        <translation>
 				Czy chcesz zatrzymać Agenta ochrony prywatności i odłączyć izolator jądra?
 				OSTRZEŻENIE: To wyłączy ochronę.
 			</translation>
-		</message>
-		<message>
-			<source>Volume Protection Rule for: %1</source>
-			<translation>Reguła ochrony woluminu dla: %1</translation>
-		</message>
-		<message>
-			<source>Volume Unmount Rule for: %1</source>
-			<translation>Reguła odmontowania woluminu dla: %1</translation>
-		</message>
-		<message>
-			<source>Temporary rule</source>
-			<translation>Reguła tymczasowa</translation>
-		</message>
-		<message>
-			<source>%1 - MajorPrivacy Rule</source>
-			<translation>%1 – Reguła MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>%1 - MajorPrivacy Rule Template</source>
-			<translation>%1 – Szablon reguły MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Reset Columns</source>
-			<translation>Resetuj kolumny</translation>
-		</message>
-		<message>
-			<source>Copy Cell</source>
-			<translation>Skopiuj komórkę</translation>
-		</message>
-		<message>
-			<source>Copy Row</source>
-			<translation>Skopiuj wiersz</translation>
-		</message>
-		<message>
-			<source>Copy Panel</source>
-			<translation>Skopiuj panel</translation>
-		</message>
-		<message>
-			<source>Case Sensitive</source>
-			<translation>Uwzględnij wielkość liter</translation>
-		</message>
-		<message>
-			<source>Use Regular Expressions</source>
-			<translation>Użyj wyrażeń regularnych</translation>
-		</message>
-		<message>
-			<source>Highlight Items</source>
-			<translation>Wyróżnij elementy</translation>
-		</message>
-		<message>
-			<source>Close</source>
-			<translation>Zamknij</translation>
-		</message>
-		<message>
-			<source>&amp;Find ...</source>
-			<translation>&amp;Znajdź...</translation>
-		</message>
-		<message>
-			<source>All columns</source>
-			<translation>Wszystkie kolumny</translation>
-		</message>
-		<message>
-			<source>Search ...</source>
-			<translation>Szukaj...</translation>
-		</message>
-		<message>
-			<source>Toggle Search Bar</source>
-			<translation>Przełącz pasek wyszukiwania</translation>
-		</message>
-		<message>
-			<source>&lt;h3&gt;About MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</source>
-			<translation>&lt;h3&gt;O programie MajorPrivacy&lt;/h3&gt;&lt;p&gt;Wersja %1&lt;/p&gt;&lt;p&gt;</translation>
-		</message>
-		<message>
-			<source>This version is licensed to %1.</source>
-			<translation>Ta wersja jest licencjonowana dla: %1.</translation>
-		</message>
-		<message>
-			<source>This version was licensed to %1, but its no longer valid.</source>
-			<translation>Ta wersja była licencjonowana dla %1, ale licencja jest już nieważna.</translation>
-		</message>
-		<message>
-			<source>&lt;p&gt;MajorPrivacy is a program that helps you to protect your privacy and security.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; for more information.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI Config Dir: &lt;br /&gt;%2&lt;br /&gt;Core Config Dir: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</source>
-			<translation>&lt;p&gt;MajorPrivacy to program pomagający chronić Twoją prywatność i bezpieczeństwo.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Odwiedź &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt;, aby uzyskać więcej informacji.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Katalog konfiguracji UI: &lt;br /&gt;%2&lt;br /&gt;Katalog konfiguracji rdzenia: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Ikony z &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</translation>
-		</message>
-		<message>
-			<source>Enter the path of a program that will be created in a sandbox.</source>
-			<translation>Podaj ścieżkę programu, który zostanie utworzony w piaskownicy.</translation>
-		</message>
-	</context>
-	<context>
-		<name>CMountMgrWnd</name>
-		<message>
-			<source>Volume|Device Path</source>
-			<translation>Wolumin|Ścieżka urządzenia</translation>
-		</message>
-		<message>
-			<source>Refresh</source>
-			<translation>Odśwież</translation>
-		</message>
-	</context>
-	<context>
-		<name>CNetTraceModel</name>
-		<message>
-			<source>Unknown Program</source>
-			<translation>Nieznany program</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>PROCESS MISSING</source>
-			<translation>PROCES BRAKUJE</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokół</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Direction</source>
-			<translation>Kierunek</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Zdalny adres</translation>
-		</message>
-		<message>
-			<source>Remote Port</source>
-			<translation>Zdalny port</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Lokalny adres</translation>
-		</message>
-		<message>
-			<source>Local Port</source>
-			<translation>Lokalny port</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Wysłano</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Pobrano</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CNetTraceView</name>
-		<message>
-			<source>All Directions</source>
-			<translation>Wszystkie kierunki</translation>
-		</message>
-		<message>
-			<source>Inbound</source>
-			<translation>Przychodzące</translation>
-		</message>
-		<message>
-			<source>Outbound</source>
-			<translation>Wychodzące</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>All Protocols</source>
-			<translation>Wszystkie protokoły</translation>
-		</message>
-		<message>
-			<source>HTTP(S)</source>
-			<translation>HTTP(S)</translation>
-		</message>
-		<message>
-			<source>TCP Sockets</source>
-			<translation>Gniazda TCP</translation>
-		</message>
-		<message>
-			<source>TCP Clients</source>
-			<translation>Klienci TCP</translation>
-		</message>
-		<message>
-			<source>TCP Servers</source>
-			<translation>Serwery TCP</translation>
-		</message>
-		<message>
-			<source>UDP Sockets</source>
-			<translation>Gniazda UDP</translation>
-		</message>
-		<message>
-			<source>Area Filter</source>
-			<translation>Filtr obszaru</translation>
-		</message>
-		<message>
-			<source>Internet</source>
-			<translation>Internet</translation>
-		</message>
-		<message>
-			<source>Local Area</source>
-			<translation>Sieć lokalna</translation>
-		</message>
-		<message>
-			<source>Local Host</source>
-			<translation>Host lokalny</translation>
-		</message>
-		<message>
-			<source>Auto Scroll</source>
-			<translation>Automatyczne przewijanie</translation>
-		</message>
-		<message>
-			<source>Hold updates</source>
-			<translation>Wstrzymaj aktualizacje</translation>
-		</message>
-		<message>
-			<source>Clear Trace Log</source>
-			<translation>Wyczyść dziennik śledzenia</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CNetworkPage</name>
-		<message>
-			<source>Firewall Rules</source>
-			<translation>Reguły zapory</translation>
-		</message>
-		<message>
-			<source>Open Socket</source>
-			<translation>Otwórz gniazdo</translation>
-		</message>
-		<message>
-			<source>Traffic Monitor</source>
-			<translation>Monitor ruchu</translation>
-		</message>
-		<message>
-			<source>Connection Log</source>
-			<translation>Dziennik połączeń</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>COptionsTransferWnd</name>
-		<message>
-			<source>Select the data you want to import</source>
-			<translation>Wybierz dane do zaimportowania</translation>
-		</message>
-		<message>
-			<source>Select the data you want to export</source>
-			<translation>Wybierz dane do wyeksportowania</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CPopUpWindow</name>
-		<message>
-			<source>MajorPrivacy Notifications</source>
-			<translation>Powiadomienia MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Permanent</source>
-			<translation>Na stałe</translation>
-		</message>
-		<message>
-			<source>Untill Restart</source>
-			<translation>Do ponownego uruchomienia</translation>
-		</message>
-		<message>
-			<source>for 1 Minute</source>
-			<translation>na 1 minutę</translation>
-		</message>
-		<message>
-			<source>for 5 Minutes</source>
-			<translation>na 5 minut</translation>
-		</message>
-		<message>
-			<source>for 15 Minutes</source>
-			<translation>na 15 minut</translation>
-		</message>
-		<message>
-			<source>for 30 Minutes</source>
-			<translation>na 30 minut</translation>
-		</message>
-		<message>
-			<source>for 60 Minutes</source>
-			<translation>na 60 minut</translation>
-		</message>
-		<message>
-			<source>Always Ignore this Program</source>
-			<translation>Zawsze ignoruj ten program</translation>
-		</message>
-		<message>
-			<source>Create Custom Rule</source>
-			<translation>Utwórz regułę niestandardową</translation>
-		</message>
-		<message>
-			<source>Always Ignore this Path</source>
-			<translation>Zawsze ignoruj tę ścieżkę</translation>
-		</message>
-		<message>
-			<source>Allow Read Only Access</source>
-			<translation>Zezwól tylko na odczyt</translation>
-		</message>
-		<message>
-			<source>Allow Directory Listing ONLY</source>
-			<translation>Zezwól tylko na listę katalogu</translation>
-		</message>
-		<message>
-			<source>Always Ignore this Binary</source>
-			<translation>Zawsze ignoruj ten plik binarny</translation>
-		</message>
-		<message>
-			<source>Sign Certificate</source>
-			<translation>Podpisz certyfikat</translation>
-		</message>
-		<message>
-			<source>%1/%2</source>
-			<translation>%1/%2</translation>
-		</message>
-		<message>
-			<source>%1:%2</source>
-			<translation>%1:%2</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>%1 - Rule</source>
-			<translation>%1 – Reguła</translation>
-		</message>
-		<message>
-			<source>Please select a resource to create a rule for.</source>
-			<translation>Wybierz zasób, dla którego ma zostać utworzona reguła.</translation>
-		</message>
-		<message>
-			<source>Please select a binnary file to sign with the your User Key.</source>
-			<translation>Wybierz plik binarny do podpisania swoim kluczem użytkownika.</translation>
-		</message>
-		<message>
-			<source>Selected Items do not have Certificates!</source>
-			<translation>Wybrane elementy nie mają certyfikatów!</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProcess</name>
-		<message>
-			<source>Sec: %1</source>
-			<translation>Sek: %1</translation>
-		</message>
-		<message>
-			<source>%1 (</source>
-			<translation>%1 (</translation>
-		</message>
-		<message>
-			<source>%1</source>
-			<translation>%1</translation>
-		</message>
-		<message>
-			<source>%1+%2</source>
-			<translation>%1+%2</translation>
-		</message>
-		<message>
-			<source>/%1/%2/%3)</source>
-			<translation>/%1/%2/%3)</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProcessModel</name>
-		<message>
-			<source>Process</source>
-			<translation>Proces</translation>
-		</message>
-		<message>
-			<source>PID</source>
-			<translation>PID</translation>
-		</message>
-		<message>
-			<source>Parent PID</source>
-			<translation>PID nadrzędny</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Poziom zaufania</translation>
-		</message>
-		<message>
-			<source>User Name</source>
-			<translation>Nazwa użytkownika</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Image Loads (MS/V/S/U)</source>
-			<translation>Załadowane obrazy (MS/V/S/U)</translation>
-		</message>
-		<message>
-			<source>File Name</source>
-			<translation>Nazwa pliku</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProcessPage</name>
-		<message>
-			<source>Process Rules</source>
-			<translation>Reguły procesów</translation>
-		</message>
-		<message>
-			<source>Running Processes</source>
-			<translation>Uruchomione procesy</translation>
-		</message>
-		<message>
-			<source>Loaded Modules</source>
-			<translation>Załadowane moduły</translation>
-		</message>
-		<message>
-			<source>Execution Monitor</source>
-			<translation>Monitor uruchomień</translation>
-		</message>
-		<message>
-			<source>Ingress Monitor</source>
-			<translation>Monitor wejść</translation>
-		</message>
-		<message>
-			<source>Trace Log</source>
-			<translation>Dziennik śledzenia</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProcessTraceModel</name>
-		<message>
-			<source>PROGRAM MISSING</source>
-			<translation>PROGRAM BRAK</translation>
-		</message>
-		<message>
-			<source> [%1]</source>
-			<translation> [%1]</translation>
-		</message>
-		<message>
-			<source>MODULE MISSING</source>
-			<translation>MODUŁ BRAK</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Role</source>
-			<translation>Rola</translation>
-		</message>
-		<message>
-			<source>Operation</source>
-			<translation>Operacja</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Subject</source>
-			<translation>Obiekt</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProcessTraceView</name>
-		<message>
-			<source>Any Role</source>
-			<translation>Dowolna rola</translation>
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Wykonawca</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Cel</translation>
-		</message>
-		<message>
-			<source>Any Status</source>
-			<translation>Dowolny status</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Auto Scroll</source>
-			<translation>Automatyczne przewijanie</translation>
-		</message>
-		<message>
-			<source>Hold updates</source>
-			<translation>Wstrzymaj aktualizacje</translation>
-		</message>
-		<message>
-			<source>Clear Trace Log</source>
-			<translation>Wyczyść dziennik śledzenia</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProcessView</name>
-		<message>
-			<source>All</source>
-			<translation>Wszystkie</translation>
-		</message>
-		<message>
-			<source>User</source>
-			<translation>Użytkownik</translation>
-		</message>
-		<message>
-			<source>System</source>
-			<translation>System</translation>
-		</message>
-		<message>
-			<source>Show Tree</source>
-			<translation>Pokaż drzewo</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramFile</name>
-		<message>
-			<source> (CI: Level 0)</source>
-			<translation> (CI: Poziom 0)</translation>
-		</message>
-		<message>
-			<source> (CI: Enterprise)</source>
-			<translation> (CI: Enterprise)</translation>
-		</message>
-		<message>
-			<source> (CI: Developer)</source>
-			<translation> (CI: Deweloper)</translation>
-		</message>
-		<message>
-			<source> (CI: Authenticode)</source>
-			<translation> (CI: Authenticode)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 2)</source>
-			<translation> (CI: Poziom 2)</translation>
-		</message>
-		<message>
-			<source> (CI: Store)</source>
-			<translation> (CI: Sklep)</translation>
-		</message>
-		<message>
-			<source> (CI: Antimalware)</source>
-			<translation> (CI: Antymalware)</translation>
-		</message>
-		<message>
-			<source> (CI: Microsoft)</source>
-			<translation> (CI: Microsoft)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 4)</source>
-			<translation> (CI: Poziom 4)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 5)</source>
-			<translation> (CI: Poziom 5)</translation>
-		</message>
-		<message>
-			<source> (CI: Code Gene.)</source>
-			<translation> (CI: Code Gene.)</translation>
-		</message>
-		<message>
-			<source> (CI: Windows)</source>
-			<translation> (CI: Windows)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 7)</source>
-			<translation> (CI: Poziom 7)</translation>
-		</message>
-		<message>
-			<source> (CI: Windows TCB)</source>
-			<translation> (CI: Windows TCB)</translation>
-		</message>
-		<message>
-			<source> (CI: Level 6)</source>
-			<translation> (CI: Poziom 6)</translation>
-		</message>
-		<message>
-			<source>None</source>
-			<translation>Brak</translation>
-		</message>
-		<message>
-			<source>Microsoft</source>
-			<translation>Microsoft</translation>
-		</message>
-		<message>
-			<source>Test</source>
-			<translation>Test</translation>
-		</message>
-		<message>
-			<source>Code</source>
-			<translation>Kod</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznane</translation>
-		</message>
-		<message>
-			<source>DMD</source>
-			<translation>DMD</translation>
-		</message>
-		<message>
-			<source>DMD Test</source>
-			<translation>DMD Test</translation>
-		</message>
-		<message>
-			<source>3rd Party</source>
-			<translation>Strona trzecia</translation>
-		</message>
-		<message>
-			<source>Trusted Boot</source>
-			<translation>Zaufany rozruch</translation>
-		</message>
-		<message>
-			<source>UEFI</source>
-			<translation>UEFI</translation>
-		</message>
-		<message>
-			<source>Flight</source>
-			<translation>Flight</translation>
-		</message>
-		<message>
-			<source>Other</source>
-			<translation>Inne</translation>
-		</message>
-		<message>
-			<source>Error: %1</source>
-			<translation>Błąd: %1</translation>
-		</message>
-		<message>
-			<source> (Root: %1)</source>
-			<translation> (Root: %1)</translation>
-		</message>
-		<message>
-			<source> (Roots: %1)</source>
-			<translation> (Roots: %1)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramItem</name>
-		<message>
-			<source>Executable File</source>
-			<translation>Plik wykonywalny</translation>
-		</message>
-		<message>
-			<source>File Path Pattern</source>
-			<translation>Wzorzec ścieżki pliku</translation>
-		</message>
-		<message>
-			<source>Installation</source>
-			<translation>Instalacja</translation>
-		</message>
-		<message>
-			<source>Windows Service</source>
-			<translation>Usługa Windows</translation>
-		</message>
-		<message>
-			<source>Application Package</source>
-			<translation>Paczka aplikacji</translation>
-		</message>
-		<message>
-			<source>Program Set</source>
-			<translation>Zestaw programów</translation>
-		</message>
-		<message>
-			<source>Program List</source>
-			<translation>Lista programów</translation>
-		</message>
-		<message>
-			<source>Program Group</source>
-			<translation>Grupa programów</translation>
-		</message>
-		<message>
-			<source>All Programs</source>
-			<translation>Wszystkie programy</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznany</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramModel</name>
-		<message>
-			<source>%1/%2</source>
-			<translation>%1/%2</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Processes</source>
-			<translation>Procesy</translation>
-		</message>
-		<message>
-			<source>Program Rules</source>
-			<translation>Reguły programów</translation>
-		</message>
-		<message>
-			<source>Last Execution</source>
-			<translation>Ostatnie uruchomienie</translation>
-		</message>
-		<message>
-			<source>Accessed Files</source>
-			<translation>Otwierane pliki</translation>
-		</message>
-		<message>
-			<source>Access Rules</source>
-			<translation>Reguły dostępu</translation>
-		</message>
-		<message>
-			<source>Open Sockets</source>
-			<translation>Otwarte gniazda</translation>
-		</message>
-		<message>
-			<source>FW Rules</source>
-			<translation>Reguły FW</translation>
-		</message>
-		<message>
-			<source>Last Net Activity</source>
-			<translation>Ostatnia aktywność sieciowa</translation>
-		</message>
-		<message>
-			<source>Upload</source>
-			<translation>Wysyłanie</translation>
-		</message>
-		<message>
-			<source>Download</source>
-			<translation>Pobieranie</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Wysłano</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Pobrano</translation>
-		</message>
-		<message>
-			<source>Log Size</source>
-			<translation>Rozmiar dziennika</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Ścieżka</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramPicker</name>
-		<message>
-			<source>MajorPrivacy - Select Program</source>
-			<translation>MajorPrivacy – Wybierz program</translation>
-		</message>
-		<message>
-			<source>Please select a program</source>
-			<translation>Proszę wybrać program</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramRule</name>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Chroń</translation>
-		</message>
-		<message>
-			<source>Isolate</source>
-			<translation>Izoluj</translation>
-		</message>
-		<message>
-			<source>Audit</source>
-			<translation>Audyt</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramRuleModel</name>
-		<message>
-			<source>%1 - %2</source>
-			<translation>%1 – %2</translation>
-		</message>
-		<message>
-			<source>Yes</source>
-			<translation>Tak</translation>
-		</message>
-		<message>
-			<source>No</source>
-			<translation>Nie</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Enabled</source>
-			<translation>Włączone</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Akcja</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Poziom zaufania</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramRuleView</name>
-		<message>
-			<source>Enable Rule</source>
-			<translation>Włącz regułę</translation>
-		</message>
-		<message>
-			<source>Disable Rule</source>
-			<translation>Wyłącz regułę</translation>
-		</message>
-		<message>
-			<source>Delete Rule</source>
-			<translation>Usuń regułę</translation>
-		</message>
-		<message>
-			<source>Edit Rule</source>
-			<translation>Edytuj regułę</translation>
-		</message>
-		<message>
-			<source>Duplicate Rule</source>
-			<translation>Duplikuj regułę</translation>
-		</message>
-		<message>
-			<source>Create Rule</source>
-			<translation>Utwórz regułę</translation>
-		</message>
-		<message>
-			<source>All Actions</source>
-			<translation>Wszystkie akcje</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Chroń</translation>
-		</message>
-		<message>
-			<source>Hide Disabled Rules</source>
-			<translation>Ukryj wyłączone reguły</translation>
-		</message>
-		<message>
-			<source>Refresh Rules</source>
-			<translation>Odśwież reguły</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Rules Items?</source>
-			<translation>Czy chcesz usunąć zaznaczone reguły?</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramRuleWnd</name>
-		<message>
-			<source>Create Program Rule</source>
-			<translation>Utwórz regułę programu</translation>
-		</message>
-		<message>
-			<source>Edit Program Rule</source>
-			<translation>Edytuj regułę programu</translation>
-		</message>
-		<message>
-			<source>New Program Rule</source>
-			<translation>Nowa reguła programu</translation>
-		</message>
-		<message>
-			<source>Global (Any/No Enclave)</source>
-			<translation>Globalna (dowolna/brak enklawy)</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Protect</source>
-			<translation>Chroń</translation>
-		</message>
-		<message>
-			<source>Audit</source>
-			<translation>Audyt</translation>
-		</message>
-		<message>
-			<source>Unconfigured</source>
-			<translation>Nieskonfigurowane</translation>
-		</message>
-		<message>
-			<source>User Signature ONLY (not recommended)</source>
-			<translation>Tylko podpis użytkownika (niezalecane)</translation>
-		</message>
-		<message>
-			<source>User + Microsoft/AV Signature</source>
-			<translation>Podpis użytkownika + Microsoft/AV</translation>
-		</message>
-		<message>
-			<source>User + Trusted by Microsoft (Code Root)</source>
-			<translation>Użytkownik + zaufany przez Microsoft (Code Root)</translation>
-		</message>
-		<message>
-			<source>Any Signature (Unknown Root)</source>
-			<translation>Dowolny podpis (nieznany root)</translation>
-		</message>
-		<message>
-			<source>No Signature</source>
-			<translation>Brak podpisu</translation>
-		</message>
-		<message>
-			<source>Error</source>
-			<translation>Błąd</translation>
-		</message>
-		<message>
-			<source>Please select an enclave for a protection rule.</source>
-			<translation>Wybierz enklawę dla reguły ochrony.</translation>
-		</message>
-		<message>
-			<source>The sellected program type is not supported for this rule type</source>
-			<translation>Wybrany typ programu nie jest obsługiwany dla tej reguły</translation>
-		</message>
-		<message>
-			<source>%1 %2</source>
-			<translation>%1 %2</translation>
-		</message>
-	</context>
-	<context>
-		<name>CProgramView</name>
-		<message>
-			<source>Type Filters</source>
-			<translation>Filtry typów</translation>
-		</message>
-		<message>
-			<source>Programs</source>
-			<translation>Programy</translation>
-		</message>
-		<message>
-			<source>Apps</source>
-			<translation>Aplikacje</translation>
-		</message>
-		<message>
-			<source>System</source>
-			<translation>System</translation>
-		</message>
-		<message>
-			<source>Groups</source>
-			<translation>Grupy</translation>
-		</message>
-		<message>
-			<source>Run Filters</source>
-			<translation>Filtry uruchomień</translation>
-		</message>
-		<message>
-			<source>Ran Recently</source>
-			<translation>Uruchamiane ostatnio</translation>
-		</message>
-		<message>
-			<source>Rule Filters</source>
-			<translation>Filtry reguł</translation>
-		</message>
-		<message>
-			<source>Execution Rules</source>
-			<translation>Reguły wykonywania</translation>
-		</message>
-		<message>
-			<source>Access Rules</source>
-			<translation>Reguły dostępu</translation>
-		</message>
-		<message>
-			<source>Firewall Rules</source>
-			<translation>Reguły zapory</translation>
-		</message>
-		<message>
-			<source>Traffic Filters</source>
-			<translation>Filtry ruchu</translation>
-		</message>
-		<message>
-			<source>Recent Traffic</source>
-			<translation>Ostatni ruch</translation>
-		</message>
-		<message>
-			<source>Blocked Traffic</source>
-			<translation>Zablokowany ruch</translation>
-		</message>
-		<message>
-			<source>Allowed Traffic</source>
-			<translation>Dozwolony ruch</translation>
-		</message>
-		<message>
-			<source>Socket Filters</source>
-			<translation>Filtry gniazd</translation>
-		</message>
-		<message>
-			<source>CleanUp Program List</source>
-			<translation>Wyczyść listę programów</translation>
-		</message>
-		<message>
-			<source>Re-Group all Programs</source>
-			<translation>Przypisz programy do grup od nowa</translation>
-		</message>
-		<message>
-			<source>Add Program Item</source>
-			<translation>Dodaj element programu</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Automatyczne rozwijanie</translation>
-		</message>
-		<message>
-			<source>Edit Program</source>
-			<translation>Edytuj program</translation>
-		</message>
-		<message>
-			<source>Clear Trace</source>
-			<translation>Wyczyść ślady</translation>
-		</message>
-		<message>
-			<source>Execution Trace</source>
-			<translation>Ślad wykonania</translation>
-		</message>
-		<message>
-			<source>Resource Trace</source>
-			<translation>Ślad dostępu</translation>
-		</message>
-		<message>
-			<source>Network Trace</source>
-			<translation>Ślad sieciowy</translation>
-		</message>
-		<message>
-			<source>Trace Config</source>
-			<translation>Konfiguracja śledzenia</translation>
-		</message>
-		<message>
-			<source>Use Global Preset</source>
-			<translation>Użyj globalnego ustawienia</translation>
-		</message>
-		<message>
-			<source>Private Trace</source>
-			<translation>Ślad prywatny</translation>
-		</message>
-		<message>
-			<source>Trace</source>
-			<translation>Śledzenie</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Trace</source>
-			<translation>Nie śledź</translation>
-		</message>
-		<message>
-			<source>Store Trace</source>
-			<translation>Zapisuj ślad</translation>
-		</message>
-		<message>
-			<source>Save to Disk</source>
-			<translation>Zapisz na dysk</translation>
-		</message>
-		<message>
-			<source>Cache only in RAM</source>
-			<translation>Tylko pamięć RAM</translation>
-		</message>
-		<message>
-			<source>Add to Group</source>
-			<translation>Dodaj do grupy</translation>
-		</message>
-		<message>
-			<source>Remove</source>
-			<translation>Usuń</translation>
-		</message>
-		<message>
-			<source>Add Program</source>
-			<translation>Dodaj program</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Volume Protection Rule for: %1</source>
+        <translation>Reguła ochrony woluminu dla: %1</translation>
+    </message>
+    <message>
+        <source>Volume Unmount Rule for: %1</source>
+        <translation>Reguła odmontowania woluminu dla: %1</translation>
+    </message>
+    <message>
+        <source>Temporary rule</source>
+        <translation>Reguła tymczasowa</translation>
+    </message>
+    <message>
+        <source>%1 - MajorPrivacy Rule</source>
+        <translation>%1 – Reguła MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>%1 - MajorPrivacy Rule Template</source>
+        <translation>%1 – Szablon reguły MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Reset Columns</source>
+        <translation>Resetuj kolumny</translation>
+    </message>
+    <message>
+        <source>Copy Cell</source>
+        <translation>Skopiuj komórkę</translation>
+    </message>
+    <message>
+        <source>Copy Row</source>
+        <translation>Skopiuj wiersz</translation>
+    </message>
+    <message>
+        <source>Copy Panel</source>
+        <translation>Skopiuj panel</translation>
+    </message>
+    <message>
+        <source>Case Sensitive</source>
+        <translation>Uwzględnij wielkość liter</translation>
+    </message>
+    <message>
+        <source>Use Regular Expressions</source>
+        <translation>Użyj wyrażeń regularnych</translation>
+    </message>
+    <message>
+        <source>Highlight Items</source>
+        <translation>Wyróżnij elementy</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Zamknij</translation>
+    </message>
+    <message>
+        <source>&amp;Find ...</source>
+        <translation>&amp;Znajdź...</translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation>Wszystkie kolumny</translation>
+    </message>
+    <message>
+        <source>Search ...</source>
+        <translation>Szukaj...</translation>
+    </message>
+    <message>
+        <source>Toggle Search Bar</source>
+        <translation>Przełącz pasek wyszukiwania</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;About MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</source>
+        <translation>&lt;h3&gt;O programie MajorPrivacy&lt;/h3&gt;&lt;p&gt;Wersja %1&lt;/p&gt;&lt;p&gt;</translation>
+    </message>
+    <message>
+        <source>This version is licensed to %1.</source>
+        <translation>Ta wersja jest licencjonowana dla: %1.</translation>
+    </message>
+    <message>
+        <source>This version was licensed to %1, but its no longer valid.</source>
+        <translation>Ta wersja była licencjonowana dla %1, ale licencja jest już nieważna.</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;MajorPrivacy is a program that helps you to protect your privacy and security.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; for more information.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI Config Dir: &lt;br /&gt;%2&lt;br /&gt;Core Config Dir: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;MajorPrivacy to program pomagający chronić Twoją prywatność i bezpieczeństwo.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Odwiedź &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt;, aby uzyskać więcej informacji.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Katalog konfiguracji UI: &lt;br /&gt;%2&lt;br /&gt;Katalog konfiguracji rdzenia: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Ikony z &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Enter the path of a program that will be created in a sandbox.</source>
+        <translation>Podaj ścieżkę programu, który zostanie utworzony w piaskownicy.</translation>
+    </message>
+</context>
+<context>
+    <name>CMountMgrWnd</name>
+    <message>
+        <source>Volume|Device Path</source>
+        <translation>Wolumin|Ścieżka urządzenia</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Odśwież</translation>
+    </message>
+</context>
+<context>
+    <name>CNetTraceModel</name>
+    <message>
+        <source>Unknown Program</source>
+        <translation>Nieznany program</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>PROCESS MISSING</source>
+        <translation>PROCES BRAKUJE</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokół</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Kierunek</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Zdalny adres</translation>
+    </message>
+    <message>
+        <source>Remote Port</source>
+        <translation>Zdalny port</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Lokalny adres</translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation>Lokalny port</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Wysłano</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Pobrano</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CNetTraceView</name>
+    <message>
+        <source>All Directions</source>
+        <translation>Wszystkie kierunki</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Przychodzące</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Wychodzące</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>All Protocols</source>
+        <translation>Wszystkie protokoły</translation>
+    </message>
+    <message>
+        <source>HTTP(S)</source>
+        <translation>HTTP(S)</translation>
+    </message>
+    <message>
+        <source>TCP Sockets</source>
+        <translation>Gniazda TCP</translation>
+    </message>
+    <message>
+        <source>TCP Clients</source>
+        <translation>Klienci TCP</translation>
+    </message>
+    <message>
+        <source>TCP Servers</source>
+        <translation>Serwery TCP</translation>
+    </message>
+    <message>
+        <source>UDP Sockets</source>
+        <translation>Gniazda UDP</translation>
+    </message>
+    <message>
+        <source>Area Filter</source>
+        <translation>Filtr obszaru</translation>
+    </message>
+    <message>
+        <source>Internet</source>
+        <translation>Internet</translation>
+    </message>
+    <message>
+        <source>Local Area</source>
+        <translation>Sieć lokalna</translation>
+    </message>
+    <message>
+        <source>Local Host</source>
+        <translation>Host lokalny</translation>
+    </message>
+    <message>
+        <source>Auto Scroll</source>
+        <translation>Automatyczne przewijanie</translation>
+    </message>
+    <message>
+        <source>Hold updates</source>
+        <translation>Wstrzymaj aktualizacje</translation>
+    </message>
+    <message>
+        <source>Clear Trace Log</source>
+        <translation>Wyczyść dziennik śledzenia</translation>
+    </message>
+</context>
+<context>
+    <name>CNetworkPage</name>
+    <message>
+        <source>Firewall Rules</source>
+        <translation>Reguły zapory</translation>
+    </message>
+    <message>
+        <source>Open Socket</source>
+        <translation>Otwórz gniazdo</translation>
+    </message>
+    <message>
+        <source>Traffic Monitor</source>
+        <translation>Monitor ruchu</translation>
+    </message>
+    <message>
+        <source>Connection Log</source>
+        <translation>Dziennik połączeń</translation>
+    </message>
+</context>
+<context>
+    <name>COptionsTransferWnd</name>
+    <message>
+        <source>Select the data you want to import</source>
+        <translation>Wybierz dane do zaimportowania</translation>
+    </message>
+    <message>
+        <source>Select the data you want to export</source>
+        <translation>Wybierz dane do wyeksportowania</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpWindow</name>
+    <message>
+        <source>MajorPrivacy Notifications</source>
+        <translation>Powiadomienia MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Permanent</source>
+        <translation>Na stałe</translation>
+    </message>
+    <message>
+        <source>Untill Restart</source>
+        <translation>Do ponownego uruchomienia</translation>
+    </message>
+    <message>
+        <source>for 1 Minute</source>
+        <translation>na 1 minutę</translation>
+    </message>
+    <message>
+        <source>for 5 Minutes</source>
+        <translation>na 5 minut</translation>
+    </message>
+    <message>
+        <source>for 15 Minutes</source>
+        <translation>na 15 minut</translation>
+    </message>
+    <message>
+        <source>for 30 Minutes</source>
+        <translation>na 30 minut</translation>
+    </message>
+    <message>
+        <source>for 60 Minutes</source>
+        <translation>na 60 minut</translation>
+    </message>
+    <message>
+        <source>Always Ignore this Program</source>
+        <translation>Zawsze ignoruj ten program</translation>
+    </message>
+    <message>
+        <source>Create Custom Rule</source>
+        <translation>Utwórz regułę niestandardową</translation>
+    </message>
+    <message>
+        <source>Always Ignore this Path</source>
+        <translation>Zawsze ignoruj tę ścieżkę</translation>
+    </message>
+    <message>
+        <source>Allow Read Only Access</source>
+        <translation>Zezwól tylko na odczyt</translation>
+    </message>
+    <message>
+        <source>Allow Directory Listing ONLY</source>
+        <translation>Zezwól tylko na listę katalogu</translation>
+    </message>
+    <message>
+        <source>Always Ignore this Binary</source>
+        <translation>Zawsze ignoruj ten plik binarny</translation>
+    </message>
+    <message>
+        <source>Sign Certificate</source>
+        <translation>Podpisz certyfikat</translation>
+    </message>
+    <message>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <source>%1:%2</source>
+        <translation>%1:%2</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>%1 - Rule</source>
+        <translation>%1 – Reguła</translation>
+    </message>
+    <message>
+        <source>Please select a resource to create a rule for.</source>
+        <translation>Wybierz zasób, dla którego ma zostać utworzona reguła.</translation>
+    </message>
+    <message>
+        <source>Please select a binnary file to sign with the your User Key.</source>
+        <translation>Wybierz plik binarny do podpisania swoim kluczem użytkownika.</translation>
+    </message>
+    <message>
+        <source>Selected Items do not have Certificates!</source>
+        <translation>Wybrane elementy nie mają certyfikatów!</translation>
+    </message>
+</context>
+<context>
+    <name>CProcess</name>
+    <message>
+        <source>Sec: %1</source>
+        <translation>Sek: %1</translation>
+    </message>
+    <message>
+        <source>%1 (</source>
+        <translation>%1 (</translation>
+    </message>
+    <message>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <source>%1+%2</source>
+        <translation>%1+%2</translation>
+    </message>
+    <message>
+        <source>/%1/%2/%3)</source>
+        <translation>/%1/%2/%3)</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessModel</name>
+    <message>
+        <source>Process</source>
+        <translation>Proces</translation>
+    </message>
+    <message>
+        <source>PID</source>
+        <translation>PID</translation>
+    </message>
+    <message>
+        <source>Parent PID</source>
+        <translation>PID nadrzędny</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Poziom zaufania</translation>
+    </message>
+    <message>
+        <source>User Name</source>
+        <translation>Nazwa użytkownika</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Image Loads (MS/V/S/U)</source>
+        <translation>Załadowane obrazy (MS/V/S/U)</translation>
+    </message>
+    <message>
+        <source>File Name</source>
+        <translation>Nazwa pliku</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessPage</name>
+    <message>
+        <source>Process Rules</source>
+        <translation>Reguły procesów</translation>
+    </message>
+    <message>
+        <source>Running Processes</source>
+        <translation>Uruchomione procesy</translation>
+    </message>
+    <message>
+        <source>Loaded Modules</source>
+        <translation>Załadowane moduły</translation>
+    </message>
+    <message>
+        <source>Execution Monitor</source>
+        <translation>Monitor uruchomień</translation>
+    </message>
+    <message>
+        <source>Ingress Monitor</source>
+        <translation>Monitor wejść</translation>
+    </message>
+    <message>
+        <source>Trace Log</source>
+        <translation>Dziennik śledzenia</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessTraceModel</name>
+    <message>
+        <source>PROGRAM MISSING</source>
+        <translation>PROGRAM BRAK</translation>
+    </message>
+    <message>
+        <source> [%1]</source>
+        <translation> [%1]</translation>
+    </message>
+    <message>
+        <source>MODULE MISSING</source>
+        <translation>MODUŁ BRAK</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rola</translation>
+    </message>
+    <message>
+        <source>Operation</source>
+        <translation>Operacja</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Subject</source>
+        <translation>Obiekt</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessTraceView</name>
+    <message>
+        <source>Any Role</source>
+        <translation>Dowolna rola</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Wykonawca</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Cel</translation>
+    </message>
+    <message>
+        <source>Any Status</source>
+        <translation>Dowolny status</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Auto Scroll</source>
+        <translation>Automatyczne przewijanie</translation>
+    </message>
+    <message>
+        <source>Hold updates</source>
+        <translation>Wstrzymaj aktualizacje</translation>
+    </message>
+    <message>
+        <source>Clear Trace Log</source>
+        <translation>Wyczyść dziennik śledzenia</translation>
+    </message>
+</context>
+<context>
+    <name>CProcessView</name>
+    <message>
+        <source>All</source>
+        <translation>Wszystkie</translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation>Użytkownik</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Show Tree</source>
+        <translation>Pokaż drzewo</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramFile</name>
+    <message>
+        <source> (CI: Level 0)</source>
+        <translation> (CI: Poziom 0)</translation>
+    </message>
+    <message>
+        <source> (CI: Enterprise)</source>
+        <translation> (CI: Enterprise)</translation>
+    </message>
+    <message>
+        <source> (CI: Developer)</source>
+        <translation> (CI: Deweloper)</translation>
+    </message>
+    <message>
+        <source> (CI: Authenticode)</source>
+        <translation> (CI: Authenticode)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 2)</source>
+        <translation> (CI: Poziom 2)</translation>
+    </message>
+    <message>
+        <source> (CI: Store)</source>
+        <translation> (CI: Sklep)</translation>
+    </message>
+    <message>
+        <source> (CI: Antimalware)</source>
+        <translation> (CI: Antymalware)</translation>
+    </message>
+    <message>
+        <source> (CI: Microsoft)</source>
+        <translation> (CI: Microsoft)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 4)</source>
+        <translation> (CI: Poziom 4)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 5)</source>
+        <translation> (CI: Poziom 5)</translation>
+    </message>
+    <message>
+        <source> (CI: Code Gen.)</source>
+        <translation> (CI: Code Gen.)</translation>
+    </message>
+    <message>
+        <source> (CI: Windows)</source>
+        <translation> (CI: Windows)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 7)</source>
+        <translation> (CI: Poziom 7)</translation>
+    </message>
+    <message>
+        <source> (CI: Windows TCB)</source>
+        <translation> (CI: Windows TCB)</translation>
+    </message>
+    <message>
+        <source> (CI: Level 6)</source>
+        <translation> (CI: Poziom 6)</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Brak</translation>
+    </message>
+    <message>
+        <source>Microsoft</source>
+        <translation>Microsoft</translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message>
+        <source>Code</source>
+        <translation>Kod</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznane</translation>
+    </message>
+    <message>
+        <source>DMD</source>
+        <translation>DMD</translation>
+    </message>
+    <message>
+        <source>DMD Test</source>
+        <translation>DMD Test</translation>
+    </message>
+    <message>
+        <source>3rd Party</source>
+        <translation>Strona trzecia</translation>
+    </message>
+    <message>
+        <source>Trusted Boot</source>
+        <translation>Zaufany rozruch</translation>
+    </message>
+    <message>
+        <source>UEFI</source>
+        <translation>UEFI</translation>
+    </message>
+    <message>
+        <source>Flight</source>
+        <translation>Flight</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>Inne</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation>Błąd: %1</translation>
+    </message>
+    <message>
+        <source> (Root: %1)</source>
+        <translation> (Root: %1)</translation>
+    </message>
+    <message>
+        <source> (Roots: %1)</source>
+        <translation> (Roots: %1)</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramItem</name>
+    <message>
+        <source>Executable File</source>
+        <translation>Plik wykonywalny</translation>
+    </message>
+    <message>
+        <source>File Path Pattern</source>
+        <translation>Wzorzec ścieżki pliku</translation>
+    </message>
+    <message>
+        <source>Installation</source>
+        <translation>Instalacja</translation>
+    </message>
+    <message>
+        <source>Windows Service</source>
+        <translation>Usługa Windows</translation>
+    </message>
+    <message>
+        <source>Application Package</source>
+        <translation>Paczka aplikacji</translation>
+    </message>
+    <message>
+        <source>Program Set</source>
+        <translation>Zestaw programów</translation>
+    </message>
+    <message>
+        <source>Program List</source>
+        <translation>Lista programów</translation>
+    </message>
+    <message>
+        <source>Program Group</source>
+        <translation>Grupa programów</translation>
+    </message>
+    <message>
+        <source>All Programs</source>
+        <translation>Wszystkie programy</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznany</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramModel</name>
+    <message>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Processes</source>
+        <translation>Procesy</translation>
+    </message>
+    <message>
+        <source>Program Rules</source>
+        <translation>Reguły programów</translation>
+    </message>
+    <message>
+        <source>Last Execution</source>
+        <translation>Ostatnie uruchomienie</translation>
+    </message>
+    <message>
+        <source>Accessed Files</source>
+        <translation>Otwierane pliki</translation>
+    </message>
+    <message>
+        <source>Access Rules</source>
+        <translation>Reguły dostępu</translation>
+    </message>
+    <message>
+        <source>Open Sockets</source>
+        <translation>Otwarte gniazda</translation>
+    </message>
+    <message>
+        <source>FW Rules</source>
+        <translation>Reguły FW</translation>
+    </message>
+    <message>
+        <source>Last Net Activity</source>
+        <translation>Ostatnia aktywność sieciowa</translation>
+    </message>
+    <message>
+        <source>Upload</source>
+        <translation>Wysyłanie</translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation>Pobieranie</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Wysłano</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Pobrano</translation>
+    </message>
+    <message>
+        <source>Log Size</source>
+        <translation>Rozmiar dziennika</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Ścieżka</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramPicker</name>
+    <message>
+        <source>MajorPrivacy - Select Program</source>
+        <translation>MajorPrivacy – Wybierz program</translation>
+    </message>
+    <message>
+        <source>Please select a program</source>
+        <translation>Proszę wybrać program</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRule</name>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Chroń</translation>
+    </message>
+    <message>
+        <source>Isolate</source>
+        <translation>Izoluj</translation>
+    </message>
+    <message>
+        <source>Audit</source>
+        <translation>Audyt</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRuleModel</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation>%1 – %2</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Tak</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Włączone</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Akcja</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Poziom zaufania</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRuleView</name>
+    <message>
+        <source>Enable Rule</source>
+        <translation>Włącz regułę</translation>
+    </message>
+    <message>
+        <source>Disable Rule</source>
+        <translation>Wyłącz regułę</translation>
+    </message>
+    <message>
+        <source>Delete Rule</source>
+        <translation>Usuń regułę</translation>
+    </message>
+    <message>
+        <source>Edit Rule</source>
+        <translation>Edytuj regułę</translation>
+    </message>
+    <message>
+        <source>Duplicate Rule</source>
+        <translation>Duplikuj regułę</translation>
+    </message>
+    <message>
+        <source>Create Rule</source>
+        <translation>Utwórz regułę</translation>
+    </message>
+    <message>
+        <source>All Actions</source>
+        <translation>Wszystkie akcje</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Chroń</translation>
+    </message>
+    <message>
+        <source>Hide Disabled Rules</source>
+        <translation>Ukryj wyłączone reguły</translation>
+    </message>
+    <message>
+        <source>Refresh Rules</source>
+        <translation>Odśwież reguły</translation>
+    </message>
+    <message>
+        <source>Do you want to delete selected Rules Items?</source>
+        <translation>Czy chcesz usunąć zaznaczone reguły?</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramRuleWnd</name>
+    <message>
+        <source>Create Program Rule</source>
+        <translation>Utwórz regułę programu</translation>
+    </message>
+    <message>
+        <source>Edit Program Rule</source>
+        <translation>Edytuj regułę programu</translation>
+    </message>
+    <message>
+        <source>New Program Rule</source>
+        <translation>Nowa reguła programu</translation>
+    </message>
+    <message>
+        <source>Global (Any/No Enclave)</source>
+        <translation>Globalna (dowolna/brak enklawy)</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Protect</source>
+        <translation>Chroń</translation>
+    </message>
+    <message>
+        <source>Audit</source>
+        <translation>Audyt</translation>
+    </message>
+    <message>
+        <source>Unconfigured</source>
+        <translation>Nieskonfigurowane</translation>
+    </message>
+    <message>
+        <source>User Signature ONLY (not recommended)</source>
+        <translation>Tylko podpis użytkownika (niezalecane)</translation>
+    </message>
+    <message>
+        <source>User + Microsoft/AV Signature</source>
+        <translation>Podpis użytkownika + Microsoft/AV</translation>
+    </message>
+    <message>
+        <source>User + Trusted by Microsoft (Code Root)</source>
+        <translation>Użytkownik + zaufany przez Microsoft (Code Root)</translation>
+    </message>
+    <message>
+        <source>Any Signature (Unknown Root)</source>
+        <translation>Dowolny podpis (nieznany root)</translation>
+    </message>
+    <message>
+        <source>No Signature</source>
+        <translation>Brak podpisu</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <source>Please select an enclave for a protection rule.</source>
+        <translation>Wybierz enklawę dla reguły ochrony.</translation>
+    </message>
+    <message>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Wybrany typ programu nie jest obsługiwany dla tej reguły</translation>
+    </message>
+    <message>
+        <source>%1 %2</source>
+        <translation>%1 %2</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramView</name>
+    <message>
+        <source>Type Filters</source>
+        <translation>Filtry typów</translation>
+    </message>
+    <message>
+        <source>Programs</source>
+        <translation>Programy</translation>
+    </message>
+    <message>
+        <source>Apps</source>
+        <translation>Aplikacje</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <translation>Grupy</translation>
+    </message>
+    <message>
+        <source>Run Filters</source>
+        <translation>Filtry uruchomień</translation>
+    </message>
+    <message>
+        <source>Ran Recently</source>
+        <translation>Uruchamiane ostatnio</translation>
+    </message>
+    <message>
+        <source>Rule Filters</source>
+        <translation>Filtry reguł</translation>
+    </message>
+    <message>
+        <source>Execution Rules</source>
+        <translation>Reguły wykonywania</translation>
+    </message>
+    <message>
+        <source>Access Rules</source>
+        <translation>Reguły dostępu</translation>
+    </message>
+    <message>
+        <source>Firewall Rules</source>
+        <translation>Reguły zapory</translation>
+    </message>
+    <message>
+        <source>Traffic Filters</source>
+        <translation>Filtry ruchu</translation>
+    </message>
+    <message>
+        <source>Recent Traffic</source>
+        <translation>Ostatni ruch</translation>
+    </message>
+    <message>
+        <source>Blocked Traffic</source>
+        <translation>Zablokowany ruch</translation>
+    </message>
+    <message>
+        <source>Allowed Traffic</source>
+        <translation>Dozwolony ruch</translation>
+    </message>
+    <message>
+        <source>Socket Filters</source>
+        <translation>Filtry gniazd</translation>
+    </message>
+    <message>
+        <source>CleanUp Program List</source>
+        <translation>Wyczyść listę programów</translation>
+    </message>
+    <message>
+        <source>Re-Group all Programs</source>
+        <translation>Przypisz programy do grup od nowa</translation>
+    </message>
+    <message>
+        <source>Add Program Item</source>
+        <translation>Dodaj element programu</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Automatyczne rozwijanie</translation>
+    </message>
+    <message>
+        <source>Edit Program</source>
+        <translation>Edytuj program</translation>
+    </message>
+    <message>
+        <source>Clear Trace</source>
+        <translation>Wyczyść ślady</translation>
+    </message>
+    <message>
+        <source>Execution Trace</source>
+        <translation>Ślad wykonania</translation>
+    </message>
+    <message>
+        <source>Resource Trace</source>
+        <translation>Ślad dostępu</translation>
+    </message>
+    <message>
+        <source>Network Trace</source>
+        <translation>Ślad sieciowy</translation>
+    </message>
+    <message>
+        <source>Trace Config</source>
+        <translation>Konfiguracja śledzenia</translation>
+    </message>
+    <message>
+        <source>Use Global Preset</source>
+        <translation>Użyj globalnego ustawienia</translation>
+    </message>
+    <message>
+        <source>Private Trace</source>
+        <translation>Ślad prywatny</translation>
+    </message>
+    <message>
+        <source>Trace</source>
+        <translation>Śledzenie</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Trace</source>
+        <translation>Nie śledź</translation>
+    </message>
+    <message>
+        <source>Store Trace</source>
+        <translation>Zapisuj ślad</translation>
+    </message>
+    <message>
+        <source>Save to Disk</source>
+        <translation>Zapisz na dysk</translation>
+    </message>
+    <message>
+        <source>Cache only in RAM</source>
+        <translation>Tylko pamięć RAM</translation>
+    </message>
+    <message>
+        <source>Add to Group</source>
+        <translation>Dodaj do grupy</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Usuń</translation>
+    </message>
+    <message>
+        <source>Add Program</source>
+        <translation>Dodaj program</translation>
+    </message>
+    <message>
+        <source>
 				Do you want to delete selected Program Items (Yes)?
 				The selected Item has children, do you want to delete them as well (Yes to All)?
 			</source>
-			<translation>
+        <translation>
 				Czy chcesz usunąć zaznaczone elementy programu (Tak)?
 				Wybrany element ma podpozycje — usunąć je również (Tak dla wszystkich)?
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				Do you want to delete selected Program Items?
-				The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.
+				The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.
 			</source>
-			<translation>
+        <translation>
 				Czy chcesz usunąć zaznaczone elementy programu?
 				Wybrany element należy do więcej niż jednej grupy — usuń ze wszystkich (Tak dla wszystkich), usuń tylko z bieżącej grupy (Tak).
 			</translation>
-		</message>
-		<message>
-			<source>Do you want to delete selected Program Items?</source>
-			<translation>Czy chcesz usunąć zaznaczone programy?</translation>
-		</message>
-		<message>
-			<source>The selected Program Item has rules, do you want to delete them as well?</source>
-			<translation>Wybrany program ma przypisane reguły — czy je również usunąć?</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the Execution/Ingress trace logs for the current program items?</source>
-			<translation>Czy na pewno chcesz wyczyścić dzienniki wykonania/wejścia dla bieżących programów?</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the Resource Access trace logs for the current program items?</source>
-			<translation>Czy na pewno chcesz wyczyścić dzienniki dostępu do zasobów dla bieżących programów?</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the Network Access trace logs for the current program items?</source>
-			<translation>Czy na pewno chcesz wyczyścić dzienniki dostępu sieciowego dla bieżących programów?</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CProgramWnd</name>
-		<message>
-			<source>Change Icon</source>
-			<translation>Zmień ikonę</translation>
-		</message>
-		<message>
-			<source>Browse for Image</source>
-			<translation>Wybierz obraz</translation>
-		</message>
-		<message>
-			<source>Browse for File</source>
-			<translation>Wybierz plik</translation>
-		</message>
-		<message>
-			<source>Browse for Folder</source>
-			<translation>Wybierz folder</translation>
-		</message>
-		<message>
-			<source>Create Program Item</source>
-			<translation>Utwórz element programu</translation>
-		</message>
-		<message>
-			<source>Edit Program Item</source>
-			<translation>Edytuj element programu</translation>
-		</message>
-		<message>
-			<source>Use Global Preset</source>
-			<translation>Użyj globalnego ustawienia</translation>
-		</message>
-		<message>
-			<source>Private Trace</source>
-			<translation>Prywatny ślad</translation>
-		</message>
-		<message>
-			<source>Trace</source>
-			<translation>Śledzenie</translation>
-		</message>
-		<message>
-			<source>Don&apos;t Trace</source>
-			<translation>Nie śledź</translation>
-		</message>
-		<message>
-			<source>Save to Disk</source>
-			<translation>Zapisz na dysk</translation>
-		</message>
-		<message>
-			<source>Cache only in RAM</source>
-			<translation>Tylko w RAM</translation>
-		</message>
-		<message>
-			<source>New Program Item</source>
-			<translation>Nowy element programu</translation>
-		</message>
-		<message>
-			<source>Select Image File</source>
-			<translation>Wybierz plik graficzny</translation>
-		</message>
-		<message>
-			<source>Image Files (*.png)</source>
-			<translation>Pliki graficzne (*.png)</translation>
-		</message>
-		<message>
-			<source>Select Program File</source>
-			<translation>Wybierz plik programu</translation>
-		</message>
-		<message>
-			<source>Executable Files (*.exe)</source>
-			<translation>Pliki wykonywalne (*.exe)</translation>
-		</message>
-		<message>
-			<source>Select Directory</source>
-			<translation>Wybierz katalog</translation>
-		</message>
-	</context>
-	<context>
-		<name>CSettingsWindow</name>
-		<message>
-			<source>Major Privacy - Settings</source>
-			<translation>Major Privacy - Ustawienia</translation>
-		</message>
-		<message>
-			<source>Auto Detection</source>
-			<translation>Automatyczne wykrywanie</translation>
-		</message>
-		<message>
-			<source>No Translation</source>
-			<translation>Bez tłumaczenia</translation>
-		</message>
-		<message>
-			<source>All</source>
-			<translation>Wszystkie</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Off</source>
-			<translation>Wyłączone</translation>
-		</message>
-		<message>
-			<source>Search for settings</source>
-			<translation>Szukaj ustawień</translation>
-		</message>
-		<message>
-			<source>Enter Block Lisz URL to be added</source>
-			<translation>Wprowadź adres URL listy blokowania do dodania</translation>
-		</message>
-		<message>
-			<source>Binary Image</source>
-			<translation>Obraz binarny</translation>
-		</message>
-		<message>
-			<source>Resource Access</source>
-			<translation>Dostęp do zasobów</translation>
-		</message>
-		<message>
-			<source>Network Access</source>
-			<translation>Dostęp do sieci</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CSidResolver</name>
-		<message>
-			<source>Resolving...</source>
-			<translation>Rozwiązywanie...</translation>
-		</message>
-		<message>
-			<source>Not resolved...</source>
-			<translation>Nie rozwiązano...</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CSignatureDbWnd</name>
-		<message>
-			<source>Delete Signature</source>
-			<translation>Usuń podpis</translation>
-		</message>
-		<message>
-			<source>Name|Path</source>
-			<translation>Nazwa|Ścieżka</translation>
-		</message>
-		<message>
-			<source>Refresh</source>
-			<translation>Odśwież</translation>
-		</message>
-		<message>
-			<source>MajorPrivacy</source>
-			<translation>MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to delete the signature?</source>
-			<translation>Czy na pewno chcesz usunąć podpis?</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CSocket</name>
-		<message>
-			<source>Closed</source>
-			<translation>Zamknięte</translation>
-		</message>
-		<message>
-			<source>Open</source>
-			<translation>Otwarty</translation>
-		</message>
-		<message>
-			<source>Listen</source>
-			<translation>Nadsłuchiwanie</translation>
-		</message>
-		<message>
-			<source>SYN sent</source>
-			<translation>SYN wysłany</translation>
-		</message>
-		<message>
-			<source>SYN received</source>
-			<translation>Odebrano SYN</translation>
-		</message>
-		<message>
-			<source>Established</source>
-			<translation>Ustanowione</translation>
-		</message>
-		<message>
-			<source>FIN wait 1</source>
-			<translation>FIN czekaj 1</translation>
-		</message>
-		<message>
-			<source>FIN wait 2</source>
-			<translation>FIN czekaj 2</translation>
-		</message>
-		<message>
-			<source>Close wait</source>
-			<translation>Oczekiwanie na zamknięcie</translation>
-		</message>
-		<message>
-			<source>Closing</source>
-			<translation>Zamykanie</translation>
-		</message>
-		<message>
-			<source>Last ACK</source>
-			<translation>Ostatni ACK</translation>
-		</message>
-		<message>
-			<source>Time wait</source>
-			<translation>Oczekiwanie czasowe</translation>
-		</message>
-		<message>
-			<source>Delete TCB</source>
-			<translation>Usuń TCB</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source>Unknown %1</source>
-			<translation>Nieznane %1</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CSocketModel</name>
-		<message>
-			<source>Unknown Process</source>
-			<translation>Nieznany proces</translation>
-		</message>
-		<message>
-			<source> (%1)</source>
-			<translation> (%1)</translation>
-		</message>
-		<message>
-			<source>PROCESS MISSING</source>
-			<translation>PROCES BRAK</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokół</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Adres zdalny</translation>
-		</message>
-		<message>
-			<source>Remote Port</source>
-			<translation>Port zdalny</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Adres lokalny</translation>
-		</message>
-		<message>
-			<source>Local Port</source>
-			<translation>Port lokalny</translation>
-		</message>
-		<message>
-			<source>Access</source>
-			<translation>Dostęp</translation>
-		</message>
-		<message>
-			<source>State</source>
-			<translation>Stan</translation>
-		</message>
-		<message>
-			<source>Last Activity</source>
-			<translation>Ostatnia aktywność</translation>
-		</message>
-		<message>
-			<source>Upload</source>
-			<translation>Wysyłanie</translation>
-		</message>
-		<message>
-			<source>Download</source>
-			<translation>Pobieranie</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Wysłane</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Pobrane</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CSocketView</name>
-		<message>
-			<source>All Protocols</source>
-			<translation>Wszystkie protokoły</translation>
-		</message>
-		<message>
-			<source>HTTP(S)</source>
-			<translation>HTTP(S)</translation>
-		</message>
-		<message>
-			<source>TCP Sockets</source>
-			<translation>Gniazda TCP</translation>
-		</message>
-		<message>
-			<source>TCP Clients</source>
-			<translation>Klienci TCP</translation>
-		</message>
-		<message>
-			<source>TCP Servers</source>
-			<translation>Serwery TCP</translation>
-		</message>
-		<message>
-			<source>UDP Sockets</source>
-			<translation>Gniazda UDP</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CTraceView</name>
-		<message>
-			<source>Loading %1</source>
-			<translation>Ładowanie %1</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to clear the the trace logs for the current program items?</source>
-			<translation>Czy na pewno chcesz wyczyścić dzienniki śledzenia dla bieżących programów?</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>CTrafficModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Last Activity</source>
-			<translation>Ostatnia aktywność</translation>
-		</message>
-		<message>
-			<source>Uploaded</source>
-			<translation>Wysłane</translation>
-		</message>
-		<message>
-			<source>Downloaded</source>
-			<translation>Pobrane</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTrafficView</name>
-		<message>
-			<source>By Host</source>
-			<translation>Według hosta</translation>
-		</message>
-		<message>
-			<source>By Program</source>
-			<translation>Według programu</translation>
-		</message>
-		<message>
-			<source>Area Filter</source>
-			<translation>Filtr obszaru</translation>
-		</message>
-		<message>
-			<source>Internet</source>
-			<translation>Internet</translation>
-		</message>
-		<message>
-			<source>Local Area</source>
-			<translation>Sieć lokalna</translation>
-		</message>
-		<message>
-			<source>Local Host</source>
-			<translation>Host lokalny</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Auto rozwijanie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakInfo</name>
-		<message>
-			<source>Apply Tweak</source>
-			<translation>Zastosuj poprawkę</translation>
-		</message>
-		<message>
-			<source>Undo Tweak</source>
-			<translation>Cofnij poprawkę</translation>
-		</message>
-		<message>
-			<source>Tweak Info</source>
-			<translation>Informacje o poprawce</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Summary</source>
-			<translation>Podsumowanie</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakList</name>
-		<message>
-			<source>%1 (%2/%3)</source>
-			<translation>%1 (%2/%3)</translation>
-		</message>
-		<message>
-			<source>%1 (%2)</source>
-			<translation>%1 (%2)</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Hint</source>
-			<translation>Wskazówka</translation>
-		</message>
-		<message>
-			<source>Info</source>
-			<translation>Informacja</translation>
-		</message>
-	</context>
-	<context>
-		<name>CTweakView</name>
-		<message>
-			<source>Refresh tweak states</source>
-			<translation>Odśwież stan poprawek</translation>
-		</message>
-		<message>
-			<source>Show not available tweaks</source>
-			<translation>Pokaż niedostępne poprawki</translation>
-		</message>
-		<message>
-			<source>Approve Current State</source>
-			<translation>Zatwierdź obecny stan</translation>
-		</message>
-		<message>
-			<source>Restore Approved State</source>
-			<translation>Przywróć zatwierdzony stan</translation>
-		</message>
-		<message>
-			<source>Auto Expand</source>
-			<translation>Auto rozwijanie</translation>
-		</message>
-		<message>
-			<source>This tweak is marked as breaking, hence it may break something. Are you sure you want to apply it?</source>
-			<translation>Ta poprawka jest oznaczona jako ryzykowna i może coś zepsuć. Czy na pewno chcesz ją zastosować?</translation>
-		</message>
-		<message>
-			<source>Don&apos;t show this message again.</source>
-			<translation>Nie pokazuj ponownie tej wiadomości.</translation>
-		</message>
-		<message>
-			<source>MajorPrivacy</source>
-			<translation>MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Are you sure you want to approve the current state of all tweaks?</source>
-			<translation>Czy na pewno chcesz zatwierdzić obecny stan wszystkich poprawek?</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Do you want to delete selected Program Items?</source>
+        <translation>Czy chcesz usunąć zaznaczone programy?</translation>
+    </message>
+    <message>
+        <source>The selected Program Item has rules, do you want to delete them as well?</source>
+        <translation>Wybrany program ma przypisane reguły — czy je również usunąć?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the Execution/Ingress trace logs for the current program items?</source>
+        <translation>Czy na pewno chcesz wyczyścić dzienniki wykonania/wejścia dla bieżących programów?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the Resource Access trace logs for the current program items?</source>
+        <translation>Czy na pewno chcesz wyczyścić dzienniki dostępu do zasobów dla bieżących programów?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the Network Access trace logs for the current program items?</source>
+        <translation>Czy na pewno chcesz wyczyścić dzienniki dostępu sieciowego dla bieżących programów?</translation>
+    </message>
+</context>
+<context>
+    <name>CProgramWnd</name>
+    <message>
+        <source>Change Icon</source>
+        <translation>Zmień ikonę</translation>
+    </message>
+    <message>
+        <source>Browse for Image</source>
+        <translation>Wybierz obraz</translation>
+    </message>
+    <message>
+        <source>Browse for File</source>
+        <translation>Wybierz plik</translation>
+    </message>
+    <message>
+        <source>Browse for Folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <source>Create Program Item</source>
+        <translation>Utwórz element programu</translation>
+    </message>
+    <message>
+        <source>Edit Program Item</source>
+        <translation>Edytuj element programu</translation>
+    </message>
+    <message>
+        <source>Use Global Preset</source>
+        <translation>Użyj globalnego ustawienia</translation>
+    </message>
+    <message>
+        <source>Private Trace</source>
+        <translation>Prywatny ślad</translation>
+    </message>
+    <message>
+        <source>Trace</source>
+        <translation>Śledzenie</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Trace</source>
+        <translation>Nie śledź</translation>
+    </message>
+    <message>
+        <source>Save to Disk</source>
+        <translation>Zapisz na dysk</translation>
+    </message>
+    <message>
+        <source>Cache only in RAM</source>
+        <translation>Tylko w RAM</translation>
+    </message>
+    <message>
+        <source>New Program Item</source>
+        <translation>Nowy element programu</translation>
+    </message>
+    <message>
+        <source>Select Image File</source>
+        <translation>Wybierz plik graficzny</translation>
+    </message>
+    <message>
+        <source>Image Files (*.png)</source>
+        <translation>Pliki graficzne (*.png)</translation>
+    </message>
+    <message>
+        <source>Select Program File</source>
+        <translation>Wybierz plik programu</translation>
+    </message>
+    <message>
+        <source>Executable Files (*.exe)</source>
+        <translation>Pliki wykonywalne (*.exe)</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>Wybierz katalog</translation>
+    </message>
+</context>
+<context>
+    <name>CSettingsWindow</name>
+    <message>
+        <source>Major Privacy - Settings</source>
+        <translation>Major Privacy - Ustawienia</translation>
+    </message>
+    <message>
+        <source>Auto Detection</source>
+        <translation>Automatyczne wykrywanie</translation>
+    </message>
+    <message>
+        <source>No Translation</source>
+        <translation>Bez tłumaczenia</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Wszystkie</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Wyłączone</translation>
+    </message>
+    <message>
+        <source>Search for settings</source>
+        <translation>Szukaj ustawień</translation>
+    </message>
+    <message>
+        <source>Enter Block Lisz URL to be added</source>
+        <translation>Wprowadź adres URL listy blokowania do dodania</translation>
+    </message>
+    <message>
+        <source>Binary Image</source>
+        <translation>Obraz binarny</translation>
+    </message>
+    <message>
+        <source>Resource Access</source>
+        <translation>Dostęp do zasobów</translation>
+    </message>
+    <message>
+        <source>Network Access</source>
+        <translation>Dostęp do sieci</translation>
+    </message>
+</context>
+<context>
+    <name>CSidResolver</name>
+    <message>
+        <source>Resolving...</source>
+        <translation>Rozwiązywanie...</translation>
+    </message>
+    <message>
+        <source>Not resolved...</source>
+        <translation>Nie rozwiązano...</translation>
+    </message>
+</context>
+<context>
+    <name>CSignatureDbWnd</name>
+    <message>
+        <source>Delete Signature</source>
+        <translation>Usuń podpis</translation>
+    </message>
+    <message>
+        <source>Name|Path</source>
+        <translation>Nazwa|Ścieżka</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Odśwież</translation>
+    </message>
+    <message>
+        <source>MajorPrivacy</source>
+        <translation>MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete the signature?</source>
+        <translation>Czy na pewno chcesz usunąć podpis?</translation>
+    </message>
+</context>
+<context>
+    <name>CSocket</name>
+    <message>
+        <source>Closed</source>
+        <translation>Zamknięte</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Otwarty</translation>
+    </message>
+    <message>
+        <source>Listen</source>
+        <translation>Nadsłuchiwanie</translation>
+    </message>
+    <message>
+        <source>SYN sent</source>
+        <translation>SYN wysłany</translation>
+    </message>
+    <message>
+        <source>SYN received</source>
+        <translation>Odebrano SYN</translation>
+    </message>
+    <message>
+        <source>Established</source>
+        <translation>Ustanowione</translation>
+    </message>
+    <message>
+        <source>FIN wait 1</source>
+        <translation>FIN czekaj 1</translation>
+    </message>
+    <message>
+        <source>FIN wait 2</source>
+        <translation>FIN czekaj 2</translation>
+    </message>
+    <message>
+        <source>Close wait</source>
+        <translation>Oczekiwanie na zamknięcie</translation>
+    </message>
+    <message>
+        <source>Closing</source>
+        <translation>Zamykanie</translation>
+    </message>
+    <message>
+        <source>Last ACK</source>
+        <translation>Ostatni ACK</translation>
+    </message>
+    <message>
+        <source>Time wait</source>
+        <translation>Oczekiwanie czasowe</translation>
+    </message>
+    <message>
+        <source>Delete TCB</source>
+        <translation>Usuń TCB</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source>Unknown %1</source>
+        <translation>Nieznane %1</translation>
+    </message>
+</context>
+<context>
+    <name>CSocketModel</name>
+    <message>
+        <source>Unknown Process</source>
+        <translation>Nieznany proces</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>PROCESS MISSING</source>
+        <translation>PROCES BRAK</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokół</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Adres zdalny</translation>
+    </message>
+    <message>
+        <source>Remote Port</source>
+        <translation>Port zdalny</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Adres lokalny</translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation>Port lokalny</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>Dostęp</translation>
+    </message>
+    <message>
+        <source>State</source>
+        <translation>Stan</translation>
+    </message>
+    <message>
+        <source>Last Activity</source>
+        <translation>Ostatnia aktywność</translation>
+    </message>
+    <message>
+        <source>Upload</source>
+        <translation>Wysyłanie</translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation>Pobieranie</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Wysłane</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Pobrane</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+</context>
+<context>
+    <name>CSocketView</name>
+    <message>
+        <source>All Protocols</source>
+        <translation>Wszystkie protokoły</translation>
+    </message>
+    <message>
+        <source>HTTP(S)</source>
+        <translation>HTTP(S)</translation>
+    </message>
+    <message>
+        <source>TCP Sockets</source>
+        <translation>Gniazda TCP</translation>
+    </message>
+    <message>
+        <source>TCP Clients</source>
+        <translation>Klienci TCP</translation>
+    </message>
+    <message>
+        <source>TCP Servers</source>
+        <translation>Serwery TCP</translation>
+    </message>
+    <message>
+        <source>UDP Sockets</source>
+        <translation>Gniazda UDP</translation>
+    </message>
+</context>
+<context>
+    <name>CTraceView</name>
+    <message>
+        <source>Loading %1</source>
+        <translation>Ładowanie %1</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the the trace logs for the current program items?</source>
+        <translation>Czy na pewno chcesz wyczyścić dzienniki śledzenia dla bieżących programów?</translation>
+    </message>
+</context>
+<context>
+    <name>CTrafficModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Last Activity</source>
+        <translation>Ostatnia aktywność</translation>
+    </message>
+    <message>
+        <source>Uploaded</source>
+        <translation>Wysłane</translation>
+    </message>
+    <message>
+        <source>Downloaded</source>
+        <translation>Pobrane</translation>
+    </message>
+</context>
+<context>
+    <name>CTrafficView</name>
+    <message>
+        <source>By Host</source>
+        <translation>Według hosta</translation>
+    </message>
+    <message>
+        <source>By Program</source>
+        <translation>Według programu</translation>
+    </message>
+    <message>
+        <source>Area Filter</source>
+        <translation>Filtr obszaru</translation>
+    </message>
+    <message>
+        <source>Internet</source>
+        <translation>Internet</translation>
+    </message>
+    <message>
+        <source>Local Area</source>
+        <translation>Sieć lokalna</translation>
+    </message>
+    <message>
+        <source>Local Host</source>
+        <translation>Host lokalny</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Auto rozwijanie</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakInfo</name>
+    <message>
+        <source>Apply Tweak</source>
+        <translation>Zastosuj poprawkę</translation>
+    </message>
+    <message>
+        <source>Undo Tweak</source>
+        <translation>Cofnij poprawkę</translation>
+    </message>
+    <message>
+        <source>Tweak Info</source>
+        <translation>Informacje o poprawce</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Summary</source>
+        <translation>Podsumowanie</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakList</name>
+    <message>
+        <source>%1 (%2/%3)</source>
+        <translation>%1 (%2/%3)</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Hint</source>
+        <translation>Wskazówka</translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <translation>Informacja</translation>
+    </message>
+</context>
+<context>
+    <name>CTweakView</name>
+    <message>
+        <source>Refresh tweak states</source>
+        <translation>Odśwież stan poprawek</translation>
+    </message>
+    <message>
+        <source>Show not available tweaks</source>
+        <translation>Pokaż niedostępne poprawki</translation>
+    </message>
+    <message>
+        <source>Approve Current State</source>
+        <translation>Zatwierdź obecny stan</translation>
+    </message>
+    <message>
+        <source>Restore Approved State</source>
+        <translation>Przywróć zatwierdzony stan</translation>
+    </message>
+    <message>
+        <source>Auto Expand</source>
+        <translation>Auto rozwijanie</translation>
+    </message>
+    <message>
+        <source>This tweak is marked as breaking, hence it may break something. Are you sure you want to apply it?</source>
+        <translation>Ta poprawka jest oznaczona jako ryzykowna i może coś zepsuć. Czy na pewno chcesz ją zastosować?</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>Nie pokazuj ponownie tej wiadomości.</translation>
+    </message>
+    <message>
+        <source>MajorPrivacy</source>
+        <translation>MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to approve the current state of all tweaks?</source>
+        <translation>Czy na pewno chcesz zatwierdzić obecny stan wszystkich poprawek?</translation>
+    </message>
+    <message>
+        <source>
 				Are you sure you want to restore the approved state of all tweaks?
 
 				The following operations will be performed:
 			</source>
-			<translation>
+        <translation>
 				Czy na pewno chcesz przywrócić zatwierdzony stan wszystkich poprawek?
 
 				Zostaną wykonane następujące operacje:
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				Undo tweaks:
 			</source>
-			<translation>
+        <translation>
 				Cofnij poprawki:
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				Apply tweaks:
 			</source>
-			<translation>
+        <translation>
 				Zastosuj poprawki:
 			</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVariantEditorWnd</name>
-		<message>
-			<source>File</source>
-			<translation>Plik</translation>
-		</message>
-		<message>
-			<source>Open File</source>
-			<translation>Otwórz plik</translation>
-		</message>
-		<message>
-			<source>Close Editor</source>
-			<translation>Zamknij edytor</translation>
-		</message>
-		<message>
-			<source>Add to Root</source>
-			<translation>Dodaj do głównego</translation>
-		</message>
-		<message>
-			<source>Add</source>
-			<translation>Dodaj</translation>
-		</message>
-		<message>
-			<source>Remove</source>
-			<translation>Usuń</translation>
-		</message>
-		<message>
-			<source>All Files (*.dat)</source>
-			<translation>Wszystkie pliki (*.dat)</translation>
-		</message>
-		<message>
-			<source>Error</source>
-			<translation>Błąd</translation>
-		</message>
-		<message>
-			<source>Can&apos;t open file</source>
-			<translation>Nie można otworzyć pliku</translation>
-		</message>
-		<message>
-			<source>Can&apos;t parse file</source>
-			<translation>Nie można przetworzyć pliku</translation>
-		</message>
-		<message>
-			<source>Save File</source>
-			<translation>Zapisz plik</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVariantModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Value</source>
-			<translation>Wartość</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolume</name>
-		<message>
-			<source>Unmounted Volume</source>
-			<translation>Niezamontowany wolumin</translation>
-		</message>
-		<message>
-			<source>Mounted Volume</source>
-			<translation>Zamontowany wolumin</translation>
-		</message>
-		<message>
-			<source>Unprotected Folder</source>
-			<translation>Niechroniony folder</translation>
-		</message>
-		<message>
-			<source>Protected Folder</source>
-			<translation>Chroniony folder</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznany</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolumeModel</name>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Mount Point</source>
-			<translation>Punkt montowania</translation>
-		</message>
-		<message>
-			<source>Total Size</source>
-			<translation>Całkowity rozmiar</translation>
-		</message>
-		<message>
-			<source>Full Path</source>
-			<translation>Pełna ścieżka</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolumeView</name>
-		<message>
-			<source>Mount Volume</source>
-			<translation>Zamontuj wolumin</translation>
-		</message>
-		<message>
-			<source>Unmount Volume</source>
-			<translation>Odmontuj wolumin</translation>
-		</message>
-		<message>
-			<source>Change Volume Password</source>
-			<translation>Zmień hasło woluminu</translation>
-		</message>
-		<message>
-			<source>Rename Volume</source>
-			<translation>Zmień nazwę woluminu</translation>
-		</message>
-		<message>
-			<source>Remove Volume</source>
-			<translation>Usuń wolumin</translation>
-		</message>
-		<message>
-			<source>Create Volume</source>
-			<translation>Utwórz wolumin</translation>
-		</message>
-		<message>
-			<source>Add and Mount Volume Image</source>
-			<translation>Dodaj i zamontuj obraz woluminu</translation>
-		</message>
-		<message>
-			<source>Add Folder</source>
-			<translation>Dodaj folder</translation>
-		</message>
-		<message>
-			<source>Unmount All Volumes</source>
-			<translation>Odmontuj wszystkie woluminy</translation>
-		</message>
-		<message>
-			<source>Do you want to unmount the selected volume?</source>
-			<translation>Czy chcesz odmontować wybrany wolumin?</translation>
-		</message>
-		<message>
-			<source>Select Private Volume</source>
-			<translation>Wybierz prywatny wolumin</translation>
-		</message>
-		<message>
-			<source>Private Volume Files (*.pv)</source>
-			<translation>Pliki prywatnych woluminów (*.pv)</translation>
-		</message>
-		<message>
-			<source>Mount Secure Volume</source>
-			<translation>Zamontuj bezpieczny wolumin</translation>
-		</message>
-		<message>
-			<source>Creating new volume image, please enter a secure password, and choose a disk image size.</source>
-			<translation>Tworzenie nowego obrazu woluminu. Podaj bezpieczne hasło i wybierz rozmiar obrazu dysku.</translation>
-		</message>
-		<message>
-			<source>This volume content will be placed in an encrypted container file, please note that any corruption of the container&apos;s header will render all its content permanently inaccessible. Corruption can occur as a result of a BSOD, a storage hardware failure, or a malicious application overwriting random files. This feature is provided under a strict &lt;b&gt;No Backup No Mercy&lt;/b&gt; policy, YOU the user are responsible for the data you put into an encrypted box. &lt;br /&gt;&lt;br /&gt;IF YOU AGREE TO TAKE FULL RESPONSIBILITY FOR YOUR DATA PRESS [YES], OTHERWISE PRESS [NO].</source>
-			<translation>Zawartość woluminu zostanie umieszczona w zaszyfrowanym pliku kontenera. Uwaga: uszkodzenie nagłówka kontenera spowoduje trwałą utratę dostępu do wszystkich danych. Do uszkodzenia może dojść w wyniku BSOD, awarii sprzętu lub działania złośliwego oprogramowania. Funkcja ta jest udostępniana zgodnie z zasadą &lt;b&gt;Brak kopii zapasowej, brak litości&lt;/b&gt;. TO TY, użytkowniku, ponosisz pełną odpowiedzialność za dane umieszczone w zaszyfrowanym woluminie. &lt;br /&gt;&lt;br /&gt;JEŚLI ZGADZASZ SIĘ NA PRZYJĘCIE CAŁKOWITEJ ODPOWIEDZIALNOŚCI, NACIŚNIJ [TAK], W PRZECIWNYM RAZIE NACIŚNIJ [NIE].</translation>
-		</message>
-		<message>
-			<source>Don&apos;t show this message again.</source>
-			<translation>Nie pokazuj ponownie tej wiadomości.</translation>
-		</message>
-		<message>
-			<source>Change Volume Password.</source>
-			<translation>Zmień hasło woluminu.</translation>
-		</message>
-		<message>
-			<source>Please enter a name for the item</source>
-			<translation>Wprowadź nazwę dla elementu</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+</context>
+<context>
+    <name>CVariantEditorWnd</name>
+    <message>
+        <source>File</source>
+        <translation>Plik</translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation>Otwórz plik</translation>
+    </message>
+    <message>
+        <source>Close Editor</source>
+        <translation>Zamknij edytor</translation>
+    </message>
+    <message>
+        <source>Add to Root</source>
+        <translation>Dodaj do głównego</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Usuń</translation>
+    </message>
+    <message>
+        <source>All Files (*.dat)</source>
+        <translation>Wszystkie pliki (*.dat)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open file</source>
+        <translation>Nie można otworzyć pliku</translation>
+    </message>
+    <message>
+        <source>Can&apos;t parse file</source>
+        <translation>Nie można przetworzyć pliku</translation>
+    </message>
+    <message>
+        <source>Save File</source>
+        <translation>Zapisz plik</translation>
+    </message>
+</context>
+<context>
+    <name>CVariantModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Value</source>
+        <translation>Wartość</translation>
+    </message>
+</context>
+<context>
+    <name>CVolume</name>
+    <message>
+        <source>Unmounted Volume</source>
+        <translation>Niezamontowany wolumin</translation>
+    </message>
+    <message>
+        <source>Mounted Volume</source>
+        <translation>Zamontowany wolumin</translation>
+    </message>
+    <message>
+        <source>Unprotected Folder</source>
+        <translation>Niechroniony folder</translation>
+    </message>
+    <message>
+        <source>Protected Folder</source>
+        <translation>Chroniony folder</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznany</translation>
+    </message>
+</context>
+<context>
+    <name>CVolumeModel</name>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Mount Point</source>
+        <translation>Punkt montowania</translation>
+    </message>
+    <message>
+        <source>Total Size</source>
+        <translation>Całkowity rozmiar</translation>
+    </message>
+    <message>
+        <source>Full Path</source>
+        <translation>Pełna ścieżka</translation>
+    </message>
+</context>
+<context>
+    <name>CVolumeView</name>
+    <message>
+        <source>Mount Volume</source>
+        <translation>Zamontuj wolumin</translation>
+    </message>
+    <message>
+        <source>Unmount Volume</source>
+        <translation>Odmontuj wolumin</translation>
+    </message>
+    <message>
+        <source>Change Volume Password</source>
+        <translation>Zmień hasło woluminu</translation>
+    </message>
+    <message>
+        <source>Rename Volume</source>
+        <translation>Zmień nazwę woluminu</translation>
+    </message>
+    <message>
+        <source>Remove Volume</source>
+        <translation>Usuń wolumin</translation>
+    </message>
+    <message>
+        <source>Create Volume</source>
+        <translation>Utwórz wolumin</translation>
+    </message>
+    <message>
+        <source>Add and Mount Volume Image</source>
+        <translation>Dodaj i zamontuj obraz woluminu</translation>
+    </message>
+    <message>
+        <source>Add Folder</source>
+        <translation>Dodaj folder</translation>
+    </message>
+    <message>
+        <source>Unmount All Volumes</source>
+        <translation>Odmontuj wszystkie woluminy</translation>
+    </message>
+    <message>
+        <source>Do you want to unmount the selected volume?</source>
+        <translation>Czy chcesz odmontować wybrany wolumin?</translation>
+    </message>
+    <message>
+        <source>Select Private Volume</source>
+        <translation>Wybierz prywatny wolumin</translation>
+    </message>
+    <message>
+        <source>Private Volume Files (*.pv)</source>
+        <translation>Pliki prywatnych woluminów (*.pv)</translation>
+    </message>
+    <message>
+        <source>Mount Secure Volume</source>
+        <translation>Zamontuj bezpieczny wolumin</translation>
+    </message>
+    <message>
+        <source>Creating new volume image, please enter a secure password, and choose a disk image size.</source>
+        <translation>Tworzenie nowego obrazu woluminu. Podaj bezpieczne hasło i wybierz rozmiar obrazu dysku.</translation>
+    </message>
+    <message>
+        <source>This volume content will be placed in an encrypted container file, please note that any corruption of the container&apos;s header will render all its content permanently inaccessible. Corruption can occur as a result of a BSOD, a storage hardware failure, or a malicious application overwriting random files. This feature is provided under a strict &lt;b&gt;No Backup No Mercy&lt;/b&gt; policy, YOU the user are responsible for the data you put into an encrypted box. &lt;br /&gt;&lt;br /&gt;IF YOU AGREE TO TAKE FULL RESPONSIBILITY FOR YOUR DATA PRESS [YES], OTHERWISE PRESS [NO].</source>
+        <translation>Zawartość woluminu zostanie umieszczona w zaszyfrowanym pliku kontenera. Uwaga: uszkodzenie nagłówka kontenera spowoduje trwałą utratę dostępu do wszystkich danych. Do uszkodzenia może dojść w wyniku BSOD, awarii sprzętu lub działania złośliwego oprogramowania. Funkcja ta jest udostępniana zgodnie z zasadą &lt;b&gt;Brak kopii zapasowej, brak litości&lt;/b&gt;. TO TY, użytkowniku, ponosisz pełną odpowiedzialność za dane umieszczone w zaszyfrowanym woluminie. &lt;br /&gt;&lt;br /&gt;JEŚLI ZGADZASZ SIĘ NA PRZYJĘCIE CAŁKOWITEJ ODPOWIEDZIALNOŚCI, NACIŚNIJ [TAK], W PRZECIWNYM RAZIE NACIŚNIJ [NIE].</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>Nie pokazuj ponownie tej wiadomości.</translation>
+    </message>
+    <message>
+        <source>Change Volume Password.</source>
+        <translation>Zmień hasło woluminu.</translation>
+    </message>
+    <message>
+        <source>Please enter a name for the item</source>
+        <translation>Wprowadź nazwę dla elementu</translation>
+    </message>
+    <message>
+        <source>
 				Do you want to remove selected Volumes from list?
 				Note: The volume image files will remain intact and must be manually deleted.
 			</source>
-			<translation>
+        <translation>
 				Czy chcesz usunąć wybrane woluminy z listy?
 				Uwaga: Pliki obrazu woluminów pozostaną nienaruszone i należy je usunąć ręcznie.
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				The security of files and folders on unencrypted volumes cannot be guaranteed if Major Privacy is not running or if the Kernel Isolator driver is not loaded. In this state, folder access control will not be enforced.
 				For non-critical data, folder protection may still provide a basic level of security. However, for highly confidential or sensitive information, it is strongly recommended to use a secure, encrypted volume to ensure robust protection against unauthorized access.
 			</source>
-			<translation>
+        <translation>
 				Bezpieczeństwo plików i folderów na nieszyfrowanych woluminach nie może być zagwarantowane, jeśli Major Privacy nie jest uruchomiony lub sterownik Kernel Isolator nie jest załadowany. W takim stanie kontrola dostępu do folderów nie będzie egzekwowana.
 				Dla danych niekrytycznych ochrona folderów może nadal zapewniać podstawowy poziom bezpieczeństwa. Dla danych poufnych lub wrażliwych zaleca się jednak korzystanie z bezpiecznego, zaszyfrowanego woluminu, aby zapewnić skuteczną ochronę przed nieautoryzowanym dostępem.
 			</translation>
-		</message>
-		<message>
-			<source>Select Directory</source>
-			<translation>Wybierz katalog</translation>
-		</message>
-		<message>
-			<source>%1 - Protection</source>
-			<translation>%1 - Ochrona</translation>
-		</message>
-	</context>
-	<context>
-		<name>CVolumeWindow</name>
-		<message>
-			<source>kilobytes (%1)</source>
-			<translation>kilobajty (%1)</translation>
-		</message>
-		<message>
-			<source>Passwords don&apos;t match!!!</source>
-			<translation>Hasła się nie zgadzają!!!</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>Wybierz katalog</translation>
+    </message>
+    <message>
+        <source>%1 - Protection</source>
+        <translation>%1 - Ochrona</translation>
+    </message>
+</context>
+<context>
+    <name>CVolumeWindow</name>
+    <message>
+        <source>kilobytes (%1)</source>
+        <translation>kilobajty (%1)</translation>
+    </message>
+    <message>
+        <source>Passwords don&apos;t match!!!</source>
+        <translation>Hasła się nie zgadzają!!!</translation>
+    </message>
+    <message>
+        <source>
 				WARNING: Short passwords are easy to crack using brute force techniques!
 
 				It is recommended to choose a password consisting of 20 or more characters. Are you sure you want to use a short password?
 			</source>
-			<translation>
+        <translation>
 				OSTRZEŻENIE: Krótkie hasła są łatwe do złamania metodą brute-force!
 
 				Zaleca się wybór hasła zawierającego co najmniej 20 znaków. Czy na pewno chcesz użyć krótkiego hasła?
 			</translation>
-		</message>
-		<message>
-			<source>
+    </message>
+    <message>
+        <source>
 				The password is constrained to a maximum length of 128 characters.
 				This length permits approximately 384 bits of entropy with a passphrase composed of actual English words,
 				increases to 512 bits with the application of Leet (L337) speak modifications, and exceeds 768 bits when composed of entirely random printable ASCII characters.
 			</source>
-			<translation>
+        <translation>
 				Hasło może mieć maksymalnie 128 znaków.
 				Taka długość zapewnia około 384 bitów entropii dla frazy hasłowej ze słów angielskich,
 				512 bitów przy użyciu modyfikacji typu Leet (L337) i ponad 768 bitów dla całkowicie losowych znaków ASCII.
 			</translation>
-		</message>
-		<message>
-			<source>The Box Disk Image must be at least 256 MB in size, 2GB are recommended.</source>
-			<translation>Obraz dysku musi mieć co najmniej 256 MB, zalecane jest 2 GB.</translation>
-		</message>
-		<message>
-			<source>Select Mount Point</source>
-			<translation>Wybierz punkt montowania</translation>
-		</message>
-		<message>
-			<source>Never</source>
-			<translation>Nigdy</translation>
-		</message>
-		<message>
-			<source>5 minutes</source>
-			<translation>5 minut</translation>
-		</message>
-		<message>
-			<source>15 minutes</source>
-			<translation>15 minut</translation>
-		</message>
-		<message>
-			<source>30 minutes</source>
-			<translation>30 minut</translation>
-		</message>
-		<message>
-			<source>1 hour</source>
-			<translation>1 godzina</translation>
-		</message>
-		<message>
-			<source>%1 hours</source>
-			<translation>%1 godzin</translation>
-		</message>
-		<message>
-			<source>%1 minutes</source>
-			<translation>%1 minut</translation>
-		</message>
-	</context>
-	<context>
-		<name>EnclaveWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formularz</translation>
-		</message>
-		<message>
-			<source>Secure Enclave Identity</source>
-			<translation>Tożsamość bezpiecznej enklawy</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Code Integrity Presets</source>
-			<translation>Ustawienia integralności kodu</translation>
-		</message>
-		<message>
-			<source>Require Signature</source>
-			<translation>Wymagaj podpisu</translation>
-		</message>
-		<message>
-			<source>Image Load Protection</source>
-			<translation>Ochrona ładowania obrazów</translation>
-		</message>
-		<message>
-			<source>Process Spawn Handling</source>
-			<translation>Obsługa uruchamiania procesów</translation>
-		</message>
-		<message>
-			<source>On Trusted</source>
-			<translation>Dla zaufanych</translation>
-		</message>
-		<message>
-			<source>On UN Trusted</source>
-			<translation>Dla niezaufanych</translation>
-		</message>
-		<message>
-			<source>Other Options</source>
-			<translation>Inne opcje</translation>
-		</message>
-		<message>
-			<source>Elevate Token Integrity Level, for User Interface Privilege Isolation</source>
-			<translation>Podnieś poziom integralności tokenu (UIPI – izolacja uprawnień interfejsu)</translation>
-		</message>
-		<message>
-			<source>Token Integrity (UIPI)</source>
-			<translation>Integralność tokenu (UIPI)</translation>
-		</message>
-		<message>
-			<source>Prevent termination</source>
-			<translation>Zapobiegaj zakończeniu</translation>
-		</message>
-		<message>
-			<source>Allow Debuging (INSECURE !!!)</source>
-			<translation>Zezwól na debugowanie (NIEBEZPIECZNE!!!)</translation>
-		</message>
-	</context>
-	<context>
-		<name>FirewallRuleWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formularz</translation>
-		</message>
-		<message>
-			<source>Firewall Rule Identity</source>
-			<translation>Tożsamość reguły zapory</translation>
-		</message>
-		<message>
-			<source>Group</source>
-			<translation>Grupa</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Description...</source>
-			<translation>Opis...</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-		<message>
-			<source>Service Tag</source>
-			<translation>Tag usługi</translation>
-		</message>
-		<message>
-			<source>Executable</source>
-			<translation>Plik wykonywalny</translation>
-		</message>
-		<message>
-			<source>App Package</source>
-			<translation>Paczka aplikacji</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Action &amp;&amp; Scope</source>
-			<translation>Działanie i zakres</translation>
-		</message>
-		<message>
-			<source>Sellected:</source>
-			<translation>Wybrano:</translation>
-		</message>
-		<message>
-			<source>All Profiles</source>
-			<translation>Wszystkie profile</translation>
-		</message>
-		<message>
-			<source>LAN</source>
-			<translation>LAN</translation>
-		</message>
-		<message>
-			<source>Private</source>
-			<translation>Prywatny</translation>
-		</message>
-		<message>
-			<source>WLAN</source>
-			<translation>WLAN</translation>
-		</message>
-		<message>
-			<source>Domain</source>
-			<translation>Domena</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Działanie</translation>
-		</message>
-		<message>
-			<source>Specific Types:</source>
-			<translation>Typy szczegółowe:</translation>
-		</message>
-		<message>
-			<source>VPN</source>
-			<translation>VPN</translation>
-		</message>
-		<message>
-			<source>Public</source>
-			<translation>Publiczny</translation>
-		</message>
-		<message>
-			<source>All Interface Types</source>
-			<translation>Wszystkie typy interfejsów</translation>
-		</message>
-		<message>
-			<source>Network Properties</source>
-			<translation>Właściwości sieci</translation>
-		</message>
-		<message>
-			<source>Ok</source>
-			<translation>OK</translation>
-		</message>
-		<message>
-			<source>Local Address</source>
-			<translation>Adres lokalny</translation>
-		</message>
-		<message>
-			<source>Selected Addresses</source>
-			<translation>Wybrane adresy</translation>
-		</message>
-		<message>
-			<source>Local Port</source>
-			<translation>Port lokalny</translation>
-		</message>
-		<message>
-			<source>Remote Address</source>
-			<translation>Adres zdalny</translation>
-		</message>
-		<message>
-			<source>Any Address</source>
-			<translation>Dowolny adres</translation>
-		</message>
-		<message>
-			<source>Direction</source>
-			<translation>Kierunek</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokół</translation>
-		</message>
-		<message>
-			<source>ICMP Type</source>
-			<translation>Typ ICMP</translation>
-		</message>
-		<message>
-			<source>Remote Port</source>
-			<translation>Port zdalny</translation>
-		</message>
-	</context>
-	<context>
-		<name>OptionsTransferWnd</name>
-		<message>
-			<source>Option Transfer</source>
-			<translation>Transfer opcji</translation>
-		</message>
-		<message>
-			<source>OK</source>
-			<translation>OK</translation>
-		</message>
-		<message>
-			<source>Cancel</source>
-			<translation>Anuluj</translation>
-		</message>
-		<message>
-			<source>User Interface Options</source>
-			<translation>Opcje interfejsu użytkownika</translation>
-		</message>
-		<message>
-			<source>Process Protection Rules</source>
-			<translation>Reguły ochrony procesów</translation>
-		</message>
-		<message>
-			<source>Please sellect which options you want to import/export.</source>
-			<translation>Wybierz, które opcje chcesz zaimportować/wyeksportować.</translation>
-		</message>
-		<message>
-			<source>Resource Access Rules</source>
-			<translation>Reguły dostępu do zasobów</translation>
-		</message>
-		<message>
-			<source>Full Program List</source>
-			<translation>Pełna lista programów</translation>
-		</message>
-		<message>
-			<source>Privacy Agent Options</source>
-			<translation>Opcje agenta prywatności</translation>
-		</message>
-		<message>
-			<source>User Key (Remains Encrypted with User PW)</source>
-			<translation>Klucz użytkownika (pozostaje zaszyfrowany hasłem)</translation>
-		</message>
-		<message>
-			<source>Trace Log Data</source>
-			<translation>Dane logów śledzenia</translation>
-		</message>
-		<message>
-			<source>Windows Firewall Rules</source>
-			<translation>Reguły zapory systemu Windows</translation>
-		</message>
-		<message>
-			<source>Kernel Isolator Options</source>
-			<translation>Opcje izolatora jądra</translation>
-		</message>
-		<message>
-			<source>Secure Enclave Configuration</source>
-			<translation>Konfiguracja bezpiecznej enklawy</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>PopUpWindow</name>
-		<message>
-			<source>MajorPrivacy Notifications</source>
-			<translation>Powiadomienia MajorPrivacy</translation>
-		</message>
-		<message>
-			<source>Firewall</source>
-			<translation>Zapora</translation>
-		</message>
-		<message>
-			<source>0/0</source>
-			<translation>0/0</translation>
-		</message>
-		<message>
-			<source>Ignore</source>
-			<translation>Ignoruj</translation>
-		</message>
-		<message>
-			<source>Allow</source>
-			<translation>Zezwól</translation>
-		</message>
-		<message>
-			<source>Block</source>
-			<translation>Zablokuj</translation>
-		</message>
-		<message>
-			<source>Previouse</source>
-			<translation>Poprzedni</translation>
-		</message>
-		<message>
-			<source>Next</source>
-			<translation>Następny</translation>
-		</message>
-		<message>
-			<source>GroupBox</source>
-			<translation>Grupa</translation>
-		</message>
-		<message>
-			<source>TextLabel</source>
-			<translation>Etykieta tekstu</translation>
-		</message>
-		<message>
-			<source>Protocol</source>
-			<translation>Protokół</translation>
-		</message>
-		<message>
-			<source>Endpoint</source>
-			<translation>Adres końcowy</translation>
-		</message>
-		<message>
-			<source>Time Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Process Id</source>
-			<translation>ID procesu</translation>
-		</message>
-		<message>
-			<source>Command Line</source>
-			<translation>Wiersz polecenia</translation>
-		</message>
-		<message>
-			<source>Icon</source>
-			<translation>Ikona</translation>
-		</message>
-		<message>
-			<source>Access</source>
-			<translation>Dostęp</translation>
-		</message>
-		<message>
-			<source>Path</source>
-			<translation>Ścieżka</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Działanie</translation>
-		</message>
-		<message>
-			<source>Tiem Stamp</source>
-			<translation>Znacznik czasu</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Process ID</source>
-			<translation>ID procesu</translation>
-		</message>
-		<message>
-			<source>Exec</source>
-			<translation>Wykonanie</translation>
-		</message>
-		<message>
-			<source>File Name</source>
-			<translation>Nazwa pliku</translation>
-		</message>
-		<message>
-			<source>Trust Level</source>
-			<translation>Poziom zaufania</translation>
-		</message>
-		<message>
-			<source>Signing Certificate</source>
-			<translation>Certyfikat podpisu</translation>
-		</message>
-		<message>
-			<source>File Path</source>
-			<translation>Ścieżka pliku</translation>
-		</message>
-		<message>
-			<source>Sign File</source>
-			<translation>Podpisz plik</translation>
-		</message>
-		<message>
-			<source>Tweaks</source>
-			<translation>Dostosowania</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Status</source>
-			<translation>Status</translation>
-		</message>
-		<message>
-			<source>Description</source>
-			<translation>Opis</translation>
-		</message>
-		<message>
-			<source>Approve</source>
-			<translation>Zatwierdź</translation>
-		</message>
-		<message>
-			<source>Reject</source>
-			<translation>Odrzuć</translation>
-		</message>
-	</context>
-	<context>
-		<name>ProgramPicker</name>
-		<message>
-			<source>Major Privacy - Select Program</source>
-			<translation>Major Privacy – Wybierz program</translation>
-		</message>
-		<message>
-			<source>All Programs</source>
-			<translation>Wszystkie programy</translation>
-		</message>
-		<message>
-			<source>Select a program from the list</source>
-			<translation>Wybierz program z listy</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-		<message>
-			<source>Add New Program Item</source>
-			<translation>Dodaj nowy element programu</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>ProgramRuleWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formularz</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Path Pattern</source>
-			<translation>Wzorzec ścieżki</translation>
-		</message>
-		<message>
-			<source>Enclave</source>
-			<translation>Enklawa</translation>
-		</message>
-		<message>
-			<source>Program Rule Identity</source>
-			<translation>Tożsamość reguły programu</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Action</source>
-			<translation>Działanie</translation>
-		</message>
-		<message>
-			<source>Require Signature</source>
-			<translation>Wymagaj podpisu</translation>
-		</message>
-		<message>
-			<source>Image Load Protection</source>
-			<translation>Ochrona ładowania obrazu</translation>
-		</message>
-	</context>
-
-	<context>
-		<name>ProgramWnd</name>
-		<message>
-			<source>Form</source>
-			<translation>Formularz</translation>
-		</message>
-		<message>
-			<source>Program Info</source>
-			<translation>Informacje o programie</translation>
-		</message>
-		<message>
-			<source>Name</source>
-			<translation>Nazwa</translation>
-		</message>
-		<message>
-			<source>Program</source>
-			<translation>Program</translation>
-		</message>
-		<message>
-			<source>Exact File Path or Path Pattern (DOS style)</source>
-			<translation>Dokładna ścieżka pliku lub wzorzec ścieżki (styl DOS)</translation>
-		</message>
-		<message>
-			<source>Executable Path</source>
-			<translation>Ścieżka pliku wykonywalnego</translation>
-		</message>
-		<message>
-			<source>App Package</source>
-			<translation>Paczka aplikacji</translation>
-		</message>
-		<message>
-			<source>Service Tag</source>
-			<translation>Tag usługi</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Trace Logs and Records</source>
-			<translation>Logi i rejestry śledzenia</translation>
-		</message>
-		<message>
-			<source>Network Trace</source>
-			<translation>Śledzenie sieci</translation>
-		</message>
-		<message>
-			<source>Save Trace</source>
-			<translation>Zapisz śledzenie</translation>
-		</message>
-		<message>
-			<source>Resource Trace</source>
-			<translation>Śledzenie zasobów</translation>
-		</message>
-		<message>
-			<source>Ingress Trace</source>
-			<translation>Śledzenie wejścia</translation>
-		</message>
-	</context>
-	<context>
-		<name>QObject</name>
-		<message>
-			<source>Change Permissions</source>
-			<translation>Zmień uprawnienia</translation>
-		</message>
-		<message>
-			<source>Write Data</source>
-			<translation>Zapisz dane</translation>
-		</message>
-		<message>
-			<source>Read Data</source>
-			<translation>Odczytaj dane</translation>
-		</message>
-		<message>
-			<source>Write Attributes</source>
-			<translation>Zapisz atrybuty</translation>
-		</message>
-		<message>
-			<source>Read Attributes</source>
-			<translation>Odczytaj atrybuty</translation>
-		</message>
-		<message>
-			<source>%1</source>
-			<translation>%1</translation>
-		</message>
-		<message>
-			<source>Allowed</source>
-			<translation>Dozwolone</translation>
-		</message>
-		<message>
-			<source>Blocked</source>
-			<translation>Zablokowane</translation>
-		</message>
-		<message>
-			<source> (0x%1)</source>
-			<translation> (0x%1)</translation>
-		</message>
-		<message>
-			<source>Booth</source>
-			<translation>Stanowisko</translation>
-			<!-- lub "Oboje", zależnie od kontekstu -->
-		</message>
-		<message>
-			<source>Actor</source>
-			<translation>Podmiot</translation>
-		</message>
-		<message>
-			<source>Target</source>
-			<translation>Cel</translation>
-		</message>
-		<message>
-			<source>Unknown</source>
-			<translation>Nieznane</translation>
-		</message>
-		<message>
-			<source>Process Started</source>
-			<translation>Proces uruchomiony</translation>
-		</message>
-		<message>
-			<source>Image Loaded</source>
-			<translation>Obraz załadowany</translation>
-		</message>
-		<message>
-			<source>Thread Access</source>
-			<translation>Dostęp do wątku</translation>
-		</message>
-		<message>
-			<source>Process Access</source>
-			<translation>Dostęp do procesu</translation>
-		</message>
-		<message>
-			<source>Control Execution</source>
-			<translation>Kontrola wykonania</translation>
-		</message>
-		<message>
-			<source>Write Memory</source>
-			<translation>Zapisz pamięć</translation>
-		</message>
-		<message>
-			<source>Read Memory</source>
-			<translation>Odczytaj pamięć</translation>
-		</message>
-		<message>
-			<source>Special Permissions</source>
-			<translation>Specjalne uprawnienia</translation>
-		</message>
-		<message>
-			<source>Write Properties</source>
-			<translation>Zapisz właściwości</translation>
-		</message>
-		<message>
-			<source>Read Properties</source>
-			<translation>Odczytaj właściwości</translation>
-		</message>
-		<message>
-			<source>Allowed (Untrusted)</source>
-			<translation>Dozwolone (Niezaufane)</translation>
-		</message>
-		<message>
-			<source>Allowed (Ejected)</source>
-			<translation>Dozwolone (Wyrzucone)</translation>
-		</message>
-		<message>
-			<source>Blocked (Protected)</source>
-			<translation>Zablokowane (Chronione)</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsWindow</name>
-		<message>
-			<source>Major Privacy Settings</source>
-			<translation>Ustawienia Major Privacy</translation>
-		</message>
-		<message>
-			<source>General Config</source>
-			<translation>Konfiguracja ogólna</translation>
-		</message>
-		<message>
-			<source>UI Language:</source>
-			<translation>Język interfejsu:</translation>
-		</message>
-		<message>
-			<source>Major Privacy Options</source>
-			<translation>Opcje Major Privacy</translation>
-		</message>
-		<message>
-			<source>Auto list installed applications in the program tree</source>
-			<translation>Automatycznie wyświetlaj zainstalowane aplikacje w drzewie programów</translation>
-		</message>
-		<message>
-			<source>Interface Config</source>
-			<translation>Konfiguracja interfejsu</translation>
-		</message>
-		<message>
-			<source>Use Dark Theme</source>
-			<translation>Użyj ciemnego motywu</translation>
-		</message>
-		<message>
-			<source>Interface Options</source>
-			<translation>Opcje interfejsu</translation>
-		</message>
-		<message>
-			<source>Use Fusion Theme</source>
-			<translation>Użyj motywu Fusion</translation>
-		</message>
-		<message>
-			<source>Notifications</source>
-			<translation>Powiadomienia</translation>
-		</message>
-		<message>
-			<source>Type</source>
-			<translation>Typ</translation>
-		</message>
-		<message>
-			<source>Data</source>
-			<translation>Dane</translation>
-		</message>
-		<message>
-			<source>Ignore List</source>
-			<translation>Lista ignorowanych</translation>
-		</message>
-		<message>
-			<source>Remove Entry</source>
-			<translation>Usuń wpis</translation>
-		</message>
-		<message>
-			<source>When an event notification is displayed you can ignore all future notifications for a specific file, these ignore entries can be removed usin the below list, to add new entries you need to add them from the notification popup.</source>
-			<translation>Gdy pojawi się powiadomienie o zdarzeniu, możesz zignorować wszystkie przyszłe powiadomienia dla określonego pliku; te wpisy ignorowania można usunąć za pomocą poniższej listy, a nowe wpisy należy dodawać z poziomu wyskakującego okienka powiadomień.</translation>
-		</message>
-		<message>
-			<source>Process Protection</source>
-			<translation>Ochrona procesów</translation>
-		</message>
-		<message>
-			<source>Process Protection Logging</source>
-			<translation>Rejestrowanie ochrony procesów</translation>
-		</message>
-		<message>
-			<source>Show Process Protection Notification Popups</source>
-			<translation>Wyświetlaj wyskakujące powiadomienia o ochronie procesów</translation>
-		</message>
-		<message>
-			<source>Record Process Execution and Ingress to Disk (IngressRecord.dat)</source>
-			<translation>Zapisuj wykonanie procesów i dostęp do dysku (IngressRecord.dat)</translation>
-		</message>
-		<message>
-			<source>Log Process Execution and Ingress (to RAM)</source>
-			<translation>Rejestruj wykonanie procesów i dostęp (do pamięci RAM)</translation>
-		</message>
-		<message>
-			<source>Process Execution and Ingress Tracing</source>
-			<translation>Śledzenie wykonania procesów i dostępu</translation>
-		</message>
-		<message>
-			<source>Access Protection</source>
-			<translation>Ochrona dostępu</translation>
-		</message>
-		<message>
-			<source>Save File/Folder Accesses Record to Disk (AccessRecord.dat)</source>
-			<translation>Zapisuj dostęp do plików/folderów na dysku (AccessRecord.dat)</translation>
-		</message>
-		<message>
-			<source>Resource Access Logging</source>
-			<translation>Rejestrowanie dostępu do zasobów</translation>
-		</message>
-		<message>
-			<source>Show Resource Access Notification Popups</source>
-			<translation>Wyświetlaj wyskakujące powiadomienia o dostępie do zasobów</translation>
-		</message>
-		<message>
-			<source>List All Open Files</source>
-			<translation>Wyświetl wszystkie otwarte pliki</translation>
-		</message>
-		<message>
-			<source>File/Folder Accesses Tracing</source>
-			<translation>Śledzenie dostępu do plików/folderów</translation>
-		</message>
-		<message>
-			<source>Trace also access atempts to non existing resources</source>
-			<translation>Śledź również próby dostępu do nieistniejących zasobów</translation>
-		</message>
-		<message>
-			<source>Registry Access Tracing (not recommended, adds some CPU load)</source>
-			<translation>Śledzenie dostępu do rejestru (niezalecane, zwiększa obciążenie CPU)</translation>
-		</message>
-		<message>
-			<source>Log all File/Folder Accesses (to RAM)</source>
-			<translation>Rejestruj wszystkie dostępy do plików/folderów (w pamięci RAM)</translation>
-		</message>
-		<message>
-			<source>Firewall Config</source>
-			<translation>Konfiguracja zapory</translation>
-		</message>
-		<message>
-			<source>This feature enables the creation of firewall rule templates with path wildcards. When the Privacy Agent detects network activity matching a template without an existing rule, it automatically generates a new firewall rule.</source>
-			<translation>Ta funkcja umożliwia tworzenie szablonów reguł zapory z symbolami wieloznacznymi ścieżek. Gdy Agent Prywatności wykryje aktywność sieciową pasującą do szablonu bez istniejącej reguły, automatycznie generuje nową regułę zapory.</translation>
-		</message>
-		<message>
-			<source>Enhance Windows Firewall with Dynamic Rule Templates</source>
-			<translation>Rozszerz zaporę systemu Windows o dynamiczne szablony reguł</translation>
-		</message>
-		<message>
-			<source>Save Traffic Record to Disk (TrafficRecord.dat)</source>
-			<translation>Zapisuj ruch sieciowy na dysku (TrafficRecord.dat)</translation>
-		</message>
-		<message>
-			<source>Disable Windows Firewall (not recomended)</source>
-			<translation>Wyłącz zaporę systemu Windows (niezalecane)</translation>
-		</message>
-		<message>
-			<source>When creating a new (outbound) rule also create an inbound rule</source>
-			<translation>Podczas tworzenia nowej reguły (wychodzącej) utwórz również regułę przychodzącą</translation>
-		</message>
-		<message>
-			<source>Block List Mode (Windows default)</source>
-			<translation>Tryb listy blokowania (domyślny Windows)</translation>
-		</message>
-		<message>
-			<source>Alow List Mode (recommended)</source>
-			<translation>Tryb listy dozwolonych (zalecany)</translation>
-		</message>
-		<message>
-			<source>Windows Firewall Logging</source>
-			<translation>Rejestrowanie zapory systemu Windows</translation>
-		</message>
-		<message>
-			<source>Windows Firewall Mode</source>
-			<translation>Tryb zapory systemu Windows</translation>
-		</message>
-		<message>
-			<source>Use Simple Domain Resolution</source>
-			<translation>Użyj prostego rozwiązywania domen</translation>
-		</message>
-		<message>
-			<source>Use Reverse DNS</source>
-			<translation>Użyj odwrotnego DNS</translation>
-		</message>
-		<message>
-			<source>Show Connection Notification Popups</source>
-			<translation>Wyświetlaj wyskakujące powiadomienia o połączeniach</translation>
-		</message>
-		<message>
-			<source>Log all Network Access (to RAM)</source>
-			<translation>Rejestruj cały dostęp do sieci (w pamięci RAM)</translation>
-		</message>
-		<message>
-			<source>Firewall Audit Policy</source>
-			<translation>Polityka audytu zapory</translation>
-		</message>
-		<message>
-			<source>Load Windows Firewall Log on start (can be very slow)</source>
-			<translation>Wczytaj dziennik zapory systemu Windows przy starcie (może być bardzo wolne)</translation>
-		</message>
-		<message>
-			<source>(Should be set to All)</source>
-			<translation>(Powinno być ustawione na Wszystkie)</translation>
-		</message>
-		<message>
-			<source>Record Network Traffic</source>
-			<translation>Rejestruj ruch sieciowy</translation>
-		</message>
-		<message>
-			<source>Dns Filter</source>
-			<translation>Filtr DNS</translation>
-		</message>
-		<message>
-			<source>Setup DNS Proxy as default DNS in Windows</source>
-			<translation>Ustaw proxy DNS jako domyślny DNS w systemie Windows</translation>
-		</message>
-		<message>
-			<source>Remove</source>
-			<translation>Usuń</translation>
-		</message>
-		<message>
-			<source>Load DNS Blocklists</source>
-			<translation>Wczytaj listy blokowania DNS</translation>
-		</message>
-		<message>
-			<source>Upstream DNS Resolvers</source>
-			<translation>Górne serwery DNS</translation>
-		</message>
-		<message>
-			<source>DNS Filter</source>
-			<translation>Filtr DNS</translation>
-		</message>
-		<message>
-			<source>Enable Filtering DNS Proxy</source>
-			<translation>Włącz filtrujący proxy DNS</translation>
-		</message>
-		<message>
-			<source>8.8.8.8;1.1.1.1</source>
-			<translation>8.8.8.8;1.1.1.1</translation>
-		</message>
-		<message>
-			<source>Add List</source>
-			<translation>Dodaj listę</translation>
-		</message>
-		<message>
-			<source>Url</source>
-			<translation>Adres URL</translation>
-		</message>
-		<message>
-			<source>Entries</source>
-			<translation>Wpisy</translation>
-		</message>
-		<message>
-			<source>Advanced</source>
-			<translation>Zaawansowane</translation>
-		</message>
-		<message>
-			<source>Trace Log Entry Limit:</source>
-			<translation>Limit wpisów dziennika śledzenia:</translation>
-		</message>
-		<message>
-			<source>Trace Log Options</source>
-			<translation>Opcje dziennika śledzenia</translation>
-		</message>
-		<message>
-			<source>Trace Log Retention Tme:</source>
-			<translation>Czas przechowywania dziennika śledzenia:</translation>
-		</message>
-		<message>
-			<source>Hours</source>
-			<translation>Godziny</translation>
-		</message>
-		<message>
-			<source>Support &amp;&amp; Updates</source>
-			<translation>Wsparcie i aktualizacje</translation>
-		</message>
-		<message>
-			<source>Get</source>
-			<translation>Pobierz</translation>
-		</message>
-		<message>
-			<source>In the future, don&apos;t notify about certificate expiration</source>
-			<translation>Nie przypominaj o wygaśnięciu certyfikatu w przyszłości</translation>
-		</message>
-		<message>
-			<source>PRIV_-_____-_____-_____-_____</source>
-			<translation>PRIV_-_____-_____-_____-_____</translation>
-		</message>
-		<message>
-			<source>Please enter your Supporter Certificate or License Serial Number:</source>
-			<translation>Wprowadź certyfikat wspierającego lub numer seryjny licencji:</translation>
-		</message>
-		<message>
-			<source>Hotpatches for the installed version, updates to the Templates.ini and translations.</source>
-			<translation>Poprawki dla zainstalowanej wersji, aktualizacje Templates.ini i tłumaczeń.</translation>
-		</message>
-		<message>
-			<source>Incremental Updates</source>
-			<translation>Aktualizacje przyrostowe</translation>
-		</message>
-		<message>
-			<source>The preview channel contains the latest GitHub pre-releases.</source>
-			<translation>Kanał testowy zawiera najnowsze wersje wstępne z GitHuba.</translation>
-		</message>
-		<message>
-			<source>Search in the Preview channel</source>
-			<translation>Wyszukuj w kanale testowym</translation>
-		</message>
-		<message>
-			<source>Update Settings</source>
-			<translation>Ustawienia aktualizacji</translation>
-		</message>
-		<message>
-			<source>The stable channel contains the latest stable GitHub releases.</source>
-			<translation>Kanał stabilny zawiera najnowsze stabilne wersje z GitHuba.</translation>
-		</message>
-		<message>
-			<source>Search in the Stable channel</source>
-			<translation>Wyszukuj w kanale stabilnym</translation>
-		</message>
-		<message>
-			<source>New full installers from the selected release channel.</source>
-			<translation>Nowe pełne instalatory z wybranego kanału wydania.</translation>
-		</message>
-		<message>
-			<source>Full Upgrades</source>
-			<translation>Pełne aktualizacje</translation>
-		</message>
-		<message>
-			<source>Update Check Interval</source>
-			<translation>Interwał sprawdzania aktualizacji</translation>
-		</message>
-		<message>
-			<source>Check periodically for new versions</source>
-			<translation>Okresowo sprawdzaj dostępność nowych wersji</translation>
-		</message>
-		<message>
-			<source>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Certificate usage guide&lt;/a&gt;</source>
-			<translation>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Instrukcja użycia certyfikatu&lt;/a&gt;</translation>
-		</message>
-		<message>
-			<source>This supporter certificate has expired, please &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;get an updated certificate&lt;/a&gt;.</source>
-			<translation>Ten certyfikat wspierającego wygasł, proszę &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;pobrać nowy certyfikat&lt;/a&gt;.</translation>
-		</message>
-		<message>
-			<source>Enter the support certificate here</source>
-			<translation>Wprowadź tutaj certyfikat wsparcia</translation>
-		</message>
-		<message>
-			<source>Retrieve/Upgrade/Renew certificate using Serial Number</source>
-			<translation>Pobierz/zaktualizuj/odnów certyfikat za pomocą numeru seryjnego</translation>
-		</message>
-	</context>
-	<context>
-		<name>VolumeWindow</name>
-		<message>
-			<source>Form</source>
-			<translation>Formularz</translation>
-		</message>
-		<message>
-			<source>Load volume access protection rules</source>
-			<translation>Wczytaj zasady ochrony dostępu do woluminu</translation>
-		</message>
-		<message>
-			<source>Select directory as mount point</source>
-			<translation>Wybierz katalog jako punkt montowania</translation>
-		</message>
-		<message>
-			<source>...</source>
-			<translation>...</translation>
-		</message>
-		<message>
-			<source>Mount Point</source>
-			<translation>Punkt montowania</translation>
-		</message>
-		<message>
-			<source>New Password</source>
-			<translation>Nowe hasło</translation>
-		</message>
-		<message>
-			<source>Repeat Password</source>
-			<translation>Powtórz hasło</translation>
-		</message>
-		<message>
-			<source>kilobytes</source>
-			<translation>kilobajty</translation>
-		</message>
-		<message>
-			<source>TextLabel</source>
-			<translation>EtykietaTekstowa</translation>
-		</message>
-		<message>
-			<source>Encryption Cipher</source>
-			<translation>Szyfr szyfrowania</translation>
-		</message>
-		<message>
-			<source>Show Password</source>
-			<translation>Pokaż hasło</translation>
-		</message>
-		<message>
-			<source>Enter Password</source>
-			<translation>Wprowadź hasło</translation>
-		</message>
-		<message>
-			<source>Disk Image Size</source>
-			<translation>Rozmiar obrazu dysku</translation>
-		</message>
-		<message>
-			<source>Auto Lock after</source>
-			<translation>Automatycznie zablokuj po</translation>
-		</message>
-	</context>
+    </message>
+    <message>
+        <source>The Box Disk Image must be at least 256 MB in size, 2GB are recommended.</source>
+        <translation>Obraz dysku musi mieć co najmniej 256 MB, zalecane jest 2 GB.</translation>
+    </message>
+    <message>
+        <source>Select Mount Point</source>
+        <translation>Wybierz punkt montowania</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation>Nigdy</translation>
+    </message>
+    <message>
+        <source>5 minutes</source>
+        <translation>5 minut</translation>
+    </message>
+    <message>
+        <source>15 minutes</source>
+        <translation>15 minut</translation>
+    </message>
+    <message>
+        <source>30 minutes</source>
+        <translation>30 minut</translation>
+    </message>
+    <message>
+        <source>1 hour</source>
+        <translation>1 godzina</translation>
+    </message>
+    <message>
+        <source>%1 hours</source>
+        <translation>%1 godzin</translation>
+    </message>
+    <message>
+        <source>%1 minutes</source>
+        <translation>%1 minut</translation>
+    </message>
+</context>
+<context>
+    <name>EnclaveWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formularz</translation>
+    </message>
+    <message>
+        <source>Secure Enclave Identity</source>
+        <translation>Tożsamość bezpiecznej enklawy</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Code Integrity Presets</source>
+        <translation>Ustawienia integralności kodu</translation>
+    </message>
+    <message>
+        <source>Require Signature</source>
+        <translation>Wymagaj podpisu</translation>
+    </message>
+    <message>
+        <source>Image Load Protection</source>
+        <translation>Ochrona ładowania obrazów</translation>
+    </message>
+    <message>
+        <source>Process Spawn Handling</source>
+        <translation>Obsługa uruchamiania procesów</translation>
+    </message>
+    <message>
+        <source>On Trusted</source>
+        <translation>Dla zaufanych</translation>
+    </message>
+    <message>
+        <source>On UN Trusted</source>
+        <translation>Dla niezaufanych</translation>
+    </message>
+    <message>
+        <source>Other Options</source>
+        <translation>Inne opcje</translation>
+    </message>
+    <message>
+        <source>Elevate Token Integrity Level, for User Interface Privilege Isolation</source>
+        <translation>Podnieś poziom integralności tokenu (UIPI – izolacja uprawnień interfejsu)</translation>
+    </message>
+    <message>
+        <source>Token Integrity (UIPI)</source>
+        <translation>Integralność tokenu (UIPI)</translation>
+    </message>
+    <message>
+        <source>Prevent termination</source>
+        <translation>Zapobiegaj zakończeniu</translation>
+    </message>
+    <message>
+        <source>Allow Debugging (INSECURE !!!)</source>
+        <translation>Zezwól na debugowanie (NIEBEZPIECZNE!!!)</translation>
+    </message>
+</context>
+<context>
+    <name>FirewallRuleWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formularz</translation>
+    </message>
+    <message>
+        <source>Firewall Rule Identity</source>
+        <translation>Tożsamość reguły zapory</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Grupa</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Description...</source>
+        <translation>Opis...</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <source>Service Tag</source>
+        <translation>Tag usługi</translation>
+    </message>
+    <message>
+        <source>Executable</source>
+        <translation>Plik wykonywalny</translation>
+    </message>
+    <message>
+        <source>App Package</source>
+        <translation>Paczka aplikacji</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Action &amp;&amp; Scope</source>
+        <translation>Działanie i zakres</translation>
+    </message>
+    <message>
+        <source>Selected:</source>
+        <translation>Wybrano:</translation>
+    </message>
+    <message>
+        <source>All Profiles</source>
+        <translation>Wszystkie profile</translation>
+    </message>
+    <message>
+        <source>LAN</source>
+        <translation>LAN</translation>
+    </message>
+    <message>
+        <source>Private</source>
+        <translation>Prywatny</translation>
+    </message>
+    <message>
+        <source>WLAN</source>
+        <translation>WLAN</translation>
+    </message>
+    <message>
+        <source>Domain</source>
+        <translation>Domena</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Działanie</translation>
+    </message>
+    <message>
+        <source>Specific Types:</source>
+        <translation>Typy szczegółowe:</translation>
+    </message>
+    <message>
+        <source>VPN</source>
+        <translation>VPN</translation>
+    </message>
+    <message>
+        <source>Public</source>
+        <translation>Publiczny</translation>
+    </message>
+    <message>
+        <source>All Interface Types</source>
+        <translation>Wszystkie typy interfejsów</translation>
+    </message>
+    <message>
+        <source>Network Properties</source>
+        <translation>Właściwości sieci</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Local Address</source>
+        <translation>Adres lokalny</translation>
+    </message>
+    <message>
+        <source>Selected Addresses</source>
+        <translation>Wybrane adresy</translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation>Port lokalny</translation>
+    </message>
+    <message>
+        <source>Remote Address</source>
+        <translation>Adres zdalny</translation>
+    </message>
+    <message>
+        <source>Any Address</source>
+        <translation>Dowolny adres</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Kierunek</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokół</translation>
+    </message>
+    <message>
+        <source>ICMP Type</source>
+        <translation>Typ ICMP</translation>
+    </message>
+    <message>
+        <source>Remote Port</source>
+        <translation>Port zdalny</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsTransferWnd</name>
+    <message>
+        <source>Option Transfer</source>
+        <translation>Transfer opcji</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <source>User Interface Options</source>
+        <translation>Opcje interfejsu użytkownika</translation>
+    </message>
+    <message>
+        <source>Process Protection Rules</source>
+        <translation>Reguły ochrony procesów</translation>
+    </message>
+    <message>
+        <source>Please select which options you want to import/export.</source>
+        <translation>Wybierz, które opcje chcesz zaimportować/wyeksportować.</translation>
+    </message>
+    <message>
+        <source>Resource Access Rules</source>
+        <translation>Reguły dostępu do zasobów</translation>
+    </message>
+    <message>
+        <source>Full Program List</source>
+        <translation>Pełna lista programów</translation>
+    </message>
+    <message>
+        <source>Privacy Agent Options</source>
+        <translation>Opcje agenta prywatności</translation>
+    </message>
+    <message>
+        <source>User Key (Remains Encrypted with User PW)</source>
+        <translation>Klucz użytkownika (pozostaje zaszyfrowany hasłem)</translation>
+    </message>
+    <message>
+        <source>Trace Log Data</source>
+        <translation>Dane logów śledzenia</translation>
+    </message>
+    <message>
+        <source>Windows Firewall Rules</source>
+        <translation>Reguły zapory systemu Windows</translation>
+    </message>
+    <message>
+        <source>Kernel Isolator Options</source>
+        <translation>Opcje izolatora jądra</translation>
+    </message>
+    <message>
+        <source>Secure Enclave Configuration</source>
+        <translation>Konfiguracja bezpiecznej enklawy</translation>
+    </message>
+</context>
+<context>
+    <name>PopUpWindow</name>
+    <message>
+        <source>MajorPrivacy Notifications</source>
+        <translation>Powiadomienia MajorPrivacy</translation>
+    </message>
+    <message>
+        <source>Firewall</source>
+        <translation>Zapora</translation>
+    </message>
+    <message>
+        <source>0/0</source>
+        <translation>0/0</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation>Ignoruj</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Zezwól</translation>
+    </message>
+    <message>
+        <source>Block</source>
+        <translation>Zablokuj</translation>
+    </message>
+    <message>
+        <source>Previous</source>
+        <translation>Poprzedni</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>Następny</translation>
+    </message>
+    <message>
+        <source>GroupBox</source>
+        <translation>Grupa</translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation>Etykieta tekstu</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protokół</translation>
+    </message>
+    <message>
+        <source>Endpoint</source>
+        <translation>Adres końcowy</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>Znacznik czasu</translation>
+    </message>
+    <message>
+        <source>Process Id</source>
+        <translation>ID procesu</translation>
+    </message>
+    <message>
+        <source>Command Line</source>
+        <translation>Wiersz polecenia</translation>
+    </message>
+    <message>
+        <source>Icon</source>
+        <translation>Ikona</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>Dostęp</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Ścieżka</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Działanie</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Process ID</source>
+        <translation>ID procesu</translation>
+    </message>
+    <message>
+        <source>Exec</source>
+        <translation>Wykonanie</translation>
+    </message>
+    <message>
+        <source>File Name</source>
+        <translation>Nazwa pliku</translation>
+    </message>
+    <message>
+        <source>Trust Level</source>
+        <translation>Poziom zaufania</translation>
+    </message>
+    <message>
+        <source>Signing Certificate</source>
+        <translation>Certyfikat podpisu</translation>
+    </message>
+    <message>
+        <source>File Path</source>
+        <translation>Ścieżka pliku</translation>
+    </message>
+    <message>
+        <source>Sign File</source>
+        <translation>Podpisz plik</translation>
+    </message>
+    <message>
+        <source>Tweaks</source>
+        <translation>Dostosowania</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Description</source>
+        <translation>Opis</translation>
+    </message>
+    <message>
+        <source>Approve</source>
+        <translation>Zatwierdź</translation>
+    </message>
+    <message>
+        <source>Reject</source>
+        <translation>Odrzuć</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramPicker</name>
+    <message>
+        <source>Major Privacy - Select Program</source>
+        <translation>Major Privacy – Wybierz program</translation>
+    </message>
+    <message>
+        <source>All Programs</source>
+        <translation>Wszystkie programy</translation>
+    </message>
+    <message>
+        <source>Select a program from the list</source>
+        <translation>Wybierz program z listy</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <source>Add New Program Item</source>
+        <translation>Dodaj nowy element programu</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramRuleWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formularz</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Path Pattern</source>
+        <translation>Wzorzec ścieżki</translation>
+    </message>
+    <message>
+        <source>Enclave</source>
+        <translation>Enklawa</translation>
+    </message>
+    <message>
+        <source>Program Rule Identity</source>
+        <translation>Tożsamość reguły programu</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Działanie</translation>
+    </message>
+    <message>
+        <source>Require Signature</source>
+        <translation>Wymagaj podpisu</translation>
+    </message>
+    <message>
+        <source>Image Load Protection</source>
+        <translation>Ochrona ładowania obrazu</translation>
+    </message>
+</context>
+<context>
+    <name>ProgramWnd</name>
+    <message>
+        <source>Form</source>
+        <translation>Formularz</translation>
+    </message>
+    <message>
+        <source>Program Info</source>
+        <translation>Informacje o programie</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <source>Exact File Path or Path Pattern (DOS style)</source>
+        <translation>Dokładna ścieżka pliku lub wzorzec ścieżki (styl DOS)</translation>
+    </message>
+    <message>
+        <source>Executable Path</source>
+        <translation>Ścieżka pliku wykonywalnego</translation>
+    </message>
+    <message>
+        <source>App Package</source>
+        <translation>Paczka aplikacji</translation>
+    </message>
+    <message>
+        <source>Service Tag</source>
+        <translation>Tag usługi</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Trace Logs and Records</source>
+        <translation>Logi i rejestry śledzenia</translation>
+    </message>
+    <message>
+        <source>Network Trace</source>
+        <translation>Śledzenie sieci</translation>
+    </message>
+    <message>
+        <source>Save Trace</source>
+        <translation>Zapisz śledzenie</translation>
+    </message>
+    <message>
+        <source>Resource Trace</source>
+        <translation>Śledzenie zasobów</translation>
+    </message>
+    <message>
+        <source>Ingress Trace</source>
+        <translation>Śledzenie wejścia</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Change Permissions</source>
+        <translation>Zmień uprawnienia</translation>
+    </message>
+    <message>
+        <source>Write Data</source>
+        <translation>Zapisz dane</translation>
+    </message>
+    <message>
+        <source>Read Data</source>
+        <translation>Odczytaj dane</translation>
+    </message>
+    <message>
+        <source>Write Attributes</source>
+        <translation>Zapisz atrybuty</translation>
+    </message>
+    <message>
+        <source>Read Attributes</source>
+        <translation>Odczytaj atrybuty</translation>
+    </message>
+    <message>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>Dozwolone</translation>
+    </message>
+    <message>
+        <source>Blocked</source>
+        <translation>Zablokowane</translation>
+    </message>
+    <message>
+        <source> (0x%1)</source>
+        <translation> (0x%1)</translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation>Stanowisko</translation>
+    </message>
+    <message>
+        <source>Actor</source>
+        <translation>Podmiot</translation>
+    </message>
+    <message>
+        <source>Target</source>
+        <translation>Cel</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznane</translation>
+    </message>
+    <message>
+        <source>Process Started</source>
+        <translation>Proces uruchomiony</translation>
+    </message>
+    <message>
+        <source>Image Loaded</source>
+        <translation>Obraz załadowany</translation>
+    </message>
+    <message>
+        <source>Thread Access</source>
+        <translation>Dostęp do wątku</translation>
+    </message>
+    <message>
+        <source>Process Access</source>
+        <translation>Dostęp do procesu</translation>
+    </message>
+    <message>
+        <source>Control Execution</source>
+        <translation>Kontrola wykonania</translation>
+    </message>
+    <message>
+        <source>Write Memory</source>
+        <translation>Zapisz pamięć</translation>
+    </message>
+    <message>
+        <source>Read Memory</source>
+        <translation>Odczytaj pamięć</translation>
+    </message>
+    <message>
+        <source>Special Permissions</source>
+        <translation>Specjalne uprawnienia</translation>
+    </message>
+    <message>
+        <source>Write Properties</source>
+        <translation>Zapisz właściwości</translation>
+    </message>
+    <message>
+        <source>Read Properties</source>
+        <translation>Odczytaj właściwości</translation>
+    </message>
+    <message>
+        <source>Allowed (Untrusted)</source>
+        <translation>Dozwolone (Niezaufane)</translation>
+    </message>
+    <message>
+        <source>Allowed (Ejected)</source>
+        <translation>Dozwolone (Wyrzucone)</translation>
+    </message>
+    <message>
+        <source>Blocked (Protected)</source>
+        <translation>Zablokowane (Chronione)</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>Major Privacy Settings</source>
+        <translation>Ustawienia Major Privacy</translation>
+    </message>
+    <message>
+        <source>General Config</source>
+        <translation>Konfiguracja ogólna</translation>
+    </message>
+    <message>
+        <source>UI Language:</source>
+        <translation>Język interfejsu:</translation>
+    </message>
+    <message>
+        <source>Major Privacy Options</source>
+        <translation>Opcje Major Privacy</translation>
+    </message>
+    <message>
+        <source>Auto list installed applications in the program tree</source>
+        <translation>Automatycznie wyświetlaj zainstalowane aplikacje w drzewie programów</translation>
+    </message>
+    <message>
+        <source>Interface Config</source>
+        <translation>Konfiguracja interfejsu</translation>
+    </message>
+    <message>
+        <source>Use Dark Theme</source>
+        <translation>Użyj ciemnego motywu</translation>
+    </message>
+    <message>
+        <source>Interface Options</source>
+        <translation>Opcje interfejsu</translation>
+    </message>
+    <message>
+        <source>Use Fusion Theme</source>
+        <translation>Użyj motywu Fusion</translation>
+    </message>
+    <message>
+        <source>Notifications</source>
+        <translation>Powiadomienia</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>Data</source>
+        <translation>Dane</translation>
+    </message>
+    <message>
+        <source>Ignore List</source>
+        <translation>Lista ignorowanych</translation>
+    </message>
+    <message>
+        <source>Remove Entry</source>
+        <translation>Usuń wpis</translation>
+    </message>
+    <message>
+        <source>When an event notification is displayed you can ignore all future notifications for a specific file, these ignore entries can be removed usin the below list, to add new entries you need to add them from the notification popup.</source>
+        <translation>Gdy pojawi się powiadomienie o zdarzeniu, możesz zignorować wszystkie przyszłe powiadomienia dla określonego pliku; te wpisy ignorowania można usunąć za pomocą poniższej listy, a nowe wpisy należy dodawać z poziomu wyskakującego okienka powiadomień.</translation>
+    </message>
+    <message>
+        <source>Process Protection</source>
+        <translation>Ochrona procesów</translation>
+    </message>
+    <message>
+        <source>Process Protection Logging</source>
+        <translation>Rejestrowanie ochrony procesów</translation>
+    </message>
+    <message>
+        <source>Show Process Protection Notification Popups</source>
+        <translation>Wyświetlaj wyskakujące powiadomienia o ochronie procesów</translation>
+    </message>
+    <message>
+        <source>Record Process Execution and Ingress to Disk (IngressRecord.dat)</source>
+        <translation>Zapisuj wykonanie procesów i dostęp do dysku (IngressRecord.dat)</translation>
+    </message>
+    <message>
+        <source>Log Process Execution and Ingress (to RAM)</source>
+        <translation>Rejestruj wykonanie procesów i dostęp (do pamięci RAM)</translation>
+    </message>
+    <message>
+        <source>Process Execution and Ingress Tracing</source>
+        <translation>Śledzenie wykonania procesów i dostępu</translation>
+    </message>
+    <message>
+        <source>Access Protection</source>
+        <translation>Ochrona dostępu</translation>
+    </message>
+    <message>
+        <source>Save File/Folder Accesses Record to Disk (AccessRecord.dat)</source>
+        <translation>Zapisuj dostęp do plików/folderów na dysku (AccessRecord.dat)</translation>
+    </message>
+    <message>
+        <source>Resource Access Logging</source>
+        <translation>Rejestrowanie dostępu do zasobów</translation>
+    </message>
+    <message>
+        <source>Show Resource Access Notification Popups</source>
+        <translation>Wyświetlaj wyskakujące powiadomienia o dostępie do zasobów</translation>
+    </message>
+    <message>
+        <source>List All Open Files</source>
+        <translation>Wyświetl wszystkie otwarte pliki</translation>
+    </message>
+    <message>
+        <source>File/Folder Accesses Tracing</source>
+        <translation>Śledzenie dostępu do plików/folderów</translation>
+    </message>
+    <message>
+        <source>Trace also access attempts to non existing resources</source>
+        <translation>Śledź również próby dostępu do nieistniejących zasobów</translation>
+    </message>
+    <message>
+        <source>Registry Access Tracing (not recommended, adds some CPU load)</source>
+        <translation>Śledzenie dostępu do rejestru (niezalecane, zwiększa obciążenie CPU)</translation>
+    </message>
+    <message>
+        <source>Log all File/Folder Accesses (to RAM)</source>
+        <translation>Rejestruj wszystkie dostępy do plików/folderów (w pamięci RAM)</translation>
+    </message>
+    <message>
+        <source>Firewall Config</source>
+        <translation>Konfiguracja zapory</translation>
+    </message>
+    <message>
+        <source>This feature enables the creation of firewall rule templates with path wildcards. When the Privacy Agent detects network activity matching a template without an existing rule, it automatically generates a new firewall rule.</source>
+        <translation>Ta funkcja umożliwia tworzenie szablonów reguł zapory z symbolami wieloznacznymi ścieżek. Gdy Agent Prywatności wykryje aktywność sieciową pasującą do szablonu bez istniejącej reguły, automatycznie generuje nową regułę zapory.</translation>
+    </message>
+    <message>
+        <source>Enhance Windows Firewall with Dynamic Rule Templates</source>
+        <translation>Rozszerz zaporę systemu Windows o dynamiczne szablony reguł</translation>
+    </message>
+    <message>
+        <source>Save Traffic Record to Disk (TrafficRecord.dat)</source>
+        <translation>Zapisuj ruch sieciowy na dysku (TrafficRecord.dat)</translation>
+    </message>
+    <message>
+        <source>Disable Windows Firewall (not recomended)</source>
+        <translation>Wyłącz zaporę systemu Windows (niezalecane)</translation>
+    </message>
+    <message>
+        <source>When creating a new (outbound) rule also create an inbound rule</source>
+        <translation>Podczas tworzenia nowej reguły (wychodzącej) utwórz również regułę przychodzącą</translation>
+    </message>
+    <message>
+        <source>Block List Mode (Windows default)</source>
+        <translation>Tryb listy blokowania (domyślny Windows)</translation>
+    </message>
+    <message>
+        <source>Allow List Mode (recommended)</source>
+        <translation>Tryb listy dozwolonych (zalecany)</translation>
+    </message>
+    <message>
+        <source>Windows Firewall Logging</source>
+        <translation>Rejestrowanie zapory systemu Windows</translation>
+    </message>
+    <message>
+        <source>Windows Firewall Mode</source>
+        <translation>Tryb zapory systemu Windows</translation>
+    </message>
+    <message>
+        <source>Use Simple Domain Resolution</source>
+        <translation>Użyj prostego rozwiązywania domen</translation>
+    </message>
+    <message>
+        <source>Use Reverse DNS</source>
+        <translation>Użyj odwrotnego DNS</translation>
+    </message>
+    <message>
+        <source>Show Connection Notification Popups</source>
+        <translation>Wyświetlaj wyskakujące powiadomienia o połączeniach</translation>
+    </message>
+    <message>
+        <source>Log all Network Access (to RAM)</source>
+        <translation>Rejestruj cały dostęp do sieci (w pamięci RAM)</translation>
+    </message>
+    <message>
+        <source>Firewall Audit Policy</source>
+        <translation>Polityka audytu zapory</translation>
+    </message>
+    <message>
+        <source>Load Windows Firewall Log on start (can be very slow)</source>
+        <translation>Wczytaj dziennik zapory systemu Windows przy starcie (może być bardzo wolne)</translation>
+    </message>
+    <message>
+        <source>(Should be set to All)</source>
+        <translation>(Powinno być ustawione na Wszystkie)</translation>
+    </message>
+    <message>
+        <source>Record Network Traffic</source>
+        <translation>Rejestruj ruch sieciowy</translation>
+    </message>
+    <message>
+        <source>Dns Filter</source>
+        <translation>Filtr DNS</translation>
+    </message>
+    <message>
+        <source>Setup DNS Proxy as default DNS in Windows</source>
+        <translation>Ustaw proxy DNS jako domyślny DNS w systemie Windows</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Usuń</translation>
+    </message>
+    <message>
+        <source>Load DNS Blocklists</source>
+        <translation>Wczytaj listy blokowania DNS</translation>
+    </message>
+    <message>
+        <source>Upstream DNS Resolvers</source>
+        <translation>Górne serwery DNS</translation>
+    </message>
+    <message>
+        <source>DNS Filter</source>
+        <translation>Filtr DNS</translation>
+    </message>
+    <message>
+        <source>Enable Filtering DNS Proxy</source>
+        <translation>Włącz filtrujący proxy DNS</translation>
+    </message>
+    <message>
+        <source>8.8.8.8;1.1.1.1</source>
+        <translation>8.8.8.8;1.1.1.1</translation>
+    </message>
+    <message>
+        <source>Add List</source>
+        <translation>Dodaj listę</translation>
+    </message>
+    <message>
+        <source>Url</source>
+        <translation>Adres URL</translation>
+    </message>
+    <message>
+        <source>Entries</source>
+        <translation>Wpisy</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation>Zaawansowane</translation>
+    </message>
+    <message>
+        <source>Trace Log Entry Limit:</source>
+        <translation>Limit wpisów dziennika śledzenia:</translation>
+    </message>
+    <message>
+        <source>Trace Log Options</source>
+        <translation>Opcje dziennika śledzenia</translation>
+    </message>
+    <message>
+        <source>Trace Log Retention Time:</source>
+        <translation>Czas przechowywania dziennika śledzenia:</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Godziny</translation>
+    </message>
+    <message>
+        <source>Support &amp;&amp; Updates</source>
+        <translation>Wsparcie i aktualizacje</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation>Pobierz</translation>
+    </message>
+    <message>
+        <source>In the future, don&apos;t notify about certificate expiration</source>
+        <translation>Nie przypominaj o wygaśnięciu certyfikatu w przyszłości</translation>
+    </message>
+    <message>
+        <source>PRIV_-_____-_____-_____-_____</source>
+        <translation>PRIV_-_____-_____-_____-_____</translation>
+    </message>
+    <message>
+        <source>Please enter your Supporter Certificate or License Serial Number:</source>
+        <translation>Wprowadź certyfikat wspierającego lub numer seryjny licencji:</translation>
+    </message>
+    <message>
+        <source>Hotpatches for the installed version, updates to the Templates.ini and translations.</source>
+        <translation>Poprawki dla zainstalowanej wersji, aktualizacje Templates.ini i tłumaczeń.</translation>
+    </message>
+    <message>
+        <source>Incremental Updates</source>
+        <translation>Aktualizacje przyrostowe</translation>
+    </message>
+    <message>
+        <source>The preview channel contains the latest GitHub pre-releases.</source>
+        <translation>Kanał testowy zawiera najnowsze wersje wstępne z GitHuba.</translation>
+    </message>
+    <message>
+        <source>Search in the Preview channel</source>
+        <translation>Wyszukuj w kanale testowym</translation>
+    </message>
+    <message>
+        <source>Update Settings</source>
+        <translation>Ustawienia aktualizacji</translation>
+    </message>
+    <message>
+        <source>The stable channel contains the latest stable GitHub releases.</source>
+        <translation>Kanał stabilny zawiera najnowsze stabilne wersje z GitHuba.</translation>
+    </message>
+    <message>
+        <source>Search in the Stable channel</source>
+        <translation>Wyszukuj w kanale stabilnym</translation>
+    </message>
+    <message>
+        <source>New full installers from the selected release channel.</source>
+        <translation>Nowe pełne instalatory z wybranego kanału wydania.</translation>
+    </message>
+    <message>
+        <source>Full Upgrades</source>
+        <translation>Pełne aktualizacje</translation>
+    </message>
+    <message>
+        <source>Update Check Interval</source>
+        <translation>Interwał sprawdzania aktualizacji</translation>
+    </message>
+    <message>
+        <source>Check periodically for new versions</source>
+        <translation>Okresowo sprawdzaj dostępność nowych wersji</translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Certificate usage guide&lt;/a&gt;</source>
+        <translation>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Instrukcja użycia certyfikatu&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>This supporter certificate has expired, please &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;get an updated certificate&lt;/a&gt;.</source>
+        <translation>Ten certyfikat wspierającego wygasł, proszę &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;pobrać nowy certyfikat&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <source>Enter the support certificate here</source>
+        <translation>Wprowadź tutaj certyfikat wsparcia</translation>
+    </message>
+    <message>
+        <source>Retrieve/Upgrade/Renew certificate using Serial Number</source>
+        <translation>Pobierz/zaktualizuj/odnów certyfikat za pomocą numeru seryjnego</translation>
+    </message>
+</context>
+<context>
+    <name>VolumeWindow</name>
+    <message>
+        <source>Form</source>
+        <translation>Formularz</translation>
+    </message>
+    <message>
+        <source>Load volume access protection rules</source>
+        <translation>Wczytaj zasady ochrony dostępu do woluminu</translation>
+    </message>
+    <message>
+        <source>Select directory as mount point</source>
+        <translation>Wybierz katalog jako punkt montowania</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Mount Point</source>
+        <translation>Punkt montowania</translation>
+    </message>
+    <message>
+        <source>New Password</source>
+        <translation>Nowe hasło</translation>
+    </message>
+    <message>
+        <source>Repeat Password</source>
+        <translation>Powtórz hasło</translation>
+    </message>
+    <message>
+        <source>kilobytes</source>
+        <translation>kilobajty</translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation>EtykietaTekstowa</translation>
+    </message>
+    <message>
+        <source>Encryption Cipher</source>
+        <translation>Szyfr szyfrowania</translation>
+    </message>
+    <message>
+        <source>Show Password</source>
+        <translation>Pokaż hasło</translation>
+    </message>
+    <message>
+        <source>Enter Password</source>
+        <translation>Wprowadź hasło</translation>
+    </message>
+    <message>
+        <source>Disk Image Size</source>
+        <translation>Rozmiar obrazu dysku</translation>
+    </message>
+    <message>
+        <source>Auto Lock after</source>
+        <translation>Automatycznie zablokuj po</translation>
+    </message>
+</context>
 </TS>

--- a/MajorPrivacy/MajorPrivacy_tr.ts
+++ b/MajorPrivacy/MajorPrivacy_tr.ts
@@ -1,2128 +1,2129 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="tr">
+<TS version="2.1" language="tr_TR">
 <context>
     <name>AccessRuleWnd</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Access Rule Identity</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Kuralı Kimliği</translation>
     </message>
     <message>
         <source>Description...</source>
-        <translation type="unfinished"></translation>
+        <translation>Açıklama...</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <source>Path Pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol Deseni</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Path &amp;&amp; Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol &amp;&amp; Eylem</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol</translation>
     </message>
 </context>
 <context>
     <name>CAbstractTweak</name>
     <message>
         <source>Tweak Group</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce Ayar Grubu</translation>
     </message>
     <message>
         <source>Tweak Bundle</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce Ayar Paketi</translation>
     </message>
     <message>
         <source>Set Registry Option</source>
-        <translation type="unfinished"></translation>
+        <translation>Kayıt Defteri Seçeneği Ayarlaması</translation>
     </message>
     <message>
         <source>Configure Group Policy</source>
-        <translation type="unfinished"></translation>
+        <translation>Grup İlkesi Yapılandırması</translation>
     </message>
     <message>
         <source>Disable System Service</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem Hizmeti Devre Dışı Bırakma</translation>
     </message>
     <message>
         <source>Disable Scheduled Task</source>
-        <translation type="unfinished"></translation>
+        <translation>Zamanlanmış Görevi Devre Dışı Bırakma</translation>
     </message>
     <message>
         <source>Resource Access Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Erişim Kuralı</translation>
     </message>
     <message>
         <source>Execution Control Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme Denetimi Kuralı</translation>
     </message>
     <message>
         <source>Firewall Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Kuralı</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
     <message>
         <source>Not set</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlanmamış</translation>
     </message>
     <message>
         <source>Applied</source>
-        <translation type="unfinished"></translation>
+        <translation>Uygulanmış</translation>
     </message>
     <message>
         <source>Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlı</translation>
     </message>
     <message>
         <source>Missing</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksik</translation>
     </message>
     <message>
         <source>Ineffective</source>
-        <translation type="unfinished"></translation>
+        <translation>Etkisiz</translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel</translation>
     </message>
     <message>
         <source>Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Grup</translation>
     </message>
     <message>
         <source>Not available</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut değil</translation>
     </message>
     <message>
         <source>Recommended</source>
-        <translation type="unfinished"></translation>
+        <translation>Önerilen</translation>
     </message>
     <message>
         <source>Not recommended</source>
-        <translation type="unfinished"></translation>
+        <translation>Önerilmeyen</translation>
     </message>
     <message>
         <source>Breaking</source>
-        <translation type="unfinished"></translation>
+        <translation>Kırıcı</translation>
     </message>
 </context>
 <context>
     <name>CAccessListModel</name>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Last Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Erişim</translation>
     </message>
     <message>
         <source>Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
 </context>
 <context>
     <name>CAccessListView</name>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
 </context>
 <context>
     <name>CAccessModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Last Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Erişim</translation>
     </message>
 </context>
 <context>
     <name>CAccessPage</name>
     <message>
         <source>Access Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Kuralları</translation>
     </message>
     <message>
         <source>Open Resources</source>
-        <translation type="unfinished"></translation>
+        <translation>Açık Kaynaklar</translation>
     </message>
     <message>
         <source>Access Monitor</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Monitörü</translation>
     </message>
     <message>
         <source>Trace Log</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğü</translation>
     </message>
 </context>
 <context>
     <name>CAccessRule</name>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Allow Read-Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Salt Okumaya İzin Ver</translation>
     </message>
     <message>
         <source>Allow Listing</source>
-        <translation type="unfinished"></translation>
+        <translation>Listelemeye İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Protect</source>
-        <translation type="unfinished"></translation>
+        <translation>Koru</translation>
     </message>
     <message>
         <source>Don&apos;t Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Günlüğe Kaydetme</translation>
     </message>
 </context>
 <context>
     <name>CAccessRuleModel</name>
     <message>
         <source>%1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Hayır</translation>
     </message>
     <message>
         <source> (Hidden)</source>
-        <translation type="unfinished"></translation>
+        <translation> (Gizlenmiş)</translation>
     </message>
     <message>
         <source> (Temporary)</source>
-        <translation type="unfinished"></translation>
+        <translation> (Geçici)</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Etkin</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CAccessRuleView</name>
     <message>
         <source>Enable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Etkinleştir</translation>
     </message>
     <message>
         <source>Disable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Devre Dışı Bırak</translation>
     </message>
     <message>
         <source>Delete Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Sil</translation>
     </message>
     <message>
         <source>Edit Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Düzenle</translation>
     </message>
     <message>
         <source>Duplicate Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Çoğalt</translation>
     </message>
     <message>
         <source>Create Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Oluştur</translation>
     </message>
     <message>
         <source>All Actions</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Eylemler</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilen</translation>
     </message>
     <message>
         <source>Allow Read-Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Salt Okunan</translation>
     </message>
     <message>
         <source>Allow Listing</source>
-        <translation type="unfinished"></translation>
+        <translation>Listeleme İzni Verilen</translation>
     </message>
     <message>
         <source>Protect</source>
-        <translation type="unfinished"></translation>
+        <translation>Korunan</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenen</translation>
     </message>
     <message>
         <source>Don&apos;t Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Günlüğe Kaydedilmeyen</translation>
     </message>
     <message>
         <source>Hide Disabled Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Devre Dışı Kuralları Gizle</translation>
     </message>
     <message>
         <source>Show Hidden Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizli Kuralları Göster</translation>
     </message>
     <message>
         <source>Refresh Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralları Yenile</translation>
     </message>
     <message>
         <source>Remove Temporary Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçici Kuralları Kaldır</translation>
     </message>
     <message>
         <source>Do you want to delete selected Rules Items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen kural öğelerini silmek istiyor musunuz?</translation>
     </message>
     <message>
         <source>Do you want to delete all Temporary Rules?</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm geçici kuralları silmek ister misiniz?</translation>
     </message>
 </context>
 <context>
     <name>CAccessRuleWnd</name>
     <message>
         <source>Create Program Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kuralı Oluşturma</translation>
     </message>
     <message>
         <source>Edit Program Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kuralı Düzenleme</translation>
     </message>
     <message>
         <source>New Access Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Erişim Kuralı</translation>
     </message>
     <message>
         <source>Global (Any/No Enclave)</source>
-        <translation type="unfinished"></translation>
+        <translation>Genel (Herhangi/Kapanım Yok)</translation>
     </message>
     <message>
         <source>Browse for Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Klasör için Göz At</translation>
     </message>
     <message>
         <source>Browse for File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya için Göz At</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Read Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Salt Okunur</translation>
     </message>
     <message>
         <source>Directory Listing</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizin Listele</translation>
     </message>
     <message>
         <source>Protect</source>
-        <translation type="unfinished"></translation>
+        <translation>Koru</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Don&apos;t Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Günlüğe Kaydetme</translation>
     </message>
     <message>
         <source>Select Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizin Seç</translation>
     </message>
     <message>
         <source>Select File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Seç</translation>
     </message>
     <message>
         <source>The path must be contained within the volume.</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol birim içinde bulunmalıdır.</translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
-        <translation type="unfinished"></translation>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Bu kural türü için seçilen program türü desteklenmez</translation>
     </message>
     <message>
         <source>%1 %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 %2 %3</translation>
     </message>
     <message>
         <source> (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (%1)</translation>
     </message>
 </context>
 <context>
     <name>CAccessTraceModel</name>
     <message>
         <source>Unknown Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen Program</translation>
     </message>
     <message>
         <source> (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (%1)</translation>
     </message>
     <message>
         <source>PROGRAM MISSING</source>
-        <translation type="unfinished"></translation>
+        <translation>PROGRAM EKSİK</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol</translation>
     </message>
     <message>
         <source>Operation</source>
-        <translation type="unfinished"></translation>
+        <translation>Operasyon</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Program (Actor)</source>
-        <translation type="unfinished"></translation>
+        <translation>Program (Kaynak)</translation>
     </message>
 </context>
 <context>
     <name>CAccessTraceView</name>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Auto Scroll</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Kaydırma</translation>
     </message>
     <message>
         <source>Hold updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Güncellemeleri Tut</translation>
     </message>
     <message>
         <source>Clear Trace Log</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğünü Temizle</translation>
     </message>
 </context>
 <context>
     <name>CAccessView</name>
     <message>
         <source>Any Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Erişimler</translation>
     </message>
     <message>
         <source>Read/Write</source>
-        <translation type="unfinished"></translation>
+        <translation>Okuma/Yazma</translation>
     </message>
     <message>
         <source>Write Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Salt Yazma</translation>
     </message>
     <message>
         <source>Reload Access Tree</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Ağacını Yeniden Yükle</translation>
     </message>
     <message>
         <source>CleanUp Access Tree</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Ağacını Temizle</translation>
     </message>
     <message>
         <source>Copy Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yolu Kopyala</translation>
     </message>
     <message>
         <source>My Computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilgisayarım</translation>
     </message>
     <message>
         <source>\\.\</source>
-        <translation type="unfinished"></translation>
+        <translation>\\. \</translation>
     </message>
     <message>
         <source>Registry</source>
-        <translation type="unfinished"></translation>
+        <translation>Kayıt Defteri</translation>
     </message>
     <message>
         <source>Network</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ</translation>
     </message>
     <message>
         <source>Loading %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Yükleniyor %1</translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
-        <translation type="unfinished"></translation>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <translation>Erişim Ağacını temizlemek ister misiniz? Bu, Sistemde artık bulunmayan tüm Dosyaları ve klasörleri kaldıracaktır. Ayrıca, mevcut ancak şu anda bağlanmamış birimlerde bulunan tüm dosya ve klasörlere yapılan tüm başvuruları da kaldıracaktır. İşlem, tüm kayıtlı konumlara erişmeyi deneyecektir ve biraz zaman alacaktır, tamamlandıktan sonra görünüm yenilenecektir.</translation>
     </message>
 </context>
 <context>
     <name>CDnsCacheEntry</name>
     <message>
         <source>UNKNOWN (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>BİLİNMEYEN (%1)</translation>
     </message>
     <message>
         <source>Cached</source>
-        <translation type="unfinished"></translation>
+        <translation>Önbelleğe Alınmış</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
 </context>
 <context>
     <name>CDnsCacheModel</name>
     <message>
         <source>Host name</source>
-        <translation type="unfinished"></translation>
+        <translation>Sunucu Adı</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <source>TTL (sec)</source>
-        <translation type="unfinished"></translation>
+        <translation>TTL (Sn)</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Last seen</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Görülme</translation>
     </message>
     <message>
         <source>Counter</source>
-        <translation type="unfinished"></translation>
+        <translation>Sayaç</translation>
     </message>
     <message>
         <source>Resolved data</source>
-        <translation type="unfinished"></translation>
+        <translation>Çözümlenmiş Veri</translation>
     </message>
 </context>
 <context>
     <name>CDnsCacheView</name>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Cached</source>
-        <translation type="unfinished"></translation>
+        <translation>Önbelleğe Alınmış</translation>
     </message>
     <message>
         <source>Any Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Türler</translation>
     </message>
     <message>
         <source>A or AAAA</source>
-        <translation type="unfinished"></translation>
+        <translation>A veya AAAA</translation>
     </message>
     <message>
         <source>A</source>
-        <translation type="unfinished"></translation>
+        <translation>A</translation>
     </message>
     <message>
         <source>AAAA</source>
-        <translation type="unfinished"></translation>
+        <translation>AAAA</translation>
     </message>
     <message>
         <source>CNAME</source>
-        <translation type="unfinished"></translation>
+        <translation>CNAME</translation>
     </message>
     <message>
         <source>MX</source>
-        <translation type="unfinished"></translation>
+        <translation>MX</translation>
     </message>
     <message>
         <source>PTR</source>
-        <translation type="unfinished"></translation>
+        <translation>PTR</translation>
     </message>
     <message>
         <source>SRV</source>
-        <translation type="unfinished"></translation>
+        <translation>SRV</translation>
     </message>
     <message>
         <source>TXT</source>
-        <translation type="unfinished"></translation>
+        <translation>TXT</translation>
     </message>
     <message>
         <source>WKS</source>
-        <translation type="unfinished"></translation>
+        <translation>WKS</translation>
     </message>
     <message>
         <source>Clear System DNS Cache</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem DNS önbelleğini temizle</translation>
     </message>
 </context>
 <context>
     <name>CDnsPage</name>
     <message>
         <source>Dns Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Kuralları</translation>
     </message>
     <message>
         <source>DnsCache</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Önbelleği</translation>
     </message>
 </context>
 <context>
     <name>CDnsRule</name>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Hiçbiri</translation>
     </message>
 </context>
 <context>
     <name>CDnsRuleModel</name>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Hayır</translation>
     </message>
     <message>
         <source> (Temporary)</source>
-        <translation type="unfinished"></translation>
+        <translation> (Geçici)</translation>
     </message>
     <message>
         <source>Host Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Sunucu Adı</translation>
     </message>
     <message>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Etkin</translation>
     </message>
     <message>
         <source>Hit Count</source>
-        <translation type="unfinished"></translation>
+        <translation>İsabet Sayısı</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
 </context>
 <context>
     <name>CDnsRuleView</name>
     <message>
         <source>Enable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Etkinleştir</translation>
     </message>
     <message>
         <source>Disable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Devre Dışı Bırak</translation>
     </message>
     <message>
         <source>Set Blocking</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelleye Ayarla</translation>
     </message>
     <message>
         <source>Set Allowing</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Vere Ayarla</translation>
     </message>
     <message>
         <source>Delete Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Sil</translation>
     </message>
     <message>
         <source>Edit Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Düzenle</translation>
     </message>
     <message>
         <source>Duplicate Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Çoğalt</translation>
     </message>
     <message>
         <source>Create Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Oluştur</translation>
     </message>
     <message>
         <source>All Actions</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Eylemler</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilen</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenen</translation>
     </message>
     <message>
         <source>Hide Disabled Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Devre Dışı Kuralları Gizle</translation>
     </message>
     <message>
         <source>Refresh Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralları Yenile</translation>
     </message>
     <message>
         <source>Edit Dns Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Kuralı Düzenleme</translation>
     </message>
     <message>
         <source>Enter Host Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Sunucu Adını Girin</translation>
     </message>
     <message>
         <source>Do you want to delete selected Rules Items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen kural öğelerini silmek istiyor musunuz?</translation>
     </message>
 </context>
 <context>
     <name>CEnclave</name>
     <message>
         <source>Developer Signed</source>
-        <translation type="unfinished"></translation>
+        <translation>Geliştirici İmzalı</translation>
     </message>
     <message>
         <source>User Signed</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı İmzalı</translation>
     </message>
     <message>
         <source>Microsoft</source>
-        <translation type="unfinished"></translation>
+        <translation>Microsoft</translation>
     </message>
     <message>
         <source>Microsoft/AV</source>
-        <translation type="unfinished"></translation>
+        <translation>Microsoft/AV</translation>
     </message>
     <message>
         <source>Microsoft Trusted</source>
-        <translation type="unfinished"></translation>
+        <translation>Microsoft Güvenilen</translation>
     </message>
     <message>
         <source>Unknown Root</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen Kök</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Hiçbiri</translation>
     </message>
     <message>
         <source>Undetermined</source>
-        <translation type="unfinished"></translation>
+        <translation>Belirsiz</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Eject</source>
-        <translation type="unfinished"></translation>
+        <translation>Çıkar</translation>
     </message>
 </context>
 <context>
     <name>CEnclaveManager</name>
     <message>
         <source>Major Privacy&apos;s Private Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy&apos;in Özel Kapanım</translation>
     </message>
 </context>
 <context>
     <name>CEnclaveModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Kimlik</translation>
     </message>
     <message>
         <source>Trust Level</source>
-        <translation type="unfinished"></translation>
+        <translation>Güven Seviyesi</translation>
     </message>
     <message>
         <source>Trusted Spawn/UnTrusted</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenilen/Güvenilmez Oluşturmada</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CEnclaveView</name>
     <message>
         <source>Run in Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanımda Çalıştır</translation>
     </message>
     <message>
         <source>Terminate All Processes</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm İşlemleri Sonlandır</translation>
     </message>
     <message>
         <source>Delete Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanımı Sil</translation>
     </message>
     <message>
         <source>Edit Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanımı Düzenle</translation>
     </message>
     <message>
         <source>Duplicate Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanımı Çoğalt</translation>
     </message>
     <message>
         <source>Create Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım Oluştur</translation>
     </message>
     <message>
         <source>Open Parent Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Üst Klasörü Aç</translation>
     </message>
     <message>
         <source>File Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Özellikleri</translation>
     </message>
     <message>
         <source>Terminate Process</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlemleri Sonlandır</translation>
     </message>
     <message>
         <source>%1 can&apos;t be edited!</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 düzenlenemez!</translation>
     </message>
     <message>
         <source>The process was ejected form the enclave, and is running unprotected, probably due to insuficient signature level!</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem, kapanımdan çıkartıldı ve muhtemelen yetersiz imza seviyesi nedeniyle korunmasız çalışıyor!</translation>
     </message>
     <message>
         <source>Failed to start process!</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem başlatılamadı!</translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
-        <translation type="unfinished"></translation>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
+        <translation>Seçilen kapanımlardaki tüm işlemleri sonlandırmak ister misiniz?</translation>
     </message>
     <message>
         <source>Terminate without asking</source>
-        <translation type="unfinished"></translation>
+        <translation>Sormadan sonlandır</translation>
     </message>
     <message>
         <source>Do you want to delete selected Enclave?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen Kapanımı silmek ister misiniz?</translation>
     </message>
     <message>
         <source>Do you want to terminate %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1&apos;i sonlandırmak ister misiniz?</translation>
     </message>
     <message>
         <source>the selected processes</source>
-        <translation type="unfinished"></translation>
+        <translation>seçilen işlemler</translation>
     </message>
 </context>
 <context>
     <name>CEnclaveWnd</name>
     <message>
         <source>Change Icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Simgeyi Değiştir</translation>
     </message>
     <message>
         <source>Browse for Image</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü için Göz Atın</translation>
     </message>
     <message>
         <source>Create Secure Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Kapanım Oluşturma</translation>
     </message>
     <message>
         <source>Edit Secure Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Kapanım Düzenleme</translation>
     </message>
     <message>
         <source>New Secure Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Güvenli Kapanım</translation>
     </message>
     <message>
         <source>User Signature ONLY (not recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Yalnızca Kullanıcı İmzalı (önerilmez)</translation>
     </message>
     <message>
         <source>User + Microsoft/AV Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı + Microsoft/AV İmzalı</translation>
     </message>
     <message>
         <source>User + Trusted by Microsoft (Code Root)</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı + Microsoft tarafından Güvenilen (Kod Kökü)</translation>
     </message>
     <message>
         <source>Any Signature (Unknown Root)</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir İmza (Bilinmeyen Kök)</translation>
     </message>
     <message>
         <source>No Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>İmza Yok</translation>
     </message>
     <message>
         <source>Allow Execution</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütmeye İzin Ver</translation>
     </message>
     <message>
         <source>Eject from Secure Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Kapanımndan Çıkar</translation>
     </message>
     <message>
         <source>Prevent Execution</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütmeyi Önle</translation>
     </message>
     <message>
         <source>Don&apos;t change</source>
-        <translation type="unfinished"></translation>
+        <translation>Değiştirme</translation>
     </message>
     <message>
         <source>Medium +</source>
-        <translation type="unfinished"></translation>
+        <translation>Orta +</translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüksek</translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem</translation>
     </message>
     <message>
         <source>Select Image File</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Dosyası Seçme</translation>
     </message>
     <message>
         <source>Image Files (*.png)</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Dosyaları (*.png)</translation>
     </message>
 </context>
 <context>
     <name>CExecutionModel</name>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Role</source>
-        <translation type="unfinished"></translation>
+        <translation>Rol</translation>
     </message>
     <message>
         <source>Last Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Durum</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CExecutionView</name>
     <message>
         <source>Any Role</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Roller</translation>
     </message>
     <message>
         <source>Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak</translation>
     </message>
     <message>
         <source>Target</source>
-        <translation type="unfinished"></translation>
+        <translation>Hedef</translation>
     </message>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Show entries per UPID</source>
-        <translation type="unfinished"></translation>
+        <translation>UPID başına Girişleri Göster</translation>
     </message>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
 </context>
 <context>
     <name>CFirewallRuleWnd</name>
     <message>
         <source>Create Firewall Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Kuralı Oluşturma</translation>
     </message>
     <message>
         <source>Edit Firewall Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Kuralı Düzenleme</translation>
     </message>
     <message>
         <source>&amp;MP-Rule, New Firewall Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;MP-Rule, Yeni Güvenlik Duvarı Kuralı</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Bidirectional</source>
-        <translation type="unfinished"></translation>
+        <translation>Çift Yönlü</translation>
     </message>
     <message>
         <source>Inbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelen</translation>
     </message>
     <message>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Giden</translation>
     </message>
     <message>
         <source>Any Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir Protokol</translation>
     </message>
     <message>
         <source>[Add IP]</source>
-        <translation type="unfinished"></translation>
+        <translation>[IP Ekle]</translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
-        <translation type="unfinished"></translation>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Bu kural türü için seçilen program türü desteklenmez</translation>
     </message>
     <message>
         <source>All Types</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Türler</translation>
     </message>
     <message>
         <source>Invalid Sub Net</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz Alt Ağ</translation>
     </message>
     <message>
         <source>Invalid IP Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz IP Adresi</translation>
     </message>
     <message>
         <source>Invalid IP Range</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz IP Aralığı</translation>
     </message>
     <message>
         <source>%4, %1 %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%4, %1 %2 %3</translation>
     </message>
 </context>
 <context>
     <name>CFwRule</name>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümü</translation>
     </message>
     <message>
         <source>Domain</source>
-        <translation type="unfinished"></translation>
+        <translation>Etki Alanı</translation>
     </message>
     <message>
         <source>Private</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel</translation>
     </message>
     <message>
         <source>Public</source>
-        <translation type="unfinished"></translation>
+        <translation>Ortak</translation>
     </message>
     <message>
         <source>Any</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi</translation>
     </message>
     <message>
         <source>LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>LAN</translation>
     </message>
     <message>
         <source>WiFi</source>
-        <translation type="unfinished"></translation>
+        <translation>WiFi</translation>
     </message>
     <message>
         <source>VPN</source>
-        <translation type="unfinished"></translation>
+        <translation>VPN</translation>
     </message>
     <message>
         <source>FromLog</source>
-        <translation type="unfinished"></translation>
+        <translation>Fromlog</translation>
     </message>
     <message>
         <source>UnRuled</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralsız</translation>
     </message>
     <message>
         <source>Rule Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>Kurala İzin Verilmiş</translation>
     </message>
     <message>
         <source>Rule Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural engellenmiş</translation>
     </message>
     <message>
         <source>Rule Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Hatası</translation>
     </message>
     <message>
         <source>Rule Generated</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Oluşturuldu</translation>
     </message>
     <message>
         <source>Undefined</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanımlanmamış</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Inbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelen</translation>
     </message>
     <message>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Giden</translation>
     </message>
     <message>
         <source>Bidirectional</source>
-        <translation type="unfinished"></translation>
+        <translation>Çift Yönlü</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
 </context>
 <context>
     <name>CFwRuleModel</name>
     <message>
         <source>%1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Hayır</translation>
     </message>
     <message>
         <source> (Temporary)</source>
-        <translation type="unfinished"></translation>
+        <translation> (Geçici)</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Grouping</source>
-        <translation type="unfinished"></translation>
+        <translation>Gruplandırma</translation>
     </message>
     <message>
         <source>Index</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizin</translation>
     </message>
     <message>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Etkin</translation>
     </message>
     <message>
         <source>Hit Count</source>
-        <translation type="unfinished"></translation>
+        <translation>İsabet Sayısı</translation>
     </message>
     <message>
         <source>Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>Profiller</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="unfinished"></translation>
+        <translation>Yön</translation>
     </message>
     <message>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>Protokol</translation>
     </message>
     <message>
         <source>Remote Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Adres</translation>
     </message>
     <message>
         <source>Local Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Adres</translation>
     </message>
     <message>
         <source>Remote Ports</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Bağlantı Noktaları</translation>
     </message>
     <message>
         <source>Local Ports</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Bağlantı Noktaları</translation>
     </message>
     <message>
         <source>ICMP Options</source>
-        <translation type="unfinished"></translation>
+        <translation>ICMP Seçenekleri</translation>
     </message>
     <message>
         <source>Interfaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Arabirimler</translation>
     </message>
     <message>
         <source>Edge Traversal</source>
-        <translation type="unfinished"></translation>
+        <translation>Kenar Geçişi</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CFwRuleView</name>
     <message>
         <source>Enable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Etkinleştir</translation>
     </message>
     <message>
         <source>Disable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Devre Dışı Bırak</translation>
     </message>
     <message>
         <source>Set Blocking</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelleye Ayarla</translation>
     </message>
     <message>
         <source>Set Allowing</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Vere Ayarla</translation>
     </message>
     <message>
         <source>Delete Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Sil</translation>
     </message>
     <message>
         <source>Edit Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Düzenle</translation>
     </message>
     <message>
         <source>Duplicate Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Çoğalt</translation>
     </message>
     <message>
         <source>Create Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Oluştur</translation>
     </message>
     <message>
         <source>All Directions</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Yönler</translation>
     </message>
     <message>
         <source>Inbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelen</translation>
     </message>
     <message>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Giden</translation>
     </message>
     <message>
         <source>All Actions</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Eylemler</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilen</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenen</translation>
     </message>
     <message>
         <source>Hide Disabled Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Devre Dışı Kuralları Gizle</translation>
     </message>
     <message>
         <source>Refresh Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralları Yenile</translation>
     </message>
     <message>
         <source>Remove Temporary Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçici Kuralları Kaldır</translation>
     </message>
     <message>
         <source>Do you want to delete selected Rules Items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen kural öğelerini silmek istiyor musunuz?</translation>
     </message>
     <message>
         <source>Do you want to delete all Temporary Rules?</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm geçici kuralları silmek ister misiniz?</translation>
     </message>
 </context>
 <context>
     <name>CGenericRule</name>
     <message>
         <source> (duplicate)</source>
-        <translation type="unfinished"></translation>
+        <translation> (çoğalt)</translation>
     </message>
 </context>
 <context>
     <name>CHandleModel</name>
     <message>
         <source>PROCESS MISSING</source>
-        <translation type="unfinished"></translation>
+        <translation>İŞLEM EKSİK</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CHomePage</name>
     <message>
         <source>Time Stamp|Type|Event|Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası|Tür|Olay|Mesaj</translation>
     </message>
     <message>
         <source>Success</source>
-        <translation type="unfinished"></translation>
+        <translation>Başarılı</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Hata</translation>
     </message>
     <message>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Uyarı</translation>
     </message>
     <message>
         <source>Information</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilgi</translation>
     </message>
     <message>
         <source>Audit Success</source>
-        <translation type="unfinished"></translation>
+        <translation>Denetim Başarısı</translation>
     </message>
     <message>
         <source>Audit Failure</source>
-        <translation type="unfinished"></translation>
+        <translation>Denetim Hatası</translation>
     </message>
 </context>
 <context>
     <name>CInfoView</name>
     <message>
         <source>Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilgi</translation>
     </message>
     <message>
         <source>Name: %1 (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad: %1 ( %2)</translation>
     </message>
     <message>
         <source>Path: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol: %1</translation>
     </message>
     <message>
         <source>Groups (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Gruplar (%1)</translation>
     </message>
     <message>
         <source>Root (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Kök (%1)</translation>
     </message>
     <message>
         <source>%1 (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (%2)</translation>
     </message>
 </context>
 <context>
     <name>CIngressModel</name>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Role</source>
-        <translation type="unfinished"></translation>
+        <translation>Rol</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Operation</source>
-        <translation type="unfinished"></translation>
+        <translation>Operasyon</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CIngressView</name>
     <message>
         <source>Any Role</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Roller</translation>
     </message>
     <message>
         <source>Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak</translation>
     </message>
     <message>
         <source>Target</source>
-        <translation type="unfinished"></translation>
+        <translation>Hedef</translation>
     </message>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>All Operations</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Operasyonlar</translation>
     </message>
     <message>
         <source>Control Execution</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme Denetimi</translation>
     </message>
     <message>
         <source>Change Permissions</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Değiştirme</translation>
     </message>
     <message>
         <source>Write Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Bellek Yazma</translation>
     </message>
     <message>
         <source>Read Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Bellek Okuma</translation>
     </message>
     <message>
         <source>Special Permissions</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel İzinler</translation>
     </message>
     <message>
         <source>Write Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Özelliklere Yazma</translation>
     </message>
     <message>
         <source>Read Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Özellikleri Okuma</translation>
     </message>
     <message>
         <source>Show Private Entries</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel Girişleri Göster</translation>
     </message>
     <message>
         <source>Show entries per UPID</source>
-        <translation type="unfinished"></translation>
+        <translation>UPID başına Girişleri Göster</translation>
     </message>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
 </context>
 <context>
     <name>CLibraryInfoView</name>
     <message>
         <source>Name|Signer|Valid|SHA1 Fingerprint|Certificate Fingerprint</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad|İmzalayan|Geçerli|SHA1 Parmak İzi|Sertifika Parmak İzi</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet</translation>
     </message>
     <message>
         <source>INVALID</source>
-        <translation type="unfinished"></translation>
+        <translation>GEÇERSİZ</translation>
     </message>
     <message>
         <source>Yes (Catalog)</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet (Katalog)</translation>
     </message>
 </context>
 <context>
     <name>CLibraryModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Trust Level</source>
-        <translation type="unfinished"></translation>
+        <translation>Güven Seviyesi</translation>
     </message>
     <message>
         <source>Last Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Durum</translation>
     </message>
     <message>
         <source>Last Load</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Yükleme</translation>
     </message>
     <message>
         <source>Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Sayım</translation>
     </message>
     <message>
         <source>Signing Certificate</source>
-        <translation type="unfinished"></translation>
+        <translation>İmzalayan Sertifika</translation>
     </message>
     <message>
         <source>Module</source>
-        <translation type="unfinished"></translation>
+        <translation>Bileşen</translation>
     </message>
 </context>
 <context>
     <name>CLibraryView</name>
     <message>
         <source>Sign File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya İmzala</translation>
     </message>
     <message>
         <source>Remove File Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya İmzasını Kaldır</translation>
     </message>
     <message>
         <source>Sign Certificate</source>
-        <translation type="unfinished"></translation>
+        <translation>Sertifika İmzala</translation>
     </message>
     <message>
         <source>Remove Cert Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>Sertifika İmzasını Kaldır</translation>
     </message>
     <message>
         <source>Open Parent Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Üst Klasörü Aç</translation>
     </message>
     <message>
         <source>File Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Özellikleri</translation>
     </message>
     <message>
         <source>By Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programı Olarak</translation>
     </message>
     <message>
         <source>By Library</source>
-        <translation type="unfinished"></translation>
+        <translation>Kütüphane Olarak</translation>
     </message>
     <message>
         <source>All Signatures</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm İmzalar</translation>
     </message>
     <message>
         <source>User Sign. ONLY</source>
-        <translation type="unfinished"></translation>
+        <translation>YALNIZCA Kullanıcı İmzalı</translation>
     </message>
     <message>
         <source>Microsoft/AV</source>
-        <translation type="unfinished"></translation>
+        <translation>Microsoft/AV</translation>
     </message>
     <message>
         <source>Trusted by MSFT</source>
-        <translation type="unfinished"></translation>
+        <translation>MSFT tarafından Güvenilen</translation>
     </message>
     <message>
         <source>Untrusted/None</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenilmez/Hiçbiri</translation>
     </message>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Untrusted</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenilmez</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>CleanUp Libraries</source>
-        <translation type="unfinished"></translation>
+        <translation>Kütüphaneleri Temizle</translation>
     </message>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
 </context>
 <context>
     <name>CMajorPrivacy</name>
     <message>
         <source>Starting ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Başlıyor ...</translation>
     </message>
     <message>
         <source>The driver configuration is corrupted, and could not be loaded, plrease restore from a backup.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sürücü yapılandırması bozuk ve yüklenemedi, lütfen bir yedeklemeden geri yükleyin.</translation>
     </message>
     <message>
         <source>The driver configuration is Untrusted (INVALID Signature, or Sequence). Do you want to load ir anyways?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sürücü yapılandırması güvenilmez (GEÇERSİZ İmza veya Dizi). Yine de yüklemek istiyor musun?</translation>
     </message>
     <message>
         <source>The Privacy Agent is not currently installed as a service. Would you like to install it now (Yes), run it without installation (No), or abort the connection attempt (Cancel)?</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik Aracısı şu anda bir hizmet olarak yüklü değil. Şimdi yüklemek ister misiniz (Evet), yüklemeden çalıştırmak ister misiniz (Hayır) veya bağlantı girişimini iptal etmek ister misiniz (İptal)?</translation>
     </message>
     <message>
         <source>Remember this choice.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu seçimi hatırla.</translation>
     </message>
     <message>
         <source>Major Privacy will now attempt to start the Privacy Agent, please confirm the UAC prompt.</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy şimdi Gizlilik Aracısını başlatmayı deneyecek, lütfen UAC istemini onaylayın.</translation>
     </message>
     <message>
         <source>Privacy Agent Ready %1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik Aracısı Hazır %1/ %2</translation>
     </message>
     <message>
         <source>Privacy Agent Failed: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik Aracısı Başarısız: %1</translation>
     </message>
     <message>
         <source>Do you want to close Major Privacy?</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy&apos;i kapatmak ister misiniz?</translation>
     </message>
     <message>
         <source>Lost connection to Service, do you want to reconnect?</source>
-        <translation type="unfinished"></translation>
+        <translation>Hizmet bağlantısı kesildi, yeniden bağlanmak istiyor musunuz?</translation>
     </message>
     <message>
         <source>Mem Usage: %1 + %2 (Logs)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bellek Kullanımı: %1 + %2 (Günlükler)</translation>
     </message>
     <message>
         <source>Disconnected from privacy agent</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik aracısından bağlantı kesildi</translation>
     </message>
     <message>
         <source>&amp;Maintenance</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Bakım</translation>
     </message>
     <message>
         <source>Import Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçenekleri İçe Aktar</translation>
     </message>
     <message>
         <source>Export Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçenekleri Dışa Aktar</translation>
     </message>
     <message>
         <source>&amp;Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Gelişmiş</translation>
     </message>
     <message>
         <source>Connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlan</translation>
     </message>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantıyı Kes</translation>
     </message>
     <message>
         <source>Install Services</source>
-        <translation type="unfinished"></translation>
+        <translation>Hizmetleri Yükle</translation>
     </message>
     <message>
         <source>Remove Services</source>
-        <translation type="unfinished"></translation>
+        <translation>Hizmetleri Kaldır</translation>
     </message>
     <message>
         <source>Open User Data Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Veri Klasörünü Aç</translation>
     </message>
     <message>
         <source>Open System Data Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem Veri Klasörünü Aç</translation>
     </message>
     <message>
         <source>Open *.dat Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>*.dat Düzenleyicisini Aç</translation>
     </message>
     <message>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Çıkış</translation>
     </message>
     <message>
         <source>Toggle Program Tree</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Ağacını Aç/Kapat</translation>
     </message>
     <message>
         <source>Stack Panels</source>
-        <translation type="unfinished"></translation>
+        <translation>Panelleri Üst Üste Yığ</translation>
     </message>
     <message>
         <source>Merge Panels</source>
-        <translation type="unfinished"></translation>
+        <translation>Panelleri Birleştir</translation>
     </message>
     <message>
         <source>Separate Column Sets</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayrı Sütun Kümeleri</translation>
     </message>
     <message>
         <source>Show Tab Labels</source>
-        <translation type="unfinished"></translation>
+        <translation>Sekme Etiketlerini Göster</translation>
     </message>
     <message>
         <source>Always on Top</source>
-        <translation type="unfinished"></translation>
+        <translation>Her Zaman Üstte</translation>
     </message>
     <message>
         <source>Add and Mount Volume Image</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Görüntüsü Ekle ve Bağla</translation>
     </message>
     <message>
         <source>Unmount All Volumes</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Birimleri Çıkar</translation>
     </message>
     <message>
         <source>Create Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Oluştur</translation>
     </message>
     <message>
         <source>Sign File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya İmzala</translation>
     </message>
     <message>
         <source>Signature Database</source>
-        <translation type="unfinished"></translation>
+        <translation>İmza Veritabanı</translation>
     </message>
     <message>
         <source>Unload Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Korumayı Kaldır</translation>
     </message>
     <message>
         <source>Enable Rule Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Korumasını Etkinleştir</translation>
     </message>
     <message>
         <source>Disable Rules Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Korumasını Devre Dışı Bırak</translation>
     </message>
     <message>
         <source>Setup User Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Anahtarını Ayarla</translation>
     </message>
     <message>
         <source>Remove User Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Anahtarını Kaldır</translation>
     </message>
     <message>
         <source>CleanUp Program List</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Listesi Temizle</translation>
     </message>
     <message>
         <source>Re-Group all Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Programları Yeniden Gruplandır</translation>
     </message>
     <message>
         <source>&amp;Advanced Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Gelişmiş Araçlar</translation>
     </message>
     <message>
         <source>Mount Manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlama Yöneticisi</translation>
     </message>
     <message>
         <source>Virtual Disks</source>
-        <translation type="unfinished"></translation>
+        <translation>Sanal Diskler</translation>
     </message>
     <message>
         <source>Clear All Trace Logs</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm İzleme Günlüklerini Temizle</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar</translation>
     </message>
     <message>
         <source>Unlock Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Yapılandırma Kilidini Aç</translation>
     </message>
     <message>
         <source>Commit Changes</source>
-        <translation type="unfinished"></translation>
+        <translation>Değişiklikleri İşle</translation>
     </message>
     <message>
         <source>Discard Changes</source>
-        <translation type="unfinished"></translation>
+        <translation>Değişiklikleri At</translation>
     </message>
     <message>
         <source>Clear Ignore List</source>
-        <translation type="unfinished"></translation>
+        <translation>Yok Sayma Listesini Temizle</translation>
     </message>
     <message>
         <source>Reset All Prompts</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm İstemleri Sıfırla</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Yardım</translation>
     </message>
     <message>
         <source>Visit Support Forum</source>
-        <translation type="unfinished"></translation>
+        <translation>Destek Forumunu Ziyaret Et</translation>
     </message>
     <message>
         <source>About the Qt Framework</source>
-        <translation type="unfinished"></translation>
+        <translation>QT Framework Hakkında</translation>
     </message>
     <message>
         <source>About MajorPrivacy</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy Hakkında</translation>
     </message>
     <message>
         <source>System Overview</source>
-        <translation type="unfinished"></translation>
+        <translation>Sisteme Genel Bakış</translation>
     </message>
     <message>
         <source>Process Security</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Güvenliği</translation>
     </message>
     <message>
         <source>Secure Enclaves</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Kapanım</translation>
     </message>
     <message>
         <source>Resource Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Koruması</translation>
     </message>
     <message>
         <source>Secure Volumes</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Birimler</translation>
     </message>
     <message>
         <source>Network Firewall</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ Güvenlik Duvarı</translation>
     </message>
     <message>
         <source>DNS Filtering</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Filtreleme</translation>
     </message>
     <message>
         <source>Privacy Tweaks</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik İnce Ayarları</translation>
     </message>
     <message>
         <source>Set Time Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Filtresini Ayarla</translation>
     </message>
     <message>
         <source>Any time</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir zaman</translation>
     </message>
     <message>
         <source>Last 5 Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 5 Saniye</translation>
     </message>
     <message>
         <source>Last 10 Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 10 Saniye</translation>
     </message>
     <message>
         <source>Last 30 Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 30 Saniye</translation>
     </message>
     <message>
         <source>Last Minute</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Dakika</translation>
     </message>
     <message>
         <source>Last 3 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 3 Dakika</translation>
     </message>
     <message>
         <source>Last 5 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 5 Dakika</translation>
     </message>
     <message>
         <source>Last 15 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 15 Dakika</translation>
     </message>
     <message>
         <source>Last 30 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 30 Dakika</translation>
     </message>
     <message>
         <source>Last Hour</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Saat</translation>
     </message>
     <message>
         <source>Last 3 Hours</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 3 Saat</translation>
     </message>
     <message>
         <source>Last 12 Hours</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 12 Saat</translation>
     </message>
     <message>
         <source>Last 24 Hours</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 24 Saat</translation>
     </message>
     <message>
         <source>Last 48 Hours</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 48 Saat</translation>
     </message>
     <message>
         <source>Last Week</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçen Hafta</translation>
     </message>
     <message>
         <source>Last 2 Weeks</source>
-        <translation type="unfinished"></translation>
+        <translation>Son 2 Hafta</translation>
     </message>
     <message>
         <source>Last Month</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçen Ay</translation>
     </message>
     <message>
         <source>Show/Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>Göster/Gizle</translation>
     </message>
     <message>
         <source>Process Protection Popups</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Koruma Açılır Pencereleri</translation>
     </message>
     <message>
         <source>Resource Access Popups</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Erişim Açılır Pencereleri</translation>
     </message>
     <message>
         <source>Network Firewall Popups</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ Güvenlik Duvarı Açılır Pencereleri</translation>
     </message>
     <message>
         <source>Firewall Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Profili</translation>
     </message>
     <message>
         <source>Use Allow List</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Listesi Kullan</translation>
     </message>
     <message>
         <source>Use Block List</source>
-        <translation type="unfinished"></translation>
+        <translation>Engel Listesi Kullan</translation>
     </message>
     <message>
         <source>Disabled Firewall</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Devre Dışı</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to sign a file</source>
-        <translation type="unfinished"></translation>
+        <translation>Bir dosya imzalamak için güvenli yapılandırma parolasını girin</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to sign a certificate</source>
-        <translation type="unfinished"></translation>
+        <translation>Bir sertifika imzalamak için güvenli yapılandırma parolasını girin</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to enable rule protection.
 Once that is done you can not change rules (except windows firewall) without using the user key.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural korumasını etkinleştirmek için Güvenli Yapılandırma Parolasını girin.
+Bu yapıldıktan sonra kullanıcı anahtarını kullanmadan kuralları (Windows güvenlik duvarı hariç) değiştiremezsiniz.</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to disable rule protection.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural korumasını devre dışı bırakmak için güvenli yapılandırma parolasını girin.</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to allow rule editing.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural düzenlemesine izin vermek için güvenli yapılandırma parolasını girin.</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to commit changes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Değişiklik yapmak için güvenli yapılandırma parolasını girin.</translation>
     </message>
     <message>
         <source>Enter Secure Configuration Password, to remove the user key.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı anahtarını kaldırmak için güvenli yapılandırma parolasını girin.</translation>
     </message>
     <message>
         <source>Remember Password to sign more items for:</source>
-        <translation type="unfinished"></translation>
+        <translation>Daha fazla öğe imzalamak için parola hatırlansın:</translation>
     </message>
     <message>
         <source>Remember Password and commit changes after:</source>
-        <translation type="unfinished"></translation>
+        <translation>Parola hatırlansın ve değişiklikler işlensin:</translation>
     </message>
     <message>
         <source>Select Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyaları Seçin</translation>
     </message>
     <message>
         <source>All Files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Dosyalar (*.*)</translation>
     </message>
     <message>
         <source>This setting required the service to be restarted to tak effect</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu ayarın etkili olması için hizmetin yeniden başlatılması gerekir</translation>
     </message>
     <message>
         <source>Don&apos;t show this message again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu mesaj bir daha gösterilmesin.</translation>
     </message>
     <message>
         <source>Would you like to lock down the user key (Yes), or only enable user key signature-based rule protection (No)?
@@ -2130,3058 +2131,3072 @@ Once that is done you can not change rules (except windows firewall) without usi
 Locking down the user key will prevent it from being removed or changed, and rule protection cannot be disabled until the system is rebooted.
 
 If the driver is set to auto-start, it will automatically re-lock the key on reboot!</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı anahtarını kilitlemek mi istiyorsunuz (Evet) yoksa yalnızca kullanıcı anahtarı imza tabanlı kural korumasını etkinleştirmek mi (Hayır)?
+
+Kullanıcı anahtarını kilitlemek, kaldırılmasını veya değiştirilmesini önleyecek ve kural koruması sistem yeniden başlatılana kadar devre dışı bırakılamayacak.
+
+Sürücü otomatik başlatmaya ayarlanmışsa, sistem yeniden başlatıldığında anahtarı otomatik olarak yeniden kilitleyecektir!</translation>
     </message>
     <message>
         <source>The user key is locked. Please reboot the system to complete the removal of the config protection.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı anahtarı kilitli. Yapılandırma korumasının kaldırılmasını tamamlamak için lütfen sistemi yeniden başlatın.</translation>
     </message>
     <message>
         <source>Do you really want to discard all changes?</source>
-        <translation type="unfinished"></translation>
+        <translation>Gerçekten tüm değişiklikleri atmak istiyor musunuz?</translation>
     </message>
     <message>
         <source>Set new Secure Configuration Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Güvenli Yapılandırma Parolası ayarlayın</translation>
     </message>
     <message>
         <source>Program not found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Program bulunamadı.</translation>
     </message>
     <message>
         <source>Program already exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Program zaten var.</translation>
     </message>
     <message>
         <source>This Operation can not be performed on a program which has rules.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu operasyon kuralları olan bir programda gerçekleştirilemez.</translation>
     </message>
     <message>
         <source>Parent program not found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Üst program bulunamadı.</translation>
     </message>
     <message>
         <source>Can&apos;t remove from pattern.</source>
-        <translation type="unfinished"></translation>
+        <translation>Desenden kaldırılamıyor.</translation>
     </message>
     <message>
         <source>Parent program not valid.</source>
-        <translation type="unfinished"></translation>
+        <translation>Üst program geçerli değil.</translation>
     </message>
     <message>
         <source>Removing program items which are auto generated and represent found components can not be removed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Otomatik olarak oluşturulan ve bulunan bileşenleri temsil eden program öğeleri kaldırılamaz.</translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
-        <translation type="unfinished"></translation>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
+        <translation>Bir ikiliyi imzalayabilmeniz için öncelikle Kullanıcı Anahtarınızı oluşturmanız gerekmektedir. Bunu yapmak için &apos;Güvenlik-&gt;Kullanıcı Anahtarını Ayarla&apos; menü komutunu kullanın.</translation>
     </message>
     <message>
         <source>Wrong Password!</source>
-        <translation type="unfinished"></translation>
+        <translation>Yanlış Parola!</translation>
     </message>
     <message>
         <source>Error 0x%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Hata 0x%1</translation>
     </message>
     <message>
         <source>MajorPrivacy - Error</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy - Hata</translation>
     </message>
     <message>
         <source>Operation failed for %1 item(s).</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 öğe (ler) için operasyon başarısız oldu.</translation>
     </message>
     <message>
         <source>Are you sure you want to clear the All trace logs for all program items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm program öğeleri için tüm izleme günlüklerini temizlemek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <source>Cleanup done.</source>
-        <translation type="unfinished"></translation>
+        <translation>Temizlik bitti.</translation>
     </message>
     <message>
         <source>Cleanup %1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Temizleme %1/ %2</translation>
     </message>
     <message>
         <source>Do you want to clean up the Program List? Choosing &apos;Yes&apos; will remove all missing program entries, including those with rules. Choosing &apos;No&apos; will remove only missing entries without rules. Select &apos;Cancel&apos; to abort the operation.</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Listesini temizlemek ister misiniz? &apos;Evet&apos;i seçmek, kuralları olanlar da dahil olmak üzere tüm eksik program girişlerini kaldıracaktır. &apos;Hayır&apos;ı seçmek, yalnızca kuralları olmayan eksik girişleri kaldıracaktır. İşlemi iptal etmek için &apos;İptal&apos;i seçin.</translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
-        <translation type="unfinished"></translation>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
+        <translation>Tüm Program Öğelerini yeniden gruplamak ister misiniz? Bu, tüm otomatik ilişkilendirilmiş gruplardan tüm program öğelerini kaldıracak ve varsayılan kurallara göre yeniden ekleyecektir.</translation>
     </message>
     <message>
         <source>Do you really want to clear the ignore list?</source>
-        <translation type="unfinished"></translation>
+        <translation>Gerçekten yok sayılanlar listesini temizlemek istiyor musunuz?</translation>
     </message>
     <message>
         <source>Do you also want to reset all hidden message boxes?</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayrıca tüm gizlenmiş mesaj kutularını sıfırlamak ister misiniz?</translation>
     </message>
     <message>
         <source>Options Files (*.xml)</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçenek Dosyaları (*.xml)</translation>
     </message>
     <message>
         <source>Failed to parse XML data!</source>
-        <translation type="unfinished"></translation>
+        <translation>XML verileri ayrıştırılamadı!</translation>
     </message>
     <message>
         <source>Do you want to stop the Privacy Agent and unload the Kernel Isolator?
 CAUTION: This will disable protection.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik Aracısını durdurmak ve Kernel Isolator&apos;ı kaldırmak ister misiniz?
+DİKKAT: Bu, korumayı devre dışı bırakacaktır.</translation>
     </message>
     <message>
         <source>Volume Protection Rule for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Koruma Kuralı: %1</translation>
     </message>
     <message>
         <source>Volume Unmount Rule for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Çıkarma Kuralı: %1</translation>
     </message>
     <message>
         <source>Temporary rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçici kural</translation>
     </message>
     <message>
         <source>%1 - MajorPrivacy Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - MajorPrivacy Kuralı</translation>
     </message>
     <message>
         <source>%1 - MajorPrivacy Rule Template</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - MajorPrivacy Kural Şablonu</translation>
     </message>
     <message>
         <source>Reset Columns</source>
-        <translation type="unfinished"></translation>
+        <translation>Sütunları Sıfırla</translation>
     </message>
     <message>
         <source>Copy Cell</source>
-        <translation type="unfinished"></translation>
+        <translation>Hücreyi Kopyala</translation>
     </message>
     <message>
         <source>Copy Row</source>
-        <translation type="unfinished"></translation>
+        <translation>Satırı Kopyala</translation>
     </message>
     <message>
         <source>Copy Panel</source>
-        <translation type="unfinished"></translation>
+        <translation>Paneli Kopyala</translation>
     </message>
     <message>
         <source>Case Sensitive</source>
-        <translation type="unfinished"></translation>
+        <translation>Harfe Duyarlı</translation>
     </message>
     <message>
         <source>Use Regular Expressions</source>
-        <translation type="unfinished"></translation>
+        <translation>Düzenli İfadeler Kullan</translation>
     </message>
     <message>
         <source>Highlight Items</source>
-        <translation type="unfinished"></translation>
+        <translation>Öğeler Vurgulansın</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapat</translation>
     </message>
     <message>
         <source>&amp;Find ...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Bul ...</translation>
     </message>
     <message>
         <source>All columns</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm sütunlar</translation>
     </message>
     <message>
         <source>Search ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Arama ...</translation>
     </message>
     <message>
         <source>Toggle Search Bar</source>
-        <translation type="unfinished"></translation>
+        <translation>Arama Çubuğunu Aç/Kapat</translation>
     </message>
     <message>
         <source>&lt;h3&gt;About MajorPrivacy&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h3&gt;MajorPrivacy Hakkında&lt;/h3&gt;&lt;p&gt;Sürüm %1&lt;/p&gt;&lt;p&gt;</translation>
     </message>
     <message>
         <source>This version is licensed to %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu sürüm %1 için lisanslanmıştır.</translation>
     </message>
     <message>
         <source>This version was licensed to %1, but its no longer valid.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu sürüm %1&apos;e lisanslandı, ancak artık geçerli değil.</translation>
     </message>
     <message>
         <source>&lt;p&gt;MajorPrivacy is a program that helps you to protect your privacy and security.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; for more information.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;UI Config Dir: &lt;br /&gt;%2&lt;br /&gt;Core Config Dir: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;MajorPrivacy, gizliliğinizi ve güvenliğinizi korumanıza yardımcı olan bir programdır.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Daha fazla bilgi için &lt;a href=&quot;https://xanasoft.com&quot;&gt;xanasoft.com&lt;/a&gt; adresini ziyaret edin.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Arayüz Yapılandırması Dizini: &lt;br /&gt;%2&lt;br /&gt;Çekirdek Yapılandırması Dizini: &lt;br /&gt;%3&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Simgeler için &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Enter the path of a program that will be created in a sandbox.</source>
-        <translation type="unfinished"></translation>
+        <translation>Korumalı alan ortamında oluşturulacak programın yolunu girin.</translation>
     </message>
 </context>
 <context>
     <name>CMountMgrWnd</name>
     <message>
         <source>Volume|Device Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim|Aygıt Yolu</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>Yenile</translation>
     </message>
 </context>
 <context>
     <name>CNetTraceModel</name>
     <message>
         <source>Unknown Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen Program</translation>
     </message>
     <message>
         <source> (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (%1)</translation>
     </message>
     <message>
         <source>PROCESS MISSING</source>
-        <translation type="unfinished"></translation>
+        <translation>İŞLEM EKSİK</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>Protokol</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="unfinished"></translation>
+        <translation>Yön</translation>
     </message>
     <message>
         <source>Remote Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Adres</translation>
     </message>
     <message>
         <source>Remote Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Bağlantı Noktası</translation>
     </message>
     <message>
         <source>Local Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Adres</translation>
     </message>
     <message>
         <source>Local Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Bağlantı Noktası</translation>
     </message>
     <message>
         <source>Uploaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüklendi</translation>
     </message>
     <message>
         <source>Downloaded</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirildi</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CNetTraceView</name>
     <message>
         <source>All Directions</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Yönler</translation>
     </message>
     <message>
         <source>Inbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelen</translation>
     </message>
     <message>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
+        <translation>Giden</translation>
     </message>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>All Protocols</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Protokoller</translation>
     </message>
     <message>
         <source>HTTP(S)</source>
-        <translation type="unfinished"></translation>
+        <translation>HTTP(S)</translation>
     </message>
     <message>
         <source>TCP Sockets</source>
-        <translation type="unfinished"></translation>
+        <translation>TCP Soketleri</translation>
     </message>
     <message>
         <source>TCP Clients</source>
-        <translation type="unfinished"></translation>
+        <translation>TCP İstemcileri</translation>
     </message>
     <message>
         <source>TCP Servers</source>
-        <translation type="unfinished"></translation>
+        <translation>TCP Sunucuları</translation>
     </message>
     <message>
         <source>UDP Sockets</source>
-        <translation type="unfinished"></translation>
+        <translation>UDP Soketleri</translation>
     </message>
     <message>
         <source>Area Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Alan Filtresi</translation>
     </message>
     <message>
         <source>Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>İnternet</translation>
     </message>
     <message>
         <source>Local Area</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Alan</translation>
     </message>
     <message>
         <source>Local Host</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Sunucu</translation>
     </message>
     <message>
         <source>Auto Scroll</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Kaydırma</translation>
     </message>
     <message>
         <source>Hold updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Güncellemeleri Tut</translation>
     </message>
     <message>
         <source>Clear Trace Log</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğünü Temizle</translation>
     </message>
 </context>
 <context>
     <name>CNetworkPage</name>
     <message>
         <source>Firewall Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Kuralları</translation>
     </message>
     <message>
         <source>Open Socket</source>
-        <translation type="unfinished"></translation>
+        <translation>Açık Soketler</translation>
     </message>
     <message>
         <source>Traffic Monitor</source>
-        <translation type="unfinished"></translation>
+        <translation>Trafik İzleyicisi</translation>
     </message>
     <message>
         <source>Connection Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı Günlüğü</translation>
     </message>
 </context>
 <context>
     <name>COptionsTransferWnd</name>
     <message>
         <source>Select the data you want to import</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktarmak istediğiniz verileri seçin</translation>
     </message>
     <message>
         <source>Select the data you want to export</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarmak istediğiniz verileri seçin</translation>
     </message>
 </context>
 <context>
     <name>CPopUpWindow</name>
     <message>
         <source>MajorPrivacy Notifications</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy Bildirimleri</translation>
     </message>
     <message>
         <source>Permanent</source>
-        <translation type="unfinished"></translation>
+        <translation>Kalıcı Olarak</translation>
     </message>
     <message>
         <source>Untill Restart</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeniden Başlatılana Kadar</translation>
     </message>
     <message>
         <source>for 1 Minute</source>
-        <translation type="unfinished"></translation>
+        <translation>1 dakika boyunca</translation>
     </message>
     <message>
         <source>for 5 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>5 dakika boyunca</translation>
     </message>
     <message>
         <source>for 15 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>15 dakika boyunca</translation>
     </message>
     <message>
         <source>for 30 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>30 dakika boyunca</translation>
     </message>
     <message>
         <source>for 60 Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>60 dakika boyunca</translation>
     </message>
     <message>
         <source>Always Ignore this Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Her Zaman Bu Programı Görmezden Gel</translation>
     </message>
     <message>
         <source>Create Custom Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel Kural Oluştur</translation>
     </message>
     <message>
         <source>Always Ignore this Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Her Zaman Bu Yolu Görmezden Gel</translation>
     </message>
     <message>
         <source>Allow Read Only Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Salt Okuma Erişimine İzin Ver</translation>
     </message>
     <message>
         <source>Allow Directory Listing ONLY</source>
-        <translation type="unfinished"></translation>
+        <translation>YALNIZCA Dizin Listelemesine İzin Ver</translation>
     </message>
     <message>
         <source>Always Ignore this Binary</source>
-        <translation type="unfinished"></translation>
+        <translation>Her Zaman Bu İkiliyi Görmezden Gel</translation>
     </message>
     <message>
         <source>Sign Certificate</source>
-        <translation type="unfinished"></translation>
+        <translation>Sertifika İmzala</translation>
     </message>
     <message>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2</translation>
     </message>
     <message>
         <source>%1:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1:%2</translation>
     </message>
     <message>
         <source> (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (%1)</translation>
     </message>
     <message>
         <source>%1 - Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Kural</translation>
     </message>
     <message>
         <source>Please select a resource to create a rule for.</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen bir kural oluşturmak için bir kaynak seçin.</translation>
     </message>
     <message>
         <source>Please select a binnary file to sign with the your User Key.</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen kullanıcı anahtarınızla imzalamak için bir ikili dosyası seçin.</translation>
     </message>
     <message>
         <source>Selected Items do not have Certificates!</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen öğelerin sertifikaları yok!</translation>
     </message>
 </context>
 <context>
     <name>CProcess</name>
     <message>
         <source>Sec: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Güv: %1</translation>
     </message>
     <message>
         <source>%1 (</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (</translation>
     </message>
     <message>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
         <source>%1+%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1+%2</translation>
     </message>
     <message>
         <source>/%1/%2/%3)</source>
-        <translation type="unfinished"></translation>
+        <translation>/%1/%2/%3)</translation>
     </message>
 </context>
 <context>
     <name>CProcessModel</name>
     <message>
         <source>Process</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem</translation>
     </message>
     <message>
         <source>PID</source>
-        <translation type="unfinished"></translation>
+        <translation>PID</translation>
     </message>
     <message>
         <source>Parent PID</source>
-        <translation type="unfinished"></translation>
+        <translation>Üst PID</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Trust Level</source>
-        <translation type="unfinished"></translation>
+        <translation>Güven Seviyesi</translation>
     </message>
     <message>
         <source>User Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Adı</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Image Loads (MS/V/S/U)</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Yüklemeleri (MS/V/S/U)</translation>
     </message>
     <message>
         <source>File Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Adı</translation>
     </message>
 </context>
 <context>
     <name>CProcessPage</name>
     <message>
         <source>Process Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Kuralları</translation>
     </message>
     <message>
         <source>Running Processes</source>
-        <translation type="unfinished"></translation>
+        <translation>Çalışan İşlemler</translation>
     </message>
     <message>
         <source>Loaded Modules</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüklü Bileşenler</translation>
     </message>
     <message>
         <source>Execution Monitor</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme İzleyicisi</translation>
     </message>
     <message>
         <source>Ingress Monitor</source>
-        <translation type="unfinished"></translation>
+        <translation>Giriş İzleyicisi</translation>
     </message>
     <message>
         <source>Trace Log</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğü</translation>
     </message>
 </context>
 <context>
     <name>CProcessTraceModel</name>
     <message>
         <source>PROGRAM MISSING</source>
-        <translation type="unfinished"></translation>
+        <translation>PROGRAM EKSİK</translation>
     </message>
     <message>
         <source> [%1]</source>
-        <translation type="unfinished"></translation>
+        <translation> [%1]</translation>
     </message>
     <message>
         <source>MODULE MISSING</source>
-        <translation type="unfinished"></translation>
+        <translation>BİLEŞEN EKSİK</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Role</source>
-        <translation type="unfinished"></translation>
+        <translation>Rol</translation>
     </message>
     <message>
         <source>Operation</source>
-        <translation type="unfinished"></translation>
+        <translation>Operasyon</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Subject</source>
-        <translation type="unfinished"></translation>
+        <translation>Nesne</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CProcessTraceView</name>
     <message>
         <source>Any Role</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Roller</translation>
     </message>
     <message>
         <source>Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak</translation>
     </message>
     <message>
         <source>Target</source>
-        <translation type="unfinished"></translation>
+        <translation>Hedef</translation>
     </message>
     <message>
         <source>Any Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Durumlar</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Auto Scroll</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Kaydırma</translation>
     </message>
     <message>
         <source>Hold updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Güncellemeleri Tut</translation>
     </message>
     <message>
         <source>Clear Trace Log</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğünü Temizle</translation>
     </message>
 </context>
 <context>
     <name>CProcessView</name>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümü</translation>
     </message>
     <message>
         <source>User</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı</translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem</translation>
     </message>
     <message>
         <source>Show Tree</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağacı Göster</translation>
     </message>
 </context>
 <context>
     <name>CProgramFile</name>
     <message>
         <source> (CI: Level 0)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Seviye 0)</translation>
     </message>
     <message>
         <source> (CI: Enterprise)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Kurumsal)</translation>
     </message>
     <message>
         <source> (CI: Developer)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Geliştirici)</translation>
     </message>
     <message>
         <source> (CI: Authenticode)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Authenticode)</translation>
     </message>
     <message>
         <source> (CI: Level 2)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Seviye 2)</translation>
     </message>
     <message>
         <source> (CI: Store)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Mağaza)</translation>
     </message>
     <message>
         <source> (CI: Antimalware)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Antimalware)</translation>
     </message>
     <message>
         <source> (CI: Microsoft)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Microsoft)</translation>
     </message>
     <message>
         <source> (CI: Level 4)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Seviye 4)</translation>
     </message>
     <message>
         <source> (CI: Level 5)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Seviye 5)</translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
-        <translation type="unfinished"></translation>
+        <source> (CI: Code Gen.)</source>
+        <translation> (CI: Kod Oluş.)</translation>
     </message>
     <message>
         <source> (CI: Windows)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Windows)</translation>
     </message>
     <message>
         <source> (CI: Level 7)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Seviye 7)</translation>
     </message>
     <message>
         <source> (CI: Windows TCB)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Windows TCB)</translation>
     </message>
     <message>
         <source> (CI: Level 6)</source>
-        <translation type="unfinished"></translation>
+        <translation> (CI: Seviye 6)</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Hiçbiri</translation>
     </message>
     <message>
         <source>Microsoft</source>
-        <translation type="unfinished"></translation>
+        <translation>Microsoft</translation>
     </message>
     <message>
         <source>Test</source>
-        <translation type="unfinished"></translation>
+        <translation>Test</translation>
     </message>
     <message>
         <source>Code</source>
-        <translation type="unfinished"></translation>
+        <translation>Kod</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
     <message>
         <source>DMD</source>
-        <translation type="unfinished"></translation>
+        <translation>DMD</translation>
     </message>
     <message>
         <source>DMD Test</source>
-        <translation type="unfinished"></translation>
+        <translation>DMD Testi</translation>
     </message>
     <message>
         <source>3rd Party</source>
-        <translation type="unfinished"></translation>
+        <translation>3. taraf</translation>
     </message>
     <message>
         <source>Trusted Boot</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenilir Önyükleme</translation>
     </message>
     <message>
         <source>UEFI</source>
-        <translation type="unfinished"></translation>
+        <translation>UEFI</translation>
     </message>
     <message>
         <source>Flight</source>
-        <translation type="unfinished"></translation>
+        <translation>Flight</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="unfinished"></translation>
+        <translation>Diğer</translation>
     </message>
     <message>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Hata: %1</translation>
     </message>
     <message>
         <source> (Root: %1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (Kök: %1)</translation>
     </message>
     <message>
         <source> (Roots: %1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (Kökler: %1)</translation>
     </message>
 </context>
 <context>
     <name>CProgramItem</name>
     <message>
         <source>Executable File</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütülebilir Dosya</translation>
     </message>
     <message>
         <source>File Path Pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Yolu Deseni</translation>
     </message>
     <message>
         <source>Installation</source>
-        <translation type="unfinished"></translation>
+        <translation>Kurulu</translation>
     </message>
     <message>
         <source>Windows Service</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows Hizmeti</translation>
     </message>
     <message>
         <source>Application Package</source>
-        <translation type="unfinished"></translation>
+        <translation>Uygulama Paketi</translation>
     </message>
     <message>
         <source>Program Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kümesi</translation>
     </message>
     <message>
         <source>Program List</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Listesi</translation>
     </message>
     <message>
         <source>Program Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Grubu</translation>
     </message>
     <message>
         <source>All Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Programlar</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
 </context>
 <context>
     <name>CProgramModel</name>
     <message>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <source>Processes</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlemler</translation>
     </message>
     <message>
         <source>Program Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kuralları</translation>
     </message>
     <message>
         <source>Last Execution</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Yürütme</translation>
     </message>
     <message>
         <source>Accessed Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişilen Dosyalar</translation>
     </message>
     <message>
         <source>Access Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Kuralları</translation>
     </message>
     <message>
         <source>Open Sockets</source>
-        <translation type="unfinished"></translation>
+        <translation>Açık Soketler</translation>
     </message>
     <message>
         <source>FW Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>GD Kuralları</translation>
     </message>
     <message>
         <source>Last Net Activity</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Ağ Etkinliği</translation>
     </message>
     <message>
         <source>Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>Yükleme</translation>
     </message>
     <message>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirme</translation>
     </message>
     <message>
         <source>Uploaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüklenmiş</translation>
     </message>
     <message>
         <source>Downloaded</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirilmiş</translation>
     </message>
     <message>
         <source>Log Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Günlük Boyutu</translation>
     </message>
     <message>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol</translation>
     </message>
 </context>
 <context>
     <name>CProgramPicker</name>
     <message>
         <source>MajorPrivacy - Select Program</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy - Program Seçin</translation>
     </message>
     <message>
         <source>Please select a program</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen bir program seçin</translation>
     </message>
 </context>
 <context>
     <name>CProgramRule</name>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Protect</source>
-        <translation type="unfinished"></translation>
+        <translation>Koru</translation>
     </message>
     <message>
         <source>Isolate</source>
-        <translation type="unfinished"></translation>
+        <translation>Yalıt</translation>
     </message>
     <message>
         <source>Audit</source>
-        <translation type="unfinished"></translation>
+        <translation>Denetle</translation>
     </message>
 </context>
 <context>
     <name>CProgramRuleModel</name>
     <message>
         <source>%1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Hayır</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Etkin</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Trust Level</source>
-        <translation type="unfinished"></translation>
+        <translation>Güven Seviyesi</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CProgramRuleView</name>
     <message>
         <source>Enable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Etkinleştir</translation>
     </message>
     <message>
         <source>Disable Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Devre Dışı Bırak</translation>
     </message>
     <message>
         <source>Delete Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Sil</translation>
     </message>
     <message>
         <source>Edit Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Düzenle</translation>
     </message>
     <message>
         <source>Duplicate Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralı Çoğalt</translation>
     </message>
     <message>
         <source>Create Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Oluştur</translation>
     </message>
     <message>
         <source>All Actions</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Eylemler</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilen</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenen</translation>
     </message>
     <message>
         <source>Protect</source>
-        <translation type="unfinished"></translation>
+        <translation>Korunan</translation>
     </message>
     <message>
         <source>Hide Disabled Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Devre Dışı Kuralları Gizle</translation>
     </message>
     <message>
         <source>Refresh Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuralları Yenile</translation>
     </message>
     <message>
         <source>Do you want to delete selected Rules Items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen kural öğelerini silmek istiyor musunuz?</translation>
     </message>
 </context>
 <context>
     <name>CProgramRuleWnd</name>
     <message>
         <source>Create Program Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kuralı Oluşturma</translation>
     </message>
     <message>
         <source>Edit Program Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kuralı Düzenleme</translation>
     </message>
     <message>
         <source>New Program Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Program Kuralı</translation>
     </message>
     <message>
         <source>Global (Any/No Enclave)</source>
-        <translation type="unfinished"></translation>
+        <translation>Genel (Herhangi/Kapanım Yok)</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
         <source>Protect</source>
-        <translation type="unfinished"></translation>
+        <translation>Koru</translation>
     </message>
     <message>
         <source>Audit</source>
-        <translation type="unfinished"></translation>
+        <translation>Denetle</translation>
     </message>
     <message>
         <source>Unconfigured</source>
-        <translation type="unfinished"></translation>
+        <translation>Yapılandırılmamış</translation>
     </message>
     <message>
         <source>User Signature ONLY (not recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Yalnızca Kullanıcı İmzalı (önerilmez)</translation>
     </message>
     <message>
         <source>User + Microsoft/AV Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı + Microsoft/AV İmzalı</translation>
     </message>
     <message>
         <source>User + Trusted by Microsoft (Code Root)</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı + Microsoft tarafından Güvenilen (Kod Kökü)</translation>
     </message>
     <message>
         <source>Any Signature (Unknown Root)</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir İmza (Bilinmeyen Kök)</translation>
     </message>
     <message>
         <source>No Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>İmza Yok</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Hata</translation>
     </message>
     <message>
         <source>Please select an enclave for a protection rule.</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen bir koruma kuralı için bir kapanım seçin.</translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
-        <translation type="unfinished"></translation>
+        <source>The selected program type is not supported for this rule type</source>
+        <translation>Bu kural türü için seçilen program türü desteklenmez</translation>
     </message>
     <message>
         <source>%1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 %2</translation>
     </message>
 </context>
 <context>
     <name>CProgramView</name>
     <message>
         <source>Type Filters</source>
-        <translation type="unfinished"></translation>
+        <translation>Filtre Türleri</translation>
     </message>
     <message>
         <source>Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Programlar</translation>
     </message>
     <message>
         <source>Apps</source>
-        <translation type="unfinished"></translation>
+        <translation>Uygulamalar</translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem</translation>
     </message>
     <message>
         <source>Groups</source>
-        <translation type="unfinished"></translation>
+        <translation>Grup</translation>
     </message>
     <message>
         <source>Run Filters</source>
-        <translation type="unfinished"></translation>
+        <translation>Çalışma Filtreleri</translation>
     </message>
     <message>
         <source>Ran Recently</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Zamanlarda Çalışan</translation>
     </message>
     <message>
         <source>Rule Filters</source>
-        <translation type="unfinished"></translation>
+        <translation>Kural Filtreleri</translation>
     </message>
     <message>
         <source>Execution Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme Kuralları</translation>
     </message>
     <message>
         <source>Access Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Kuralları</translation>
     </message>
     <message>
         <source>Firewall Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Kuralları</translation>
     </message>
     <message>
         <source>Traffic Filters</source>
-        <translation type="unfinished"></translation>
+        <translation>Trafik Filtreleri</translation>
     </message>
     <message>
         <source>Recent Traffic</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Trafik</translation>
     </message>
     <message>
         <source>Blocked Traffic</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş Trafik</translation>
     </message>
     <message>
         <source>Allowed Traffic</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş Trafik</translation>
     </message>
     <message>
         <source>Socket Filters</source>
-        <translation type="unfinished"></translation>
+        <translation>Soket Filtreleri</translation>
     </message>
     <message>
         <source>CleanUp Program List</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Listesini Temizle</translation>
     </message>
     <message>
         <source>Re-Group all Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Programları Yeniden Gruplandır</translation>
     </message>
     <message>
         <source>Add Program Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Öğesi Ekle</translation>
     </message>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
     <message>
         <source>Edit Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programı Düzenle</translation>
     </message>
     <message>
         <source>Clear Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>İzlemeyi Temizle</translation>
     </message>
     <message>
         <source>Execution Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme İzleme</translation>
     </message>
     <message>
         <source>Resource Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak İzleme</translation>
     </message>
     <message>
         <source>Network Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ İzleme</translation>
     </message>
     <message>
         <source>Trace Config</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Yapılandırması</translation>
     </message>
     <message>
         <source>Use Global Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Genel Ön Ayarları Kullan</translation>
     </message>
     <message>
         <source>Private Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel İzlensin</translation>
     </message>
     <message>
         <source>Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>İzlensin</translation>
     </message>
     <message>
         <source>Don&apos;t Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>İzlenmesin</translation>
     </message>
     <message>
         <source>Store Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Mağaza İzleme</translation>
     </message>
     <message>
         <source>Save to Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Diske Kaydet</translation>
     </message>
     <message>
         <source>Cache only in RAM</source>
-        <translation type="unfinished"></translation>
+        <translation>Yalnızca RAM Önbelleği</translation>
     </message>
     <message>
         <source>Add to Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Gruba Ekle</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaldır</translation>
     </message>
     <message>
         <source>Add Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Ekle</translation>
     </message>
     <message>
         <source>Do you want to delete selected Program Items (Yes)?
 The selected Item has children, do you want to delete them as well (Yes to All)?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçili Program Öğelerini silmek istiyor musunuz (Evet)?
+Seçilen Öğenin alt öğeleri var, onları da silmek istiyor musunuz (Hepsine Evet)?</translation>
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
-        <translation type="unfinished"></translation>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
+        <translation>Seçili Program Öğelerini silmek ister misiniz?
+Seçilen Öğe birden fazla Gruba aittir, onu tüm gruplardan silmek için &apos;Hepsine Evet&apos;e basın, &apos;Evet&apos;e basmak onu yalnızca seçildiği gruptan kaldıracaktır.</translation>
     </message>
     <message>
         <source>Do you want to delete selected Program Items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen program öğelerini silmek istiyor musunuz?</translation>
     </message>
     <message>
         <source>The selected Program Item has rules, do you want to delete them as well?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen program öğesinin kuralları var, bunları da silmek istiyor musunuz?</translation>
     </message>
     <message>
         <source>Are you sure you want to clear the the Execution/Ingress trace logs for the current program items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut program öğeleri için Yürütme/Giriş izleme günlüklerini temizlemek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <source>Are you sure you want to clear the the Resource Access trace logs for the current program items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut program öğeleri için Kaynak Erişimi izleme günlüklerini temizlemek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <source>Are you sure you want to clear the the Network Access trace logs for the current program items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut program öğeleri için Ağ Erişimi izleme günlüklerini temizlemek istediğinizden emin misiniz?</translation>
     </message>
 </context>
 <context>
     <name>CProgramWnd</name>
     <message>
         <source>Change Icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Simgeyi Değiştir</translation>
     </message>
     <message>
         <source>Browse for Image</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü için Göz At</translation>
     </message>
     <message>
         <source>Browse for File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya için Göz At</translation>
     </message>
     <message>
         <source>Browse for Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Klasör için Göz At</translation>
     </message>
     <message>
         <source>Create Program Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Öğesi Oluşturma</translation>
     </message>
     <message>
         <source>Edit Program Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Öğesi Düzenleme</translation>
     </message>
     <message>
         <source>Use Global Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Genel Ön Ayarları Kullan</translation>
     </message>
     <message>
         <source>Private Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel İzlensin</translation>
     </message>
     <message>
         <source>Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>İzlensin</translation>
     </message>
     <message>
         <source>Don&apos;t Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>İzlenmesin</translation>
     </message>
     <message>
         <source>Save to Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Diske Kaydet</translation>
     </message>
     <message>
         <source>Cache only in RAM</source>
-        <translation type="unfinished"></translation>
+        <translation>Yalnızca RAM Önbelleğine</translation>
     </message>
     <message>
         <source>New Program Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Program Öğesi</translation>
     </message>
     <message>
         <source>Select Image File</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Dosyasını Seçin</translation>
     </message>
     <message>
         <source>Image Files (*.png)</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Dosyaları (*.png)</translation>
     </message>
     <message>
         <source>Select Program File</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Dosyasını Seçin</translation>
     </message>
     <message>
         <source>Executable Files (*.exe)</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütülebilir Dosyalar (*.exe)</translation>
     </message>
     <message>
         <source>Select Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizin Seç</translation>
     </message>
 </context>
 <context>
     <name>CSettingsWindow</name>
     <message>
         <source>Major Privacy - Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy - Ayarlar</translation>
     </message>
     <message>
         <source>Auto Detection</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Algılama</translation>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümü</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapalı</translation>
     </message>
     <message>
         <source>Search for settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayar bul</translation>
     </message>
     <message>
         <source>Enter Block Lisz URL to be added</source>
-        <translation type="unfinished"></translation>
+        <translation>Eklenecek Engel Listesi URL&apos;sini girin</translation>
     </message>
     <message>
         <source>Binary Image</source>
-        <translation type="unfinished"></translation>
+        <translation>İkili Görüntü</translation>
     </message>
     <message>
         <source>Resource Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Erişimi</translation>
     </message>
     <message>
         <source>Network Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ Erişimi</translation>
     </message>
 </context>
 <context>
     <name>CSidResolver</name>
     <message>
         <source>Resolving...</source>
-        <translation type="unfinished"></translation>
+        <translation>Çözümleniyor ...</translation>
     </message>
     <message>
         <source>Not resolved...</source>
-        <translation type="unfinished"></translation>
+        <translation>Çözülemedi ...</translation>
     </message>
 </context>
 <context>
     <name>CSignatureDbWnd</name>
     <message>
         <source>Delete Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>İmzayı Sil</translation>
     </message>
     <message>
         <source>Name|Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad|Yol</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>Yenile</translation>
     </message>
     <message>
         <source>MajorPrivacy</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy</translation>
     </message>
     <message>
         <source>Are you sure you want to delete the signature?</source>
-        <translation type="unfinished"></translation>
+        <translation>İmzayı silmek istediğinizden emin misiniz?</translation>
     </message>
 </context>
 <context>
     <name>CSocket</name>
     <message>
         <source>Closed</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapalı</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Açık</translation>
     </message>
     <message>
         <source>Listen</source>
-        <translation type="unfinished"></translation>
+        <translation>Dinlemede</translation>
     </message>
     <message>
         <source>SYN sent</source>
-        <translation type="unfinished"></translation>
+        <translation>SYN gönderildi</translation>
     </message>
     <message>
         <source>SYN received</source>
-        <translation type="unfinished"></translation>
+        <translation>SYN alındı</translation>
     </message>
     <message>
         <source>Established</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı kuruldu</translation>
     </message>
     <message>
         <source>FIN wait 1</source>
-        <translation type="unfinished"></translation>
+        <translation>FIN bekle 1</translation>
     </message>
     <message>
         <source>FIN wait 2</source>
-        <translation type="unfinished"></translation>
+        <translation>FIN bekle 2</translation>
     </message>
     <message>
         <source>Close wait</source>
-        <translation type="unfinished"></translation>
+        <translation>Close bekle</translation>
     </message>
     <message>
         <source>Closing</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanıyor</translation>
     </message>
     <message>
         <source>Last ACK</source>
-        <translation type="unfinished"></translation>
+        <translation>Son ACK</translation>
     </message>
     <message>
         <source>Time wait</source>
-        <translation type="unfinished"></translation>
+        <translation>Time bekle</translation>
     </message>
     <message>
         <source>Delete TCB</source>
-        <translation type="unfinished"></translation>
+        <translation>TCB&apos;yi Sil</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source>Unknown %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen %1</translation>
     </message>
 </context>
 <context>
     <name>CSocketModel</name>
     <message>
         <source>Unknown Process</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen İşlem</translation>
     </message>
     <message>
         <source> (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (%1)</translation>
     </message>
     <message>
         <source>PROCESS MISSING</source>
-        <translation type="unfinished"></translation>
+        <translation>İŞLEM EKSİK</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>Protokol</translation>
     </message>
     <message>
         <source>Remote Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Adres</translation>
     </message>
     <message>
         <source>Remote Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Bağlantı Noktası</translation>
     </message>
     <message>
         <source>Local Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Adres</translation>
     </message>
     <message>
         <source>Local Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Bağlantı Noktası</translation>
     </message>
     <message>
         <source>Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim</translation>
     </message>
     <message>
         <source>State</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Last Activity</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Etkinlik</translation>
     </message>
     <message>
         <source>Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>Yükleme</translation>
     </message>
     <message>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirme</translation>
     </message>
     <message>
         <source>Uploaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüklenmiş</translation>
     </message>
     <message>
         <source>Downloaded</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirilmiş</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
 </context>
 <context>
     <name>CSocketView</name>
     <message>
         <source>All Protocols</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Protokoller</translation>
     </message>
     <message>
         <source>HTTP(S)</source>
-        <translation type="unfinished"></translation>
+        <translation>HTTP(S)</translation>
     </message>
     <message>
         <source>TCP Sockets</source>
-        <translation type="unfinished"></translation>
+        <translation>TCP Soketleri</translation>
     </message>
     <message>
         <source>TCP Clients</source>
-        <translation type="unfinished"></translation>
+        <translation>TCP İstemcileri</translation>
     </message>
     <message>
         <source>TCP Servers</source>
-        <translation type="unfinished"></translation>
+        <translation>TCP Sunucuları</translation>
     </message>
     <message>
         <source>UDP Sockets</source>
-        <translation type="unfinished"></translation>
+        <translation>UDP Soketleri</translation>
     </message>
 </context>
 <context>
     <name>CTraceView</name>
     <message>
         <source>Loading %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Yükleniyor %1</translation>
     </message>
     <message>
         <source>Are you sure you want to clear the the trace logs for the current program items?</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut program öğeleri için izleme günlüklerini temizlemek istediğinizden emin misiniz?</translation>
     </message>
 </context>
 <context>
     <name>CTrafficModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Last Activity</source>
-        <translation type="unfinished"></translation>
+        <translation>Son Etkinlik</translation>
     </message>
     <message>
         <source>Uploaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüklenen</translation>
     </message>
     <message>
         <source>Downloaded</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirilen</translation>
     </message>
 </context>
 <context>
     <name>CTrafficView</name>
     <message>
         <source>By Host</source>
-        <translation type="unfinished"></translation>
+        <translation>Sunucu Olarak</translation>
     </message>
     <message>
         <source>By Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Olarak</translation>
     </message>
     <message>
         <source>Area Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Alan Filtresi</translation>
     </message>
     <message>
         <source>Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>İnternet</translation>
     </message>
     <message>
         <source>Local Area</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Alan</translation>
     </message>
     <message>
         <source>Local Host</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Sunucu</translation>
     </message>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
 </context>
 <context>
     <name>CTweakInfo</name>
     <message>
         <source>Apply Tweak</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce Ayarı Uygula</translation>
     </message>
     <message>
         <source>Undo Tweak</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce Ayarı Geri Al</translation>
     </message>
     <message>
         <source>Tweak Info</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce Ayar Bilgisi</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>Özet</translation>
     </message>
 </context>
 <context>
     <name>CTweakList</name>
     <message>
         <source>%1 (%2/%3)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (%2/%3)</translation>
     </message>
     <message>
         <source>%1 (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (%2)</translation>
     </message>
 </context>
 <context>
     <name>CTweakModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <source>Hint</source>
-        <translation type="unfinished"></translation>
+        <translation>İpucu</translation>
     </message>
     <message>
         <source>Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilgi</translation>
     </message>
 </context>
 <context>
     <name>CTweakView</name>
     <message>
         <source>Refresh tweak states</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce ayar durumlarını yenile</translation>
     </message>
     <message>
         <source>Show not available tweaks</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut olmayan ince ayarları göster</translation>
     </message>
     <message>
         <source>Approve Current State</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut durumu onayla</translation>
     </message>
     <message>
         <source>Restore Approved State</source>
-        <translation type="unfinished"></translation>
+        <translation>Onaylı Durumları Geri Yükle</translation>
     </message>
     <message>
         <source>Auto Expand</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Genişlet</translation>
     </message>
     <message>
         <source>This tweak is marked as breaking, hence it may break something. Are you sure you want to apply it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu ince ayar kırıcı olarak işaretlenmiş, bu nedenle bir şeylerin düzgün çalışmasını engelleyebilir. Uygulamak istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <source>Don&apos;t show this message again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu mesajı bir daha gösterme.</translation>
     </message>
     <message>
         <source>MajorPrivacy</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy</translation>
     </message>
     <message>
         <source>Are you sure you want to approve the current state of all tweaks?</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm ince ayarların mevcut durumunu onaylamak istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <source>Are you sure you want to restore the approved state of all tweaks?
 
 The following operations will be performed:
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm ince ayarların onaylı durumunu geri yüklemek istediğinizden emin misiniz?
+
+Aşağıdaki işlemler gerçekleştirilecektir:
+</translation>
     </message>
     <message>
         <source>Undo tweaks:
 </source>
-        <translation type="unfinished"></translation>
+        <translation>İnce ayarları geri al:
+</translation>
     </message>
     <message>
         <source>Apply tweaks:
 </source>
-        <translation type="unfinished"></translation>
+        <translation>İnce ayarları uygula:
+</translation>
     </message>
 </context>
 <context>
     <name>CVariantEditorWnd</name>
     <message>
         <source>File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya</translation>
     </message>
     <message>
         <source>Open File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Aç</translation>
     </message>
     <message>
         <source>Close Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Düzenleyiciyi Kapat</translation>
     </message>
     <message>
         <source>Add to Root</source>
-        <translation type="unfinished"></translation>
+        <translation>Köklere Ekle</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekle</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaldır</translation>
     </message>
     <message>
         <source>All Files (*.dat)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Dosyalar (*.dat)</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Hata</translation>
     </message>
     <message>
         <source>Can&apos;t open file</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı açamıyorum</translation>
     </message>
     <message>
         <source>Can&apos;t parse file</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı ayrıştıramıyorum</translation>
     </message>
     <message>
         <source>Save File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı Kaydet</translation>
     </message>
 </context>
 <context>
     <name>CVariantModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Değer</translation>
     </message>
 </context>
 <context>
     <name>CVolume</name>
     <message>
         <source>Unmounted Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Çıkarılmış Birim</translation>
     </message>
     <message>
         <source>Mounted Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlanmış Birim</translation>
     </message>
     <message>
         <source>Unprotected Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Korumasız Klasör</translation>
     </message>
     <message>
         <source>Protected Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Korumalı Klasör</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
 </context>
 <context>
     <name>CVolumeModel</name>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Mount Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı Noktası</translation>
     </message>
     <message>
         <source>Total Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Toplam Boyut</translation>
     </message>
     <message>
         <source>Full Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam Yol</translation>
     </message>
 </context>
 <context>
     <name>CVolumeView</name>
     <message>
         <source>Mount Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Birimi Bağla</translation>
     </message>
     <message>
         <source>Unmount Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Birimi Çıkar</translation>
     </message>
     <message>
         <source>Change Volume Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Parolasını Değiştir</translation>
     </message>
     <message>
         <source>Rename Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Birimi Yeniden Adlandır</translation>
     </message>
     <message>
         <source>Remove Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Birimi Kaldır</translation>
     </message>
     <message>
         <source>Create Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Oluştur</translation>
     </message>
     <message>
         <source>Add and Mount Volume Image</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Görüntüsü Ekle ve Bağla</translation>
     </message>
     <message>
         <source>Add Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Klasör Ekle</translation>
     </message>
     <message>
         <source>Unmount All Volumes</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Birimleri Bağla</translation>
     </message>
     <message>
         <source>Do you want to unmount the selected volume?</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen birimi çıkarmak istiyor musunuz?</translation>
     </message>
     <message>
         <source>Select Private Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel Birim Seçin</translation>
     </message>
     <message>
         <source>Private Volume Files (*.pv)</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel Birim Dosyaları (*.pv)</translation>
     </message>
     <message>
         <source>Mount Secure Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Birim Bağlama</translation>
     </message>
     <message>
         <source>Creating new volume image, please enter a secure password, and choose a disk image size.</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni birim görüntüsü oluşturma, lütfen güvenli bir parola girin ve bir disk görüntü boyutu seçin.</translation>
     </message>
     <message>
         <source>This volume content will be placed in an encrypted container file, please note that any corruption of the container&apos;s header will render all its content permanently inaccessible. Corruption can occur as a result of a BSOD, a storage hardware failure, or a malicious application overwriting random files. This feature is provided under a strict &lt;b&gt;No Backup No Mercy&lt;/b&gt; policy, YOU the user are responsible for the data you put into an encrypted box. &lt;br /&gt;&lt;br /&gt;IF YOU AGREE TO TAKE FULL RESPONSIBILITY FOR YOUR DATA PRESS [YES], OTHERWISE PRESS [NO].</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu birim içeriği şifrelenmiş bir konteyner dosyasına yerleştirilecektir, konteynerin başlığının herhangi bir şekilde bozulmasının tüm içeriğini kalıcı olarak erişilemez hale getireceğini lütfen unutmayın. Bozulma, bir BSOD, bir depolama donanımı arızası veya kötü amaçlı bir uygulamanın rastgele dosyaların üzerine yazması sonucu meydana gelebilir. Bu özellik katı bir &lt;b&gt;Yedekleme Yoksa Merhamet de Yok&lt;/b&gt; politikası altında sağlanır, SİZ kullanıcı olarak şifrelenmiş bir kutuya koyduğunuz verilerden sorumlusunuz. &lt;br /&gt;&lt;br /&gt;VERİLERİNİZ İÇİN TAM SORUMLULUK ALMAYI KABUL EDİYORSANIZ [EVET]&apos;E BASIN, AKSİ TAKTİRDE [HAYIR]&apos;A BASIN.</translation>
     </message>
     <message>
         <source>Don&apos;t show this message again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu mesajı bir daha gösterme.</translation>
     </message>
     <message>
         <source>Change Volume Password.</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim Parolası Değiştirme</translation>
     </message>
     <message>
         <source>Please enter a name for the item</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen öğe için bir ad girin</translation>
     </message>
     <message>
         <source>Do you want to remove selected Volumes from list?
 Note: The volume image files will remain intact and must be manually deleted.</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçili Birimleri listeden kaldırmak istiyor musunuz?
+Not: Birim görüntü dosyaları olduğu gibi kalacak ve elle silinmesi gerekecektir.</translation>
     </message>
     <message>
         <source>The security of files and folders on unencrypted volumes cannot be guaranteed if Major Privacy is not running or if the Kernel Isolator driver is not loaded. In this state, folder access control will not be enforced.
 For non-critical data, folder protection may still provide a basic level of security. However, for highly confidential or sensitive information, it is strongly recommended to use a secure, encrypted volume to ensure robust protection against unauthorized access.</source>
-        <translation type="unfinished"></translation>
+        <translation>Şifrelenmemiş birimlerdeki dosya ve klasörlerin güvenliği, Major Privacy çalışmıyorsa veya Kernel Isolator sürücüsü yüklenmemişse garanti edilemez. Bu durumda, klasör erişim denetimi uygulanmaz.
+Kritik olmayan veriler için, klasör koruması yine de temel düzeyde güvenlik sağlayabilir. Ancak, son derece gizli veya hassas bilgiler için, yetkisiz erişime karşı sağlam koruma sağlamak amacıyla güvenli, şifrelenmiş bir birim kullanılması şiddetle önerilir.</translation>
     </message>
     <message>
         <source>Select Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizin Seç</translation>
     </message>
     <message>
         <source>%1 - Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Koruma</translation>
     </message>
 </context>
 <context>
     <name>CVolumeWindow</name>
     <message>
         <source>kilobytes (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>kilobayt (%1)</translation>
     </message>
     <message>
         <source>Passwords don&apos;t match!!!</source>
-        <translation type="unfinished"></translation>
+        <translation>Parolalar eşleşmiyor!</translation>
     </message>
     <message>
         <source>WARNING: Short passwords are easy to crack using brute force techniques!
 
 It is recommended to choose a password consisting of 20 or more characters. Are you sure you want to use a short password?</source>
-        <translation type="unfinished"></translation>
+        <translation>UYARI: Kısa parolalar, kaba kuvvet teknikleri kullanılarak kolayca kırılabilir!
+
+20 veya daha fazla karakterden oluşan bir parola seçmeniz önerilir. Kısa bir parola kullanmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <source>The password is constrained to a maximum length of 128 characters. 
 This length permits approximately 384 bits of entropy with a passphrase composed of actual English words, 
 increases to 512 bits with the application of Leet (L337) speak modifications, and exceeds 768 bits when composed of entirely random printable ASCII characters.</source>
-        <translation type="unfinished"></translation>
+        <translation>Parola, maksimum 128 karakter uzunluğunda olacak şekilde sınırlandırılmıştır.
+Bu uzunluk, gerçek İngilizce kelimelerden oluşan bir parola ile yaklaşık 384 bit entropiye izin verir,
+Leet (L337) konuşma değişikliklerinin uygulanmasıyla 512 bite çıkar ve tamamen rastgele yazdırılabilir ASCII karakterlerinden oluştuğunda 768 biti aşar.</translation>
     </message>
     <message>
         <source>The Box Disk Image must be at least 256 MB in size, 2GB are recommended.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kutu disk görüntüsünün en az 256 MB boyutunda olması gerekir, 2GB önerilir.</translation>
     </message>
     <message>
         <source>Select Mount Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı Noktasını Seçin</translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished"></translation>
+        <translation>Asla</translation>
     </message>
     <message>
         <source>5 minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>5 dakika</translation>
     </message>
     <message>
         <source>15 minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>15 dakika</translation>
     </message>
     <message>
         <source>30 minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>30 dakika</translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"></translation>
+        <translation>1 saat</translation>
     </message>
     <message>
         <source>%1 hours</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 saat</translation>
     </message>
     <message>
         <source>%1 minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 dakika</translation>
     </message>
 </context>
 <context>
     <name>EnclaveWnd</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Secure Enclave Identity</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Kapanım Kimliği</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Code Integrity Presets</source>
-        <translation type="unfinished"></translation>
+        <translation>Kod Bütünlüğü Ön Ayarları</translation>
     </message>
     <message>
         <source>Require Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>İmza Gereksinimi</translation>
     </message>
     <message>
         <source>Image Load Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Yükleme Koruması</translation>
     </message>
     <message>
         <source>Process Spawn Handling</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Oluşturma Elleçlemesi</translation>
     </message>
     <message>
         <source>On Trusted</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenilir Durumda</translation>
     </message>
     <message>
         <source>On UN Trusted</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenilmez Durumda</translation>
     </message>
     <message>
         <source>Other Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Diğer Seçenekler</translation>
     </message>
     <message>
         <source>Elevate Token Integrity Level, for User Interface Privilege Isolation</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Arayüzü Ayrıcalığı Yalıtımı (UIPI) için Belirteç Bütünlüğü Seviyesini Yükselt</translation>
     </message>
     <message>
         <source>Token Integrity (UIPI)</source>
-        <translation type="unfinished"></translation>
+        <translation>Belirteç Bütünlüğü (UIPI)</translation>
     </message>
     <message>
         <source>Prevent termination</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonlandırmayı Önle</translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
-        <translation type="unfinished"></translation>
+        <source>Allow Debugging (INSECURE !!!)</source>
+        <translation>Hata Ayıklamaya İzin Ver (Güvensiz!)</translation>
     </message>
 </context>
 <context>
     <name>FirewallRuleWnd</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Firewall Rule Identity</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Kural Kimliği</translation>
     </message>
     <message>
         <source>Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Grup</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Description...</source>
-        <translation type="unfinished"></translation>
+        <translation>Açıklama...</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
     <message>
         <source>Service Tag</source>
-        <translation type="unfinished"></translation>
+        <translation>Hizmet Etiketi</translation>
     </message>
     <message>
         <source>Executable</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütülebilir</translation>
     </message>
     <message>
         <source>App Package</source>
-        <translation type="unfinished"></translation>
+        <translation>Uygulama Paketi</translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <source>Action &amp;&amp; Scope</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem &amp;&amp; Kapsam</translation>
     </message>
     <message>
-        <source>Sellected:</source>
-        <translation type="unfinished"></translation>
+        <source>Selected:</source>
+        <translation>Seçili:</translation>
     </message>
     <message>
         <source>All Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Profiller</translation>
     </message>
     <message>
         <source>LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>LAN</translation>
     </message>
     <message>
         <source>Private</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel</translation>
     </message>
     <message>
         <source>WLAN</source>
-        <translation type="unfinished"></translation>
+        <translation>WLAN</translation>
     </message>
     <message>
         <source>Domain</source>
-        <translation type="unfinished"></translation>
+        <translation>Etki Alanı</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Specific Types:</source>
-        <translation type="unfinished"></translation>
+        <translation>Belirli Türler:</translation>
     </message>
     <message>
         <source>VPN</source>
-        <translation type="unfinished"></translation>
+        <translation>VPN</translation>
     </message>
     <message>
         <source>Public</source>
-        <translation type="unfinished"></translation>
+        <translation>Ortak</translation>
     </message>
     <message>
         <source>All Interface Types</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Arabirim Türleri</translation>
     </message>
     <message>
         <source>Network Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ Özellikleri</translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamam</translation>
     </message>
     <message>
         <source>Local Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Adres</translation>
     </message>
     <message>
         <source>Selected Addresses</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçili Adresler</translation>
     </message>
     <message>
         <source>Local Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel Bağlantı Noktası</translation>
     </message>
     <message>
         <source>Remote Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Adres</translation>
     </message>
     <message>
         <source>Any Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir Adres</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="unfinished"></translation>
+        <translation>Yön</translation>
     </message>
     <message>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>Protokol</translation>
     </message>
     <message>
         <source>ICMP Type</source>
-        <translation type="unfinished"></translation>
+        <translation>ICMP Türü</translation>
     </message>
     <message>
         <source>Remote Port</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzak Bağlantı Noktası</translation>
     </message>
 </context>
 <context>
     <name>OptionsTransferWnd</name>
     <message>
         <source>Option Transfer</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçenek Aktarımı</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>TAMAM</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal Et</translation>
     </message>
     <message>
         <source>User Interface Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Arayüzü Seçenekleri</translation>
     </message>
     <message>
         <source>Process Protection Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Koruma Kuralları</translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
-        <translation type="unfinished"></translation>
+        <source>Please select which options you want to import/export.</source>
+        <translation>Lütfen hangi seçenekleri içe aktarmak/dışa aktarmak istediğinizi seçin.</translation>
     </message>
     <message>
         <source>Resource Access Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Erişim Kuralları</translation>
     </message>
     <message>
         <source>Full Program List</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam Program Listesi</translation>
     </message>
     <message>
         <source>Privacy Agent Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Gizlilik Aracısı Seçenekleri</translation>
     </message>
     <message>
         <source>User Key (Remains Encrypted with User PW)</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Anahtarı (Kullanıcı parolası ile şifrelenmiş kalır)</translation>
     </message>
     <message>
         <source>Trace Log Data</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğü Verileri</translation>
     </message>
     <message>
         <source>Windows Firewall Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows Güvenlik Duvarı Kuralları</translation>
     </message>
     <message>
         <source>Kernel Isolator Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Çekirdek Yalıtımı Seçenekleri</translation>
     </message>
     <message>
         <source>Secure Enclave Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Kapanım Yapılandırması</translation>
     </message>
 </context>
 <context>
     <name>PopUpWindow</name>
     <message>
         <source>MajorPrivacy Notifications</source>
-        <translation type="unfinished"></translation>
+        <translation>MajorPrivacy Bildirimleri</translation>
     </message>
     <message>
         <source>Firewall</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı</translation>
     </message>
     <message>
         <source>0/0</source>
-        <translation type="unfinished"></translation>
+        <translation>0/0</translation>
     </message>
     <message>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Yok Say</translation>
     </message>
     <message>
         <source>Allow</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Ver</translation>
     </message>
     <message>
         <source>Block</source>
-        <translation type="unfinished"></translation>
+        <translation>Engelle</translation>
     </message>
     <message>
-        <source>Previouse</source>
-        <translation type="unfinished"></translation>
+        <source>Previous</source>
+        <translation>Önceki</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonraki</translation>
     </message>
     <message>
         <source>GroupBox</source>
-        <translation type="unfinished"></translation>
+        <translation>GroupBox</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>Protokol</translation>
     </message>
     <message>
         <source>Endpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Uç Nokta</translation>
     </message>
     <message>
         <source>Time Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaman Damgası</translation>
     </message>
     <message>
         <source>Process Id</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Kimliği</translation>
     </message>
     <message>
         <source>Command Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Komut Satırı</translation>
     </message>
     <message>
         <source>Icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Simge</translation>
     </message>
     <message>
         <source>Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim</translation>
     </message>
     <message>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Process ID</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Kimliği</translation>
     </message>
     <message>
         <source>Exec</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme</translation>
     </message>
     <message>
         <source>File Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Adı</translation>
     </message>
     <message>
         <source>Trust Level</source>
-        <translation type="unfinished"></translation>
+        <translation>Güven Seviyesi</translation>
     </message>
     <message>
         <source>Signing Certificate</source>
-        <translation type="unfinished"></translation>
+        <translation>İmzalayan Sertifika</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya Yolu</translation>
     </message>
     <message>
         <source>Sign File</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya İmzala</translation>
     </message>
     <message>
         <source>Tweaks</source>
-        <translation type="unfinished"></translation>
+        <translation>İnce Ayarlar</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Durum</translation>
     </message>
     <message>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Açıklama</translation>
     </message>
     <message>
         <source>Approve</source>
-        <translation type="unfinished"></translation>
+        <translation>Onayla</translation>
     </message>
     <message>
         <source>Reject</source>
-        <translation type="unfinished"></translation>
+        <translation>Reddet</translation>
     </message>
 </context>
 <context>
     <name>ProgramPicker</name>
     <message>
         <source>Major Privacy - Select Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy - Program Seçimi</translation>
     </message>
     <message>
         <source>All Programs</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Programlar</translation>
     </message>
     <message>
         <source>Select a program from the list</source>
-        <translation type="unfinished"></translation>
+        <translation>Listeden bir program seçin</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
     <message>
         <source>Add New Program Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Program Öğesi Ekle</translation>
     </message>
 </context>
 <context>
     <name>ProgramRuleWnd</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <source>Path Pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol Deseni</translation>
     </message>
     <message>
         <source>Enclave</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapanım</translation>
     </message>
     <message>
         <source>Program Rule Identity</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Kural Kimliği</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation>Eylem</translation>
     </message>
     <message>
         <source>Require Signature</source>
-        <translation type="unfinished"></translation>
+        <translation>İmza Gereksinimi</translation>
     </message>
     <message>
         <source>Image Load Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Yükleme Koruması</translation>
     </message>
 </context>
 <context>
     <name>ProgramWnd</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Program Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Program Bilgisi</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <source>Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program</translation>
     </message>
     <message>
         <source>Exact File Path or Path Pattern (DOS style)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam Dosya Yolu veya Yol Deseni (DOS stili)</translation>
     </message>
     <message>
         <source>Executable Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütülebilir Yolu</translation>
     </message>
     <message>
         <source>App Package</source>
-        <translation type="unfinished"></translation>
+        <translation>Uygulama Paketi</translation>
     </message>
     <message>
         <source>Service Tag</source>
-        <translation type="unfinished"></translation>
+        <translation>Hizmet Etiketi</translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <source>Trace Logs and Records</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlükleri ve Kayıtları</translation>
     </message>
     <message>
         <source>Network Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ İzleme</translation>
     </message>
     <message>
         <source>Save Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>İzlemeyi Kaydet</translation>
     </message>
     <message>
         <source>Resource Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak İzleme</translation>
     </message>
     <message>
         <source>Ingress Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Giriş İzleme</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Change Permissions</source>
-        <translation type="unfinished"></translation>
+        <translation>İzinleri Değiştir</translation>
     </message>
     <message>
         <source>Write Data</source>
-        <translation type="unfinished"></translation>
+        <translation>Veri Yazma</translation>
     </message>
     <message>
         <source>Read Data</source>
-        <translation type="unfinished"></translation>
+        <translation>Veri Okuma</translation>
     </message>
     <message>
         <source>Write Attributes</source>
-        <translation type="unfinished"></translation>
+        <translation>Öznitelik Yazma</translation>
     </message>
     <message>
         <source>Read Attributes</source>
-        <translation type="unfinished"></translation>
+        <translation>Öznitelik Okuma</translation>
     </message>
     <message>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş</translation>
     </message>
     <message>
         <source> (0x%1)</source>
-        <translation type="unfinished"></translation>
+        <translation> (0x%1)</translation>
     </message>
     <message>
-        <source>Booth</source>
-        <translation type="unfinished"></translation>
+        <source>Both</source>
+        <translation>Her İkisi</translation>
     </message>
     <message>
         <source>Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak</translation>
     </message>
     <message>
         <source>Target</source>
-        <translation type="unfinished"></translation>
+        <translation>Hedef</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinmeyen</translation>
     </message>
     <message>
         <source>Process Started</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Başladı</translation>
     </message>
     <message>
         <source>Image Loaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü Yükleme</translation>
     </message>
     <message>
         <source>Thread Access</source>
-        <translation type="unfinished"></translation>
+        <translation>İş Parçacığı Erişimi</translation>
     </message>
     <message>
         <source>Process Access</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Erişimi</translation>
     </message>
     <message>
         <source>Control Execution</source>
-        <translation type="unfinished"></translation>
+        <translation>Yürütme Denetimi</translation>
     </message>
     <message>
         <source>Write Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Bellek Yazma</translation>
     </message>
     <message>
         <source>Read Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Bellek Okuma</translation>
     </message>
     <message>
         <source>Special Permissions</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel İzinler</translation>
     </message>
     <message>
         <source>Write Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Öznitelik Yazma</translation>
     </message>
     <message>
         <source>Read Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Öznitelik Okuma</translation>
     </message>
     <message>
         <source>Allowed (Untrusted)</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş (Güvenilmez)</translation>
     </message>
     <message>
         <source>Allowed (Ejected)</source>
-        <translation type="unfinished"></translation>
+        <translation>İzin Verilmiş (Çıkarıldı)</translation>
     </message>
     <message>
         <source>Blocked (Protected)</source>
-        <translation type="unfinished"></translation>
+        <translation>Engellenmiş (Korumalı)</translation>
     </message>
 </context>
 <context>
     <name>SettingsWindow</name>
     <message>
         <source>Major Privacy Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy Ayarları</translation>
     </message>
     <message>
         <source>General Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Genel Yapılandırma</translation>
     </message>
     <message>
         <source>UI Language:</source>
-        <translation type="unfinished"></translation>
+        <translation>Arayüz Dili:</translation>
     </message>
     <message>
         <source>Major Privacy Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Major Privacy Seçenekleri</translation>
     </message>
     <message>
         <source>Auto list installed applications in the program tree</source>
-        <translation type="unfinished"></translation>
+        <translation>Kurulu uygulamaları program ağacında  oto listele</translation>
     </message>
     <message>
         <source>Interface Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Arayüz Yapılandırması</translation>
     </message>
     <message>
         <source>Use Dark Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Koyu Temayı Kullan</translation>
     </message>
     <message>
         <source>Interface Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Arayüz Seçenekleri</translation>
     </message>
     <message>
         <source>Use Fusion Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Füzyon Temasını Kullan</translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildirimler</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <source>Data</source>
-        <translation type="unfinished"></translation>
+        <translation>Veri</translation>
     </message>
     <message>
         <source>Ignore List</source>
-        <translation type="unfinished"></translation>
+        <translation>Listeyi Yok Say</translation>
     </message>
     <message>
         <source>Remove Entry</source>
-        <translation type="unfinished"></translation>
+        <translation>Girişi Kaldır</translation>
     </message>
     <message>
         <source>When an event notification is displayed you can ignore all future notifications for a specific file, these ignore entries can be removed usin the below list, to add new entries you need to add them from the notification popup.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bir etkinlik bildirimi görüntülendiğinde, belirli bir dosya için gelecekteki tüm bildirimleri yok sayabilirsiniz; bu yok sayılan girdiler aşağıdaki listeyi kullanarak kaldırılabilir; yeni girdiler eklemek için bunları bildirim açılır penceresinden eklemeniz gerekir.</translation>
     </message>
     <message>
         <source>Process Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Koruması</translation>
     </message>
     <message>
         <source>Process Protection Logging</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Koruma Kayıtları</translation>
     </message>
     <message>
         <source>Show Process Protection Notification Popups</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Koruma Bildirimi Açılır Pencerelerini Göster</translation>
     </message>
     <message>
         <source>Record Process Execution and Ingress to Disk (IngressRecord.dat)</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Yürütme ve Disk Girişlerini Kaydet (IngressRecord.dat)</translation>
     </message>
     <message>
         <source>Log Process Execution and Ingress (to RAM)</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem Yürütme ve Girişleri (RAM&apos;e) Günlükle</translation>
     </message>
     <message>
         <source>Process Execution and Ingress Tracing</source>
-        <translation type="unfinished"></translation>
+        <translation>İşlem ve Giriş İzleme</translation>
     </message>
     <message>
         <source>Access Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Erişim Koruması</translation>
     </message>
     <message>
         <source>Save File/Folder Accesses Record to Disk (AccessRecord.dat)</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya/Klasör Erişim Kayıtlarını Diske Kaydet (AccessRecord.dat)</translation>
     </message>
     <message>
         <source>Resource Access Logging</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Erişim Günlüğü</translation>
     </message>
     <message>
         <source>Show Resource Access Notification Popups</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaynak Erişim Bildirimi Açılır Pencerelerini Göster</translation>
     </message>
     <message>
         <source>List All Open Files</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Açık Dosyaları Listele</translation>
     </message>
     <message>
         <source>File/Folder Accesses Tracing</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya/Klasör Erişim İzleme</translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
-        <translation type="unfinished"></translation>
+        <source>Trace also access attempts to non existing resources</source>
+        <translation>Mevcut Olmayan Kaynaklara Erişim Girişimlerini de İzle</translation>
     </message>
     <message>
         <source>Registry Access Tracing (not recommended, adds some CPU load)</source>
-        <translation type="unfinished"></translation>
+        <translation>Kayıt Defteri Erişim İzleme (önerilmez, CPU yükü ekler)</translation>
     </message>
     <message>
         <source>Log all File/Folder Accesses (to RAM)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Dosya/Klasör Erişimlerini Günlüğe kaydet (RAM&apos;e)</translation>
     </message>
     <message>
         <source>Firewall Config</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Yapılandırması</translation>
     </message>
     <message>
         <source>This feature enables the creation of firewall rule templates with path wildcards. When the Privacy Agent detects network activity matching a template without an existing rule, it automatically generates a new firewall rule.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu özellik, yollarda joker karakter kullanarak güvenlik duvarı kuralı şablonlarının oluşturulmasını sağlar. Gizlilik Aracısı, mevcut bir kural olmadan bir şablonla eşleşen ağ etkinliğini algıladığında, otomatik olarak yeni bir güvenlik duvarı kuralı oluşturur.</translation>
     </message>
     <message>
         <source>Enhance Windows Firewall with Dynamic Rule Templates</source>
-        <translation type="unfinished"></translation>
+        <translation>Dinamik Kural Şablonlarıyla Windows Güvenlik Duvarını Geliştir</translation>
     </message>
     <message>
         <source>Save Traffic Record to Disk (TrafficRecord.dat)</source>
-        <translation type="unfinished"></translation>
+        <translation>Trafik Kaydını Diske Kaydet (TrafficRecord.dat)</translation>
     </message>
     <message>
         <source>Disable Windows Firewall (not recomended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows Güvenlik Duvarını Devre Dışı Bırak (önerilmez)</translation>
     </message>
     <message>
         <source>When creating a new (outbound) rule also create an inbound rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni bir (giden) kural oluştururken aynı zamanda bir gelen kural da oluştur</translation>
     </message>
     <message>
         <source>Block List Mode (Windows default)</source>
-        <translation type="unfinished"></translation>
+        <translation>Engel Listesi Modu (Windows Varsayılan)</translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
-        <translation type="unfinished"></translation>
+        <source>Allow List Mode (recommended)</source>
+        <translation>İzin Liste Modu (Önerilen)</translation>
     </message>
     <message>
         <source>Windows Firewall Logging</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows Güvenlik Duvarı Günlüğü</translation>
     </message>
     <message>
         <source>Windows Firewall Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows Güvenlik Duvarı Modu</translation>
     </message>
     <message>
         <source>Use Simple Domain Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Basit Etki Alanı Çözünürlüğü Kullan</translation>
     </message>
     <message>
         <source>Use Reverse DNS</source>
-        <translation type="unfinished"></translation>
+        <translation>Ters DNS Kullan</translation>
     </message>
     <message>
         <source>Show Connection Notification Popups</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı Bildirimi Açılır Pencerelerini Göster</translation>
     </message>
     <message>
         <source>Log all Network Access (to RAM)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm Ağ Erişimini kaydet (RAM&apos;e)</translation>
     </message>
     <message>
         <source>Firewall Audit Policy</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenlik Duvarı Denetim Politikası</translation>
     </message>
     <message>
         <source>Load Windows Firewall Log on start (can be very slow)</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows Güvenlik Duvarı Günlüğünü başlangıçta yükle (çok yavaş olabilir)</translation>
     </message>
     <message>
         <source>(Should be set to All)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Tümü olarak ayarlanmalıdır)</translation>
     </message>
     <message>
         <source>Record Network Traffic</source>
-        <translation type="unfinished"></translation>
+        <translation>Ağ Trafiğini Kaydet</translation>
     </message>
     <message>
         <source>Dns Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Filtresi</translation>
     </message>
     <message>
         <source>Setup DNS Proxy as default DNS in Windows</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Ara Sunucusu Windows&apos;ta varsayılan DNS olarak ayarlansın</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaldır</translation>
     </message>
     <message>
         <source>Load DNS Blocklists</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Engel Listeleri yükle</translation>
     </message>
     <message>
         <source>Upstream DNS Resolvers</source>
-        <translation type="unfinished"></translation>
+        <translation>Yukarı Akış DNS Çözücüleri</translation>
     </message>
     <message>
         <source>DNS Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Filtresi</translation>
     </message>
     <message>
         <source>Enable Filtering DNS Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>DNS Ara Sunucu Filtrelemesini etkinleştir</translation>
     </message>
     <message>
         <source>8.8.8.8;1.1.1.1</source>
-        <translation type="unfinished"></translation>
+        <translation>8.8.8.8; 1.1.1.1</translation>
     </message>
     <message>
         <source>Add List</source>
-        <translation type="unfinished"></translation>
+        <translation>Liste Ekle</translation>
     </message>
     <message>
         <source>Url</source>
-        <translation type="unfinished"></translation>
+        <translation>Url</translation>
     </message>
     <message>
         <source>Entries</source>
-        <translation type="unfinished"></translation>
+        <translation>Girişler</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelişmiş</translation>
     </message>
     <message>
         <source>Trace Log Entry Limit:</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğü Giriş Sınırı:</translation>
     </message>
     <message>
         <source>Trace Log Options</source>
-        <translation type="unfinished"></translation>
+        <translation>İzleme Günlüğü Seçenekleri</translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
-        <translation type="unfinished"></translation>
+        <source>Trace Log Retention Time:</source>
+        <translation>İzleme Günlüklerinin Saklanma Süresi:</translation>
     </message>
     <message>
         <source>Hours</source>
-        <translation type="unfinished"></translation>
+        <translation>Saat</translation>
     </message>
     <message>
         <source>Support &amp;&amp; Updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Destek &amp;&amp; Güncellemeler</translation>
     </message>
     <message>
         <source>Get</source>
-        <translation type="unfinished"></translation>
+        <translation>Getir</translation>
     </message>
     <message>
         <source>In the future, don&apos;t notify about certificate expiration</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelecekte, sertifika süresinin sona ermesi hakkında bilgi verilmesin</translation>
     </message>
     <message>
         <source>PRIV_-_____-_____-_____-_____</source>
-        <translation type="unfinished"></translation>
+        <translation>PRIV_-_____-_____-_____-_____</translation>
     </message>
     <message>
         <source>Please enter your Supporter Certificate or License Serial Number:</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen destekçi sertifikanızı veya lisans seri numaranızı girin:</translation>
     </message>
     <message>
         <source>Hotpatches for the installed version, updates to the Templates.ini and translations.</source>
-        <translation type="unfinished"></translation>
+        <translation>Yüklü sürüm için yamalar, Templates.ini güncellemeleri ve çeviriler.</translation>
     </message>
     <message>
         <source>Incremental Updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Artımlı Güncellemeler</translation>
     </message>
     <message>
         <source>The preview channel contains the latest GitHub pre-releases.</source>
-        <translation type="unfinished"></translation>
+        <translation>Önizleme kanalı en son GitHub ön yayınlarını içerir.</translation>
     </message>
     <message>
         <source>Search in the Preview channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Önizleme kanalında arama</translation>
     </message>
     <message>
         <source>Update Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarları Güncelle</translation>
     </message>
     <message>
         <source>The stable channel contains the latest stable GitHub releases.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kararlı kanal, en son kararlı GitHub sürümlerini içerir.</translation>
     </message>
     <message>
         <source>Search in the Stable channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Kararlı kanalda ara</translation>
     </message>
     <message>
         <source>New full installers from the selected release channel.</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen sürüm kanalından yeni tam yükleyiciler.</translation>
     </message>
     <message>
         <source>Full Upgrades</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam Yükseltmeler</translation>
     </message>
     <message>
         <source>Update Check Interval</source>
-        <translation type="unfinished"></translation>
+        <translation>Güncelleme Denetim Aralığı</translation>
     </message>
     <message>
         <source>Check periodically for new versions</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni sürümleri düzenli aralıklarla denetle</translation>
     </message>
     <message>
         <source>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Certificate usage guide&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;https://xanasoft.com/go.php?to=priv-use-cert&quot;&gt;Sertifika kullanım kılavuzu&lt;/a&gt;</translation>
     </message>
     <message>
         <source>This supporter certificate has expired, please &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;get an updated certificate&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu destekçi sertifikasının süresi doldu, lütfen &lt;a href=&quot;https://xanasoft.com/go.php?to=priv-renew-cert&quot;&gt;güncel bir sertifika edinin&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Enter the support certificate here</source>
-        <translation type="unfinished"></translation>
+        <translation>Destek sertifikasını buraya girin</translation>
     </message>
     <message>
         <source>Retrieve/Upgrade/Renew certificate using Serial Number</source>
-        <translation type="unfinished"></translation>
+        <translation>Seri Numarası Kullanarak Sertifika Al/Yükselt/Yenile</translation>
     </message>
 </context>
 <context>
     <name>VolumeWindow</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <source>Load volume access protection rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Birim erişimi koruma kurallarını yükle</translation>
     </message>
     <message>
         <source>Select directory as mount point</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı noktası olarak dizin seçin</translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <source>Mount Point</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantı Noktası</translation>
     </message>
     <message>
         <source>New Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Parola</translation>
     </message>
     <message>
         <source>Repeat Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Parolayı Tekrarla</translation>
     </message>
     <message>
         <source>kilobytes</source>
-        <translation type="unfinished"></translation>
+        <translation>kilobayt</translation>
     </message>
     <message>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <source>Encryption Cipher</source>
-        <translation type="unfinished"></translation>
+        <translation>Şifreleme Kodu</translation>
     </message>
     <message>
         <source>Show Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Parolayı Göster</translation>
     </message>
     <message>
         <source>Enter Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Parolayı Girin</translation>
     </message>
     <message>
         <source>Disk Image Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk Görüntüsü Boyutu</translation>
     </message>
     <message>
         <source>Auto Lock after</source>
-        <translation type="unfinished"></translation>
+        <translation>Oto Kilitle</translation>
     </message>
 </context>
 </TS>

--- a/MajorPrivacy/MajorPrivacy_zh_CN.ts
+++ b/MajorPrivacy/MajorPrivacy_zh_CN.ts
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/MajorPrivacy_zh_TW.ts
+++ b/MajorPrivacy/MajorPrivacy_zh_TW.ts
@@ -415,7 +415,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh.</source>
+        <source>Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. It will also remove all references to files and folders existing but contained in not currently mounted volumes. The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -917,7 +917,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to terminate all processes in the sellected enclaves?</source>
+        <source>Do you want to terminate all processes in the selected enclaves?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2173,7 +2173,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu comand to do that.</source>
+        <source>Before you can sign a Binary you need to create your User Key, use the &apos;Security-&gt;Setup User Key&apos; menu command to do that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2209,7 +2209,7 @@ If the driver is set to auto-start, it will automatically re-lock the key on reb
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do you want to re-group all Program Items? This will remove all program items from all auto assiciated groups and re add it based on the default rules.</source>
+        <source>Do you want to re-group all Program Items? This will remove all program items from all auto associated groups and re add it based on the default rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2833,7 +2833,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> (CI: Code Gene.)</source>
+        <source> (CI: Code Gen.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3222,7 +3222,7 @@ CAUTION: This will disable protection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The sellected program type is not supported for this rule type</source>
+        <source>The selected program type is not supported for this rule type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3383,7 +3383,7 @@ The selected Item has children, do you want to delete them as well (Yes to All)?
     </message>
     <message>
         <source>Do you want to delete selected Program Items?
-The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its sellected in.</source>
+The selected Item belongs to more than one Group, to delete it from all groups press &apos;Yes to All&apos;, pressing &apos;Yes&apos; will only remove it from the group its selected in.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4221,7 +4221,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Debuging (INSECURE !!!)</source>
+        <source>Allow Debugging (INSECURE !!!)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4272,7 +4272,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sellected:</source>
+        <source>Selected:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,7 +4383,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please sellect which options you want to import/export.</source>
+        <source>Please select which options you want to import/export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4446,7 +4446,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Previouse</source>
+        <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4495,10 +4495,6 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
     </message>
     <message>
         <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tiem Stamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4722,7 +4718,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Booth</source>
+        <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4901,7 +4897,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace also access atempts to non existing resources</source>
+        <source>Trace also access attempts to non existing resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4941,7 +4937,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alow List Mode (recommended)</source>
+        <source>Allow List Mode (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5041,7 +5037,7 @@ increases to 512 bits with the application of Leet (L337) speak modifications, a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Trace Log Retention Tme:</source>
+        <source>Trace Log Retention Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/MajorPrivacy/Models/ProcessTraceModel.cpp
+++ b/MajorPrivacy/Models/ProcessTraceModel.cpp
@@ -51,7 +51,7 @@ CTraceModel::STraceNode* CProcessTraceModel::MkNode(const SMergedLog::TLogEntry&
 
 	const CExecLogEntry* pEntry = dynamic_cast<const CExecLogEntry*>(pNode->pLogEntry.constData());
 
-	if (pEntry->GetRole() == EExecLogRole::eBooth)	pNode->pActor = pNode->pTarget = Data.first;
+	if (pEntry->GetRole() == EExecLogRole::eBoth)	pNode->pActor = pNode->pTarget = Data.first;
 	else if (pEntry->GetRole() == EExecLogRole::eActor) pNode->pActor = Data.first;
 	else if (pEntry->GetRole() == EExecLogRole::eTarget) pNode->pTarget = Data.first;
 

--- a/MajorPrivacy/Views/AccessView.cpp
+++ b/MajorPrivacy/Views/AccessView.cpp
@@ -361,7 +361,7 @@ void CAccessView::CleanUpTree()
 {
 	if (QMessageBox::question(this, "MajorPrivacy", tr("Do you want to clean up the Access Tree? This will remove all Files and folders which are no longer present on the System. "
 	  "It will also remove all references to files and folders existing but contained in not currently mounted volumes. "
-	  "The operation will have to atempt to access all logged locations and will take some time, once done the view will refresh."), QMessageBox::Yes, QMessageBox::Cancel) != QMessageBox::Yes)
+	  "The operation will have to attempt to access all logged locations and will take some time, once done the view will refresh."), QMessageBox::Yes, QMessageBox::Cancel) != QMessageBox::Yes)
 		return;
 	
 	QList<STATUS> Results = QList<STATUS>() << theCore->CleanUpAccessTree();

--- a/MajorPrivacy/Views/EnclaveView.cpp
+++ b/MajorPrivacy/Views/EnclaveView.cpp
@@ -197,7 +197,7 @@ void CEnclaveView::OnEnclaveAction()
 		if (theConf->GetInt("Options/WarnTerminate", -1) == -1)
 		{
 			bool State = false;
-			if(CCheckableMessageBox::question(this, "MajorPrivacy", tr("Do you want to terminate all processes in the sellected enclaves?")
+			if(CCheckableMessageBox::question(this, "MajorPrivacy", tr("Do you want to terminate all processes in the selected enclaves?")
 				, tr("Terminate without asking"), &State, QDialogButtonBox::Yes | QDialogButtonBox::No, QDialogButtonBox::Yes) != QDialogButtonBox::Yes)
 				return;
 

--- a/MajorPrivacy/Views/ProgramView.cpp
+++ b/MajorPrivacy/Views/ProgramView.cpp
@@ -665,7 +665,7 @@ void CProgramView::OnProgramAction()
 		else if (bMultiGroup)
 		{
 			int Res = QMessageBox::question(this, "MajorPrivacy", tr("Do you want to delete selected Program Items?\n"
-				"The selected Item belongs to more than one Group, to delete it from all groups press 'Yes to All', pressing 'Yes' will only remove it from the group its sellected in.")
+				"The selected Item belongs to more than one Group, to delete it from all groups press 'Yes to All', pressing 'Yes' will only remove it from the group its selected in.")
 				, QMessageBox::Yes, QMessageBox::YesToAll, QMessageBox::No);
 			if (Res == QMessageBox::No)
 				return;

--- a/MajorPrivacy/Windows/AccessRuleWnd.cpp
+++ b/MajorPrivacy/Windows/AccessRuleWnd.cpp
@@ -306,7 +306,7 @@ void CAccessRuleWnd::OnPickProgram()
 		Index = m_Items.indexOf(pItem);
 		if (Index == -1) {
 			if(!AddProgramItem(pItem))
-				QMessageBox::warning(this, "MajorPrivacy", tr("The sellected program type is not supported for this rule type"));
+				QMessageBox::warning(this, "MajorPrivacy", tr("The selected program type is not supported for this rule type"));
 			else
 				Index = m_Items.indexOf(pItem);
 		}

--- a/MajorPrivacy/Windows/FirewallRuleWnd.cpp
+++ b/MajorPrivacy/Windows/FirewallRuleWnd.cpp
@@ -362,7 +362,7 @@ void CFirewallRuleWnd::OnPickProgram()
 		Index = m_Items.indexOf(pItem);
 		if (Index == -1) {
 			if(!AddProgramItem(pItem))
-				QMessageBox::warning(this, "MajorPrivacy", tr("The sellected program type is not supported for this rule type"));
+				QMessageBox::warning(this, "MajorPrivacy", tr("The selected program type is not supported for this rule type"));
 			else
 				Index = m_Items.indexOf(pItem);
 		}

--- a/MajorPrivacy/Windows/ProgramRuleWnd.cpp
+++ b/MajorPrivacy/Windows/ProgramRuleWnd.cpp
@@ -163,7 +163,7 @@ QColor CProgramRuleWnd::GetRoleColor(EExecLogRole Role)
 	{
 	case EExecLogRole::eActor:	/*light blue */ return QColor(173, 216, 230);
 	case EExecLogRole::eTarget: /*light red*/ return QColor(255, 182, 193);
-	case EExecLogRole::eBooth:  /*light green*/ return QColor(144, 238, 144);
+	case EExecLogRole::eBoth:  /*light green*/ return QColor(144, 238, 144);
 	default: return QColor();
 	}
 }
@@ -239,7 +239,7 @@ void CProgramRuleWnd::OnPickProgram()
 		Index = m_Items.indexOf(pItem);
 		if (Index == -1) {
 			if(!AddProgramItem(pItem))
-				QMessageBox::warning(this, "MajorPrivacy", tr("The sellected program type is not supported for this rule type"));
+				QMessageBox::warning(this, "MajorPrivacy", tr("The selected program type is not supported for this rule type"));
 			else
 				Index = m_Items.indexOf(pItem);
 		}

--- a/MajorPrivacy/Windows/SettingsWindow.cpp
+++ b/MajorPrivacy/Windows/SettingsWindow.cpp
@@ -162,7 +162,7 @@ CSettingsWindow::CSettingsWindow(QWidget* parent)
 
 	connect(ui.chkResShowPopUp, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 
-	connect(ui.radFwAlowList, SIGNAL(clicked()), this, SLOT(OnFwModeChanged()));
+	connect(ui.radFwAllowList, SIGNAL(clicked()), this, SLOT(OnFwModeChanged()));
 	connect(ui.radFwBlockList, SIGNAL(clicked()), this, SLOT(OnFwModeChanged()));
 	connect(ui.radFwDisable, SIGNAL(clicked()), this, SLOT(OnFwModeChanged()));
 
@@ -513,7 +513,7 @@ void CSettingsWindow::LoadSettings()
 
 	auto FwMode = theCore->GetFwProfile();
 	if (!FwMode.IsError()) {
-		ui.radFwAlowList->setChecked(FwMode.GetValue() == FwFilteringModes::AllowList);
+		ui.radFwAllowList->setChecked(FwMode.GetValue() == FwFilteringModes::AllowList);
 		ui.radFwBlockList->setChecked(FwMode.GetValue() == FwFilteringModes::BlockList);
 		ui.radFwDisable->setChecked(FwMode.GetValue() == FwFilteringModes::NoFiltering);
 	}
@@ -606,7 +606,7 @@ void CSettingsWindow::SaveSettings()
 
 	if (m_bFwModeChanged) {
 		FwFilteringModes Mode = FwFilteringModes::Unknown;
-		if (ui.radFwAlowList->isChecked())		Mode = FwFilteringModes::AllowList;
+		if (ui.radFwAllowList->isChecked())		Mode = FwFilteringModes::AllowList;
 		else if (ui.radFwBlockList->isChecked())Mode = FwFilteringModes::BlockList;
 		else if (ui.radFwDisable->isChecked())	Mode = FwFilteringModes::NoFiltering;
 		if(Mode != FwFilteringModes::Unknown)	theCore->SetFwProfile(Mode);

--- a/MiscHelpers/Common/TreeItemModel.cpp
+++ b/MiscHelpers/Common/TreeItemModel.cpp
@@ -227,7 +227,7 @@ void CTreeItemModel::Purge(STreeNode* pParent, const QModelIndex &parent, QHash<
 					FreeNode(pNode);
 				}
 
-				// CAUTION: all row indexes must be up to date bevore endRemoveRows
+				// CAUTION: all row indexes must be up to date before endRemoveRows
 
 				//pParent->Aux.clear();
 				for (int i = pParent->Children.count() - 1; i >= 0; i--)

--- a/Service/Network/Firewall/WindowsFwLog.cpp
+++ b/Service/Network/Firewall/WindowsFwLog.cpp
@@ -185,7 +185,7 @@ std::wstring CWindowsFwLog::GetXmlQuery()
 {
 	// *[System[Provider[ @Name='%2'] and (EventID=%3)]]
 	// Note: 
-	//			Alowed connections LayerRTID == 48 
+	//			Allowed connections LayerRTID == 48 
 	//			Blocked connections LayerRTID == 44
 	//			Opening a TCP port for listening LayerRTID == 38 and 36 // Resource allocation
 	//			Opening a UDP port LayerRTID == 38 and 36 // Resource allocation

--- a/Service/Processes/ProcessList.cpp
+++ b/Service/Processes/ProcessList.cpp
@@ -623,10 +623,10 @@ void CProcessList::OnImageEvent(const SProcessImageEvent* pImageEvent)
     // todo:
 
     //
-    // Note: an image may receive a loaded event folowed by an unloaded event
-    // this means the library was unloaded bevore controll was returned to user space
+    // Note: an image may receive a loaded event followed by an unloaded event
+    // this means the library was unloaded before control was returned to user space
     // in which case we handle it as if it would have been unloaded instantly.
-    // Note: this shoudl no longer be the case, we now issue the event once all is checked and final
+    // Note: this should no longer be the case, we now issue the event once all is checked and final
     //
 
     EEventStatus Status;
@@ -644,9 +644,9 @@ void CProcessList::OnImageEvent(const SProcessImageEvent* pImageEvent)
     pProgram->AddLibrary(EnclaveGuid, pLibrary, pImageEvent->TimeStamp, &pImageEvent->VerifierInfo, Status);
 
 #ifdef DEF_USE_POOL
-	CExecLogEntryPtr pLogEntry = pProgram->Allocator()->New<CExecLogEntry>(EnclaveGuid, EExecLogRole::eBooth, EExecLogType::eImageLoad, Status, pLibrary->GetUID(), CFlexGuid(), pImageEvent->ActorServiceTag, pImageEvent->TimeStamp, pImageEvent->ProcessId);
+	CExecLogEntryPtr pLogEntry = pProgram->Allocator()->New<CExecLogEntry>(EnclaveGuid, EExecLogRole::eBoth, EExecLogType::eImageLoad, Status, pLibrary->GetUID(), CFlexGuid(), pImageEvent->ActorServiceTag, pImageEvent->TimeStamp, pImageEvent->ProcessId);
 #else
-    CExecLogEntryPtr pLogEntry = CExecLogEntryPtr(new CExecLogEntry(EnclaveGuid, EExecLogRole::eBooth, EExecLogType::eImageLoad, Status, pLibrary->GetUID(), CFlexGuid(), pImageEvent->ActorServiceTag, pImageEvent->TimeStamp, pImageEvent->ProcessId));
+    CExecLogEntryPtr pLogEntry = CExecLogEntryPtr(new CExecLogEntry(EnclaveGuid, EExecLogRole::eBoth, EExecLogType::eImageLoad, Status, pLibrary->GetUID(), CFlexGuid(), pImageEvent->ActorServiceTag, pImageEvent->TimeStamp, pImageEvent->ProcessId));
 #endif
     AddExecLogEntry(pProgram, pLogEntry);
 }

--- a/Service/Volumes/VolumeManager.cpp
+++ b/Service/Volumes/VolumeManager.cpp
@@ -817,7 +817,7 @@ STATUS CVolumeManager::MountImage(const std::wstring& Path, const std::wstring& 
     std::wstring DevicePath = IMDISK_DEVICE + std::to_wstring(Number);
 
     //
-    // Set up protection for the selected device number bevore actually mounting it
+    // Set up protection for the selected device number before actually mounting it
     //
 
     std::wstring ruleGuid;


### PR DESCRIPTION
* Observed issue 1: `UILanguage` is incorrectly saved as `vacy_xx` in the config.
* Observed issue 2: Language dropdown shows a blank entry in the UI.
---
* Added initial support for Turkish language.
* Added missing menu bar strings.
* Fixed typos in source and localization files.